### PR TITLE
[WIP] live updates of UI as network configuration changes

### DIFF
--- a/bin/console-conf-tui
+++ b/bin/console-conf-tui
@@ -75,6 +75,7 @@ def main():
     if opts.dry_run:
         LOGDIR = ".subiquity"
     LOGFILE = setup_logger(dir=LOGDIR)
+    logging.getLogger('probert').setLevel(logging.CRITICAL)
     logger = logging.getLogger('console_conf')
     logger.info("Starting console-conf v{}".format(VERSION))
     logger.info("Arguments passed: {}".format(sys.argv))

--- a/subiquitycore/controllers/netwatch.py
+++ b/subiquitycore/controllers/netwatch.py
@@ -1,0 +1,67 @@
+# Copyright 2015 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import json
+import sys
+import time
+
+from subiquitycore.prober import Prober
+
+def output(action, ifname, data=None):
+    msg = {'action': action, 'ifname': ifname}
+    if data is not None:
+        msg['data'] = data
+    print(json.dumps(msg))
+    sys.stdout.flush()
+
+def _probe():
+    NETDEV_IGNORED_IFACES = ['lo', 'bridge', 'tun', 'tap', 'dummy']
+    class opts:
+        machine_config = None
+    prober = Prober(opts)
+    network_devices = prober.get_network_devices()
+
+    info = {}
+
+    for iface in network_devices.keys():
+        if iface in NETDEV_IGNORED_IFACES:
+            continue
+        ifinfo = prober.get_network_info(iface)
+        info[iface] = {
+            'ip': ifinfo.ip,
+            'bond': ifinfo.bond,
+            'type': ifinfo.type,
+            }
+
+    return info
+
+def _run():
+    info = {}
+    while 1:
+        new_info = _probe()
+        new_ifs = set(new_info)
+        old_ifs = set(info)
+        for new_if in new_ifs - old_ifs:
+            output('new_interface', new_if, new_info[new_if])
+        for old_if in old_ifs - new_ifs:
+            output('remove_interface', old_if)
+        for ifname in old_ifs & new_ifs:
+            if info[ifname] != new_info[ifname]:
+                output('update_interface', ifname, new_info[ifname])
+        info = new_info
+        time.sleep(1.0)
+
+if __name__ == '__main__':
+    _run()

--- a/subiquitycore/controllers/netwatch.py
+++ b/subiquitycore/controllers/netwatch.py
@@ -21,7 +21,7 @@ from subiquitycore.prober import Prober
 
 # Prevent BS messages from being printed to stderr
 # (Also makes debugging impossible, so should probably be smarter here!)
-#sys.stderr.close()
+sys.stderr.close()
 
 def output(action, ifname, data=None):
     msg = {'action': action, 'ifname': ifname}

--- a/subiquitycore/controllers/network.py
+++ b/subiquitycore/controllers/network.py
@@ -43,7 +43,7 @@ class NetworkObserver:
         log.debug("new interface %s %s", interface, info)
 
     def remove_interface(self, interface):
-        log.debug("remove interface %s %s", interface)
+        log.debug("remove interface %s", interface)
 
 
 class NetworkWatcher:

--- a/subiquitycore/controllers/network.py
+++ b/subiquitycore/controllers/network.py
@@ -55,11 +55,22 @@ class NetworkController(BaseController):
                 update = yaml.safe_load(line.decode('utf-8'))
                 ifname = update['ifname']
                 action = update['action']
-                log.debug(update['action'])
                 if action == 'new_interface':
+                    log.debug("new %s %s", ifname, update['data'])
                     self.model.info[ifname] = NetworkInfo({ifname: update['data']})
                 elif action == 'update_interface':
-                    log.debug("%s %s", ifname, update['data'])
+                    log.debug("update %s %s", ifname, update['data'])
+                    if ifname in self.model.devices:
+                        del self.model.devices[ifname]
+                    self.model.info[ifname] = NetworkInfo({ifname: update['data']})
+                elif action == 'remove_interface':
+                    log.debug("remove %s", ifname)
+                    if ifname in self.model.devices:
+                        del self.model.devices[ifname]
+                    if ifname in self.model.info:
+                        del self.model.info[ifname]
+                if isinstance(self.ui.frame.body, NetworkView):
+                    self.ui.frame.body.refresh_model_inputs()
 
     def network(self):
         title = "Network connections"

--- a/subiquitycore/controllers/network.py
+++ b/subiquitycore/controllers/network.py
@@ -23,6 +23,7 @@ import yaml
 
 from probert.network import NetworkInfo
 
+from subiquitycore.async import Async
 from subiquitycore.models import NetworkModel
 from subiquitycore.ui.views import (NetworkView,
                                     NetworkSetDefaultRouteView,
@@ -31,7 +32,7 @@ from subiquitycore.ui.views import (NetworkView,
                                     NetworkConfigureIPv4InterfaceView)
 from subiquitycore.ui.dummy import DummyView
 from subiquitycore.controller import BaseController
-from subiquitycore.utils import run_command, run_command_async
+from subiquitycore.utils import run_command, run_command_start, run_command_summarize
 
 log = logging.getLogger("subiquitycore.controller.network")
 
@@ -91,15 +92,16 @@ class NetworkController(BaseController):
         rest = cmds[1:]
         self.ui.frame.body.error.set_text("trying " + stage)
         log.debug('running %s for stage %s', cmd, stage)
-        results = []
+        result_holder = []
         def run_next(ignored):
-            self._run(stage, results[0], rest)
+            self._run(stage, result_holder[0], rest)
         pipe = self.loop.watch_pipe(run_next)
-        result = run_command_async(cmd)
-        def complete(fut):
-            results.append(fut.result(0))
+        self.curp = p = run_command_start(cmd)
+        def t():
+            stdout, stderr = p.communicate()
+            result_holder.append(run_command_summarize(p, stdout, stderr))
             os.write(pipe, b'x')
-        result.add_done_callback(complete)
+        Async.pool.submit(t)
 
     def run_commands(self, cmds):
         self._run('', {'status':0}, cmds)

--- a/subiquitycore/controllers/network.py
+++ b/subiquitycore/controllers/network.py
@@ -93,7 +93,6 @@ class NetworkController(BaseController):
             online = ( ret['status'] == 0 )
 
         if online:
-            self.watcher.stop()
             self.signal.emit_signal('menu:identity:main')
         else:
             self.ui.frame.body.show_network_error(network_error)

--- a/subiquitycore/controllers/network.py
+++ b/subiquitycore/controllers/network.py
@@ -57,12 +57,10 @@ class NetworkController(BaseController):
                 action = update['action']
                 if action == 'new_interface':
                     log.debug("new %s %s", ifname, update['data'])
-                    self.model.info[ifname] = NetworkInfo({ifname: update['data']})
+                    self.model.new_interface(NetworkInfo({ifname: update['data']}))
                 elif action == 'update_interface':
                     log.debug("update %s %s", ifname, update['data'])
-                    if ifname in self.model.devices:
-                        del self.model.devices[ifname]
-                    self.model.info[ifname] = NetworkInfo({ifname: update['data']})
+                    self.model.new_interface(NetworkInfo({ifname: update['data']}))
                 elif action == 'remove_interface':
                     log.debug("remove %s", ifname)
                     if ifname in self.model.devices:

--- a/subiquitycore/controllers/network.py
+++ b/subiquitycore/controllers/network.py
@@ -14,6 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
+import threading
 import time
 
 import netifaces
@@ -28,14 +29,89 @@ from subiquitycore.ui.views import (NetworkView,
 from subiquitycore.ui.dummy import DummyView
 from subiquitycore.controller import BaseController
 from subiquitycore.utils import run_command
+from subiquitycore.prober import Prober
 
 log = logging.getLogger("subiquitycore.controller.network")
+
+
+class NetworkObserver:
+
+    def update_addresses_for_interface(self, interface, addresses):
+        log.debug("updated interface %s %s", interface, addresses)
+
+    def new_interface(self, interface, info):
+        log.debug("new interface %s %s", interface, info)
+
+    def remove_interface(self, interface):
+        log.debug("remove interface %s %s", interface)
+
+
+class NetworkWatcher:
+    """A NetworkWatcher watches the network configuration.
+
+    Methods will be called on the passed observer when a change is
+    detected. The reason for doing the interface this was is that this
+    should really work by subscribing to netlink events but that seems
+    hard.
+    """
+
+    def __init__(self, observer):
+        self.observer = observer
+        self.running = False
+        self.thread = None
+
+    def start(self):
+        self.running = True
+        self.info = self._probe()
+        threading.Thread(target=self._run).start()
+
+    def stop(self):
+        self.running = False
+        if self.thread is not None:
+            self.thread.join()
+            self.thread = None
+
+    def _probe(self):
+        NETDEV_IGNORED_IFACES = ['lo', 'bridge', 'tun', 'tap', 'dummy']
+        class opts:
+            machine_config = None
+        prober = Prober(opts)
+        network_devices = prober.get_network_devices()
+
+        info = {}
+
+        for iface in [iface for iface in network_devices.keys()
+                      if iface not in NETDEV_IGNORED_IFACES]:
+            ifinfo = prober.get_network_info(iface)
+            info[iface] = ifinfo
+
+        return info
+
+    def _run(self):
+        while 1:
+            log.debug("watching...")
+            new_info = self._probe()
+            new_ifs = set(new_info)
+            old_ifs = set(self.info)
+            for new_if in new_ifs - old_ifs:
+                self.observer.new_interface(new_if, new_info[new_if])
+            for old_if in old_ifs - new_ifs:
+                self.observer.remove_interface(old_if)
+            for ifname in old_ifs & new_ifs:
+                if self.info[ifname].ip != new_info[ifname].ip:
+                    self.observer.update_addresses_for_interface(ifname, new_info[ifname].ip)
+            self.info = new_info
+            if not self.running:
+                return
+            time.sleep(1.0)
 
 
 class NetworkController(BaseController):
     def __init__(self, common):
         super().__init__(common)
         self.model = NetworkModel(self.prober, self.opts)
+        self.watcher = NetworkWatcher(NetworkObserver())
+        self.watcher.start()
 
     def network(self):
         title = "Network connections"
@@ -69,6 +145,7 @@ class NetworkController(BaseController):
             online = ( ret['status'] == 0 )
 
         if online:
+            self.watcher.stop()
             self.signal.emit_signal('menu:identity:main')
         else:
             self.ui.frame.body.show_network_error(network_error)

--- a/subiquitycore/controllers/network.py
+++ b/subiquitycore/controllers/network.py
@@ -37,6 +37,38 @@ from subiquitycore.utils import run_command, run_command_start, run_command_summ
 log = logging.getLogger("subiquitycore.controller.network")
 
 
+
+class CommandSequence:
+    def __init__(self, cmds, controller):
+        self.cmds = cmds
+        self.controller = controller
+
+    def run(self):
+        self._run1()
+
+    def _run1(self):
+        self.stage, cmd = self.cmds[0]
+        self.cmds = self.cmds[1:]
+        self.controller.ui.frame.body.error.set_text("trying " + self.stage)
+        log.debug('running %s for stage %s', cmd, self.stage)
+        self.proc = run_command_start(cmd)
+        self.pipe = self.controller.loop.watch_pipe(self._complete)
+        Async.pool.submit(self._communicate)
+
+    def _communicate(self):
+        stdout, stderr = self.proc.communicate()
+        self.result = run_command_summarize(self.proc, stdout, stderr)
+        os.write(self.pipe, b'x')
+
+    def _complete(self, ignored):
+        if self.result['status'] != 0:
+            self.controller.ui.frame.body.show_network_error(self.stage)
+        elif len(self.cmds) == 0:
+            self.controller.signal.emit_signal('menu:identity:main')
+        else:
+            self._run1()
+
+
 class NetworkController(BaseController):
     def __init__(self, common):
         super().__init__(common)
@@ -80,32 +112,6 @@ class NetworkController(BaseController):
         self.ui.set_footer(footer, 20)
         self.ui.set_body(NetworkView(self.model, self.signal))
 
-    def _run(self, last_stage, results, cmds):
-        log.debug('_run called with %s', cmds)
-        if results['status'] != 0:
-            self.ui.frame.body.show_network_error(last_stage)
-            return
-        if len(cmds) == 0:
-            self.signal.emit_signal('menu:identity:main')
-            return
-        stage, cmd = cmds[0]
-        rest = cmds[1:]
-        self.ui.frame.body.error.set_text("trying " + stage)
-        log.debug('running %s for stage %s', cmd, stage)
-        result_holder = []
-        def run_next(ignored):
-            self._run(stage, result_holder[0], rest)
-        pipe = self.loop.watch_pipe(run_next)
-        self.curp = p = run_command_start(cmd)
-        def t():
-            stdout, stderr = p.communicate()
-            result_holder.append(run_command_summarize(p, stdout, stderr))
-            os.write(pipe, b'x')
-        Async.pool.submit(t)
-
-    def run_commands(self, cmds):
-        self._run('', {'status':0}, cmds)
-
     def network_finish(self, config):
         log.debug("network config: \n%s", yaml.dump(config, default_flow_style=False))
 
@@ -134,7 +140,7 @@ class NetworkController(BaseController):
                 ('apply', ['netplan', 'apply']),
                 ('timeout', ['/lib/systemd/systemd-networkd-wait-online', '--timeout=30']),
                 ]
-        self.run_commands(cmds)
+        CommandSequence(cmds, self).run()
 
     def set_default_v4_route(self):
         self.ui.set_header("Default route")

--- a/subiquitycore/controllers/network.py
+++ b/subiquitycore/controllers/network.py
@@ -79,32 +79,62 @@ class NetworkController(BaseController):
         self.ui.set_footer(footer, 20)
         self.ui.set_body(NetworkView(self.model, self.signal))
 
+    def _run(self, last_stage, results, cmds):
+        log.debug('_run called with %s', cmds)
+        if results['status'] != 0:
+            self.ui.frame.body.show_network_error(last_stage)
+            return
+        if len(cmds) == 0:
+            self.signal.emit_signal('menu:identity:main')
+            return
+        stage, cmd = cmds[0]
+        rest = cmds[1:]
+        self.ui.frame.body.error.set_text("trying " + stage)
+        log.debug('running %s for stage %s', cmd, stage)
+        results = []
+        def complete(ignored):
+            self._run(stage, results[0], rest)
+            #os.close(pipe)
+        pipe = self.loop.watch_pipe(complete)
+        import threading
+        def t():
+            results.append(run_command(cmd))
+            log.debug('%s completed, result %s', cmd, results[0])
+            os.write(pipe, b'x')
+        threading.Thread(target=t).start()
+
+    def run_commands(self, cmds):
+        self._run('', {'status':0}, cmds)
+
     def network_finish(self, config):
         log.debug("network config: \n%s", yaml.dump(config, default_flow_style=False))
 
-        online = True
-        network_error = None
+        self.ui.frame.body.error.set_text("trying")
 
         if self.opts.dry_run:
-            pass
+            if hasattr(self, 'tried_once'):
+                cmds = [
+                    ('one', ['sleep', '1']),
+                    ('two', ['sleep', '1']),
+                    ('three', ['sleep', '1']),
+                    ]
+            else:
+                self.tried_once = True
+                cmds = [
+                    ('one', ['sleep', '1']),
+                    ('two', ['sleep', '1']),
+                    ('three', ['false']),
+                    ('four', ['sleep 1']),
+                    ]
         else:
             with open('/etc/netplan/01-console-conf.yaml', 'w') as w:
                 w.write(yaml.dump(config))
-            network_error = 'generate'
-            ret = run_command(['/lib/netplan/generate'])
-            if ret['status'] == 0:
-                network_error = 'apply'
-                ret = run_command(['netplan', 'apply'])
-            if ret['status'] == 0:
-                network_error = 'timeout'
-                ret = run_command(['/lib/systemd/systemd-networkd-wait-online',
-                                   '--timeout=30'])
-            online = ( ret['status'] == 0 )
-
-        if online:
-            self.signal.emit_signal('menu:identity:main')
-        else:
-            self.ui.frame.body.show_network_error(network_error)
+            cmds = [
+                ('generate', ['/lib/netplan/generate']),
+                ('apply', ['netplan', 'apply']),
+                ('timeout', ['/lib/systemd/systemd-networkd-wait-online', '--timeout=30']),
+                ]
+        self.run_commands(cmds)
 
     def set_default_v4_route(self):
         self.ui.set_header("Default route")

--- a/subiquitycore/controllers/network.py
+++ b/subiquitycore/controllers/network.py
@@ -31,7 +31,7 @@ from subiquitycore.ui.views import (NetworkView,
                                     NetworkConfigureIPv4InterfaceView)
 from subiquitycore.ui.dummy import DummyView
 from subiquitycore.controller import BaseController
-from subiquitycore.utils import run_command
+from subiquitycore.utils import run_command, run_command_async
 
 log = logging.getLogger("subiquitycore.controller.network")
 
@@ -92,16 +92,14 @@ class NetworkController(BaseController):
         self.ui.frame.body.error.set_text("trying " + stage)
         log.debug('running %s for stage %s', cmd, stage)
         results = []
-        def complete(ignored):
+        def run_next(ignored):
             self._run(stage, results[0], rest)
-            #os.close(pipe)
-        pipe = self.loop.watch_pipe(complete)
-        import threading
-        def t():
-            results.append(run_command(cmd))
-            log.debug('%s completed, result %s', cmd, results[0])
+        pipe = self.loop.watch_pipe(run_next)
+        result = run_command_async(cmd)
+        def complete(fut):
+            results.append(fut.result(0))
             os.write(pipe, b'x')
-        threading.Thread(target=t).start()
+        result.add_done_callback(complete)
 
     def run_commands(self, cmds):
         self._run('', {'status':0}, cmds)

--- a/subiquitycore/models/network.py
+++ b/subiquitycore/models/network.py
@@ -336,25 +336,25 @@ class NetworkModel(BaseModel):
         return self.additional_options
 
     # --- Model Methods ----
-    def probe_network(self):
-        log.debug('model calling prober.get_network()')
-        network_devices = self.prober.get_network_devices()
-        self.network_routes = self.prober.get_network_routes()
+    ## def probe_network(self):
+    ##     log.debug('model calling prober.get_network()')
+    ##     network_devices = self.prober.get_network_devices()
+    ##     self.network_routes = self.prober.get_network_routes()
 
-        for iface in network_devices:
-            if iface in NETDEV_IGNORED_IFACES:
-                continue
-            ifinfo = self.prober.get_network_info(iface)
-            self.info[iface] = ifinfo
-            netdev = Networkdev(iface, ifinfo.type)
-            try:
-                log.debug('configuring with: {}'.format(ifinfo))
-                netdev.configure(probe_info=ifinfo)
-            except Exception as e:
-                log.error(e)
-            self.devices[iface] = netdev
+    ##     for iface in network_devices:
+    ##         if iface in NETDEV_IGNORED_IFACES:
+    ##             continue
+    ##         ifinfo = self.prober.get_network_info(iface)
+    ##         self.info[iface] = ifinfo
+    ##         netdev = Networkdev(iface, ifinfo.type)
+    ##         try:
+    ##             log.debug('configuring with: {}'.format(ifinfo))
+    ##             netdev.configure(probe_info=ifinfo)
+    ##         except Exception as e:
+    ##             log.error(e)
+    ##         self.devices[iface] = netdev
 
-        log.debug('probing network complete!')
+    ##     log.debug('probing network complete!')
 
     def get_routes(self):
         ''' get collection of currently configured routes '''

--- a/subiquitycore/models/network.py
+++ b/subiquitycore/models/network.py
@@ -335,6 +335,16 @@ class NetworkModel(BaseModel):
     def get_menu(self):
         return self.additional_options
 
+    def new_interface(self, ifinfo):
+        self.info[ifinfo.name] = ifinfo
+        netdev = Networkdev(ifinfo.name, ifinfo.type)
+        try:
+            log.debug('configuring with: {}'.format(ifinfo))
+            netdev.configure(probe_info=ifinfo)
+        except Exception as e:
+            log.error(e)
+        self.devices[ifinfo.name] = netdev
+
     # --- Model Methods ----
     def probe_network(self):
     ##     log.debug('model calling prober.get_network()')
@@ -345,14 +355,7 @@ class NetworkModel(BaseModel):
     ##         if iface in NETDEV_IGNORED_IFACES:
     ##             continue
     ##         ifinfo = self.prober.get_network_info(iface)
-    ##         self.info[iface] = ifinfo
-    ##         netdev = Networkdev(iface, ifinfo.type)
-    ##         try:
-    ##             log.debug('configuring with: {}'.format(ifinfo))
-    ##             netdev.configure(probe_info=ifinfo)
-    ##         except Exception as e:
-    ##             log.error(e)
-    ##         self.devices[iface] = netdev
+    ##         self.new_interface(ifinfo)
 
     ##     log.debug('probing network complete!')
 

--- a/subiquitycore/models/network.py
+++ b/subiquitycore/models/network.py
@@ -336,10 +336,10 @@ class NetworkModel(BaseModel):
         return self.additional_options
 
     # --- Model Methods ----
-    ## def probe_network(self):
+    def probe_network(self):
     ##     log.debug('model calling prober.get_network()')
     ##     network_devices = self.prober.get_network_devices()
-    ##     self.network_routes = self.prober.get_network_routes()
+        self.network_routes = self.prober.get_network_routes()
 
     ##     for iface in network_devices:
     ##         if iface in NETDEV_IGNORED_IFACES:

--- a/subiquitycore/ui/views/network.py
+++ b/subiquitycore/ui/views/network.py
@@ -40,9 +40,9 @@ class NetworkView(BaseView):
         self.signal = signal
         self.items = []
         self.error = Text("", align='center')
-        self.model_inputs = self._build_model_inputs()
+        self.model_input_holder = Padding.center_79(self._build_model_inputs())
         self.body = [
-            Padding.center_79(self.model_inputs),
+            self.model_input_holder,
             Padding.line_break(""),
             Padding.center_79(self._build_additional_options()),
             Padding.line_break(""),
@@ -54,6 +54,9 @@ class NetworkView(BaseView):
         self.lb = ListBox(self.body)
         self.lb.set_focus(4)  # _build_buttons
         super().__init__(self.lb)
+
+    def refresh_model_inputs(self):
+        self.model_input_holder.original_widget = self._build_model_inputs()
 
     def _build_buttons(self):
         cancel = Color.button(cancel_btn(on_press=self.cancel),
@@ -248,5 +251,5 @@ class NetworkView(BaseView):
         self.signal.emit_signal('network:finish', self.model.render())
 
     def cancel(self, button):
-        self.model.reset()
+        #self.model.reset()
         self.signal.prev_signal()

--- a/subiquitycore/ui/views/network.py
+++ b/subiquitycore/ui/views/network.py
@@ -40,8 +40,9 @@ class NetworkView(BaseView):
         self.signal = signal
         self.items = []
         self.error = Text("", align='center')
+        self.model_inputs = self._build_model_inputs()
         self.body = [
-            Padding.center_79(self._build_model_inputs()),
+            Padding.center_79(self.model_inputs),
             Padding.line_break(""),
             Padding.center_79(self._build_additional_options()),
             Padding.line_break(""),
@@ -66,7 +67,7 @@ class NetworkView(BaseView):
 
     def _build_model_inputs(self):
         log.info("probing for network devices")
-        self.model.probe_network()
+        #self.model.probe_network()
         ifaces = self.model.get_all_interface_names()
         ifname_width = 8  # default padding
 

--- a/subiquitycore/ui/views/network.py
+++ b/subiquitycore/ui/views/network.py
@@ -67,7 +67,7 @@ class NetworkView(BaseView):
 
     def _build_model_inputs(self):
         log.info("probing for network devices")
-        #self.model.probe_network()
+        self.model.probe_network()
         ifaces = self.model.get_all_interface_names()
         ifname_width = 8  # default padding
 


### PR DESCRIPTION
This is just a proof of concept really. The way to try this out is to run bin/console-conf-tui --dry-run, get to the network screen and then in another terminal is ip addr add/del to add and remove ip addresses from an interface, and watch them appear and disappear from the network screen. (It should also work to run this in qemu and use the monitor to add/remove interfaces but I haven't tried that).

The way it works is that console-conf runs a subprocess that just polls for network configuration changes and dumps yaml messages to stdout about what it sees, and console-conf uses this information instead of probing itself. If the main UI is a network view when information about a change comes in, the UI is refreshed.

Some of the code is probably in the wrong place, and certainly some of it is a bit messy, but I think I like the approach. Let me know what you think!
