### PR TITLE
remove trivial uses of signals for console-conf

### DIFF
--- a/console_conf/controllers/identity.py
+++ b/console_conf/controllers/identity.py
@@ -83,6 +83,11 @@ class IdentityController(BaseIdentityController):
                 self.model.add_user(result)
         self.login()
 
+    def cancel(self):
+        # You can only go back if we haven't created a user yet.
+        if self.model.user is None:
+            self.signal.emit_signal('prev-screen')
+
     def login(self):
         title = "Configuration Complete"
         footer = "View configured user and device access methods"

--- a/console_conf/controllers/identity.py
+++ b/console_conf/controllers/identity.py
@@ -35,7 +35,7 @@ class IdentityController(BaseIdentityController):
         if device_owner is not None:
             mark_firstboot_complete()
             self.model.add_user(device_owner)
-            self.signal.emit_signal('identity:login')
+            self.login()
 
     def get_device_owner(self):
         """ Check if device is owned """

--- a/console_conf/controllers/identity.py
+++ b/console_conf/controllers/identity.py
@@ -30,7 +30,7 @@ class IdentityController(BaseIdentityController):
         footer = ""
         self.ui.set_header(title, excerpt)
         self.ui.set_footer(footer, 40)
-        self.ui.set_body(self.identity_view(self.model, self.signal, self.opts, self.loop))
+        self.ui.set_body(self.identity_view(self.model, self, self.opts, self.loop))
 
     def identity_done(self, email):
         if not self.opts.dry_run:
@@ -57,7 +57,7 @@ class IdentityController(BaseIdentityController):
                 'username': email,
                 }
             self.model.add_user(result)
-        self.signal.emit_signal('identity:login')
+        self.login()
 
     def login(self):
         title = "Configuration Complete"
@@ -68,11 +68,7 @@ class IdentityController(BaseIdentityController):
         net_model = self.controllers['Network'].model
         net_model.probe_network()
         configured_ifaces = net_model.get_configured_interfaces()
-        login_view = LoginView(self.opts,
-                               self.model,
-                               self.signal,
-                               self.model.user,
-                               configured_ifaces)
+        login_view = LoginView(self.opts, self.model, self, configured_ifaces)
 
         self.ui.set_body(login_view)
 

--- a/console_conf/controllers/welcome.py
+++ b/console_conf/controllers/welcome.py
@@ -28,5 +28,5 @@ class WelcomeController(WelcomeControllerBase):
                    "account on this all-snap Ubuntu Core system.")
         self.ui.set_header(title, excerpt)
         self.ui.set_footer("")
-        view = WelcomeView(self.model, self.signal)
+        view = WelcomeView(self.model, self)
         self.ui.set_body(view)

--- a/console_conf/core.py
+++ b/console_conf/core.py
@@ -27,5 +27,4 @@ class ConsoleConf(Application):
         "Welcome",
         "Network",
         "Identity",
-        "Login",
     ]

--- a/console_conf/ui/views/identity.py
+++ b/console_conf/ui/views/identity.py
@@ -60,9 +60,9 @@ class SubmittingEmailEditor(EmailEditor):
 
 class IdentityView(BaseView):
 
-    def __init__(self, model, signal, opts, loop):
+    def __init__(self, model, controller, opts, loop):
         self.model = model
-        self.signal = signal
+        self.controller = controller
         self.opts = opts
         self.loop = loop
         self.items = []
@@ -105,10 +105,10 @@ class IdentityView(BaseView):
         return Pile(buttons)
 
     def cancel(self, button):
-        self.signal.emit_signal('prev-screen')
+        self.controller.cancel()
 
     def done(self, button):
         if len(self.email.value) < 1:
             self.error.set_text("Please enter an email address.")
             return
-        self.signal.emit_signal('identity:done', self.email.value)
+        self.controller.identity_done(self.email.value)

--- a/console_conf/ui/views/login.py
+++ b/console_conf/ui/views/login.py
@@ -28,11 +28,10 @@ log = logging.getLogger("subiquitycore.views.login")
 
 
 class LoginView(BaseView):
-    def __init__(self, opts, model, signal, user, ifaces):
+    def __init__(self, opts, model, controller, ifaces):
         self.opts = opts
         self.model = model
-        self.signal = signal
-        self.user = user
+        self.controller = controller
         self.ifaces = ifaces
         self.items = []
         self.body = [
@@ -118,4 +117,4 @@ class LoginView(BaseView):
         self.done()
 
     def done(self, button):
-        self.signal.emit_signal('identity:login:done')
+        self.controller.login_done()

--- a/console_conf/ui/views/welcome.py
+++ b/console_conf/ui/views/welcome.py
@@ -34,6 +34,3 @@ class WelcomeView(CoreWelcomeView):
                          focus_map='button focus'),
         ]
         return Pile(self.buttons)
-
-    def confirm(self, result):
-        self.signal.emit_signal('welcome:done')

--- a/subiquitycore/controller.py
+++ b/subiquitycore/controller.py
@@ -14,12 +14,13 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
+from abc import ABC, abstractmethod
 import logging
 
 log = logging.getLogger("subiquitycore.controller")
 
 
-class BaseController:
+class BaseController(ABC):
     """Base class for controllers."""
 
     signals = []
@@ -39,5 +40,10 @@ class BaseController:
             signals.append((sig, getattr(self, cb)))
         self.signal.connect_signals(signals)
 
+    @abstractmethod
+    def cancel(self):
+        pass
+
+    @abstractmethod
     def default(self):
-        raise NotImplementedError(self.default)
+        pass

--- a/subiquitycore/controller.py
+++ b/subiquitycore/controller.py
@@ -22,6 +22,8 @@ log = logging.getLogger("subiquitycore.controller")
 class BaseController:
     """Base class for controllers."""
 
+    signals = []
+
     def __init__(self, common):
         self.ui = common['ui']
         self.signal = common['signal']

--- a/subiquitycore/controllers/network.py
+++ b/subiquitycore/controllers/network.py
@@ -215,6 +215,9 @@ class NetworkController(BaseController):
         self.model.probe_network()
         self.start()
 
+    def cancel(self):
+        self.signal.emit_signal('prev-screen')
+
     @view
     def start(self):
         title = "Network connections"

--- a/subiquitycore/controllers/network.py
+++ b/subiquitycore/controllers/network.py
@@ -222,14 +222,18 @@ class NetworkController(BaseController):
         meth, args, kw = self.view_stack.pop()
         meth(*args, **kw)
 
+    def cancel(self):
+        if len(self.view_stack) <= 1:
+            self.signal.emit_signal('prev-screen')
+        else:
+            self.prev_view()
+
     def default(self):
         self.model.reset()
+        self.view_stack = []
         log.info("probing for network devices")
         self.model.probe_network()
         self.start()
-
-    def cancel(self):
-        self.signal.emit_signal('prev-screen')
 
     @view
     def start(self):

--- a/subiquitycore/controllers/welcome.py
+++ b/subiquitycore/controllers/welcome.py
@@ -36,7 +36,7 @@ class WelcomeController(BaseController):
                   "select your language.")
         self.ui.set_header(title, excerpt)
         self.ui.set_footer(footer)
-        view = WelcomeView(self.model, self.signal)
+        view = WelcomeView(self.model, self)
         self.ui.set_body(view)
 
     def done(self):

--- a/subiquitycore/controllers/welcome.py
+++ b/subiquitycore/controllers/welcome.py
@@ -37,3 +37,7 @@ class WelcomeController(BaseController):
 
     def done(self):
         self.signal.emit_signal('next-screen')
+
+    def cancel(self):
+        # Can't go back from here!
+        pass

--- a/subiquitycore/controllers/welcome.py
+++ b/subiquitycore/controllers/welcome.py
@@ -21,10 +21,6 @@ from subiquitycore.controller import BaseController
 
 class WelcomeController(BaseController):
 
-    signals = [
-        ('welcome:done', 'done'),
-    ]
-
     def __init__(self, common):
         super().__init__(common)
         self.model = WelcomeModel()

--- a/subiquitycore/models/identity.py
+++ b/subiquitycore/models/identity.py
@@ -61,6 +61,7 @@ class IdentityModel(BaseModel):
 
     def __init__(self, opts):
         self.opts = opts
+        self._user = None
 
     def add_user(self, result):
         if result:

--- a/subiquitycore/ui/views/identity.py
+++ b/subiquitycore/ui/views/identity.py
@@ -38,9 +38,10 @@ USERNAME_MAXLEN = 32
 
 
 class BaseIdentityView(BaseView):
-    def __init__(self, model, signal, opts):
+    def __init__(self, model, controller, opts):
         self.model = model
-        self.signal = signal
+        self.controller = controller
+        self.signal = controller.signal
         self.opts = opts
         self.items = []
         self.realname = RealnameEditor(caption="")

--- a/subiquitycore/ui/views/login.py
+++ b/subiquitycore/ui/views/login.py
@@ -23,16 +23,14 @@ from urwid import (ListBox, Pile, Text)
 from subiquitycore.ui.buttons import finish_btn
 from subiquitycore.ui.utils import Padding, Color
 from subiquitycore.view import BaseView
-from subiquitycore import utils
 
 log = logging.getLogger("subiquitycore.views.login")
 
 
 class LoginView(BaseView):
-    def __init__(self, model, signal, user, ifaces):
+    def __init__(self, model, controller, ifaces):
         self.model = model
-        self.signal = signal
-        self.user = user
+        self.controller = controller
         self.ifaces = ifaces
         self.items = []
         self.body = [
@@ -112,14 +110,5 @@ class LoginView(BaseView):
 
         return Pile(sl)
 
-    def confirm(self, result):
-        self.done()
-
     def done(self, button):
-        # mark ourselves complete
-        utils.mark_firstboot_complete()
-
-        # disable the UI service restoring getty service
-        utils.disable_first_boot_service()
-
-        self.signal.emit_signal('quit')
+        self.controller.login_done()

--- a/subiquitycore/ui/views/network.py
+++ b/subiquitycore/ui/views/network.py
@@ -290,4 +290,4 @@ class NetworkView(BaseView):
         self.controller.network_finish(self.model.render())
 
     def cancel(self, button):
-        self.controller.prev_view()
+        self.controller.cancel()

--- a/subiquitycore/ui/views/network.py
+++ b/subiquitycore/ui/views/network.py
@@ -55,9 +55,9 @@ class ApplyingConfigWidget(WidgetWrap):
 
 
 class NetworkView(BaseView):
-    def __init__(self, model, signal):
+    def __init__(self, model, controller):
         self.model = model
-        self.signal = signal
+        self.controller = controller
         self.items = []
         self.error = Text("", align='center')
         self.body = [
@@ -264,12 +264,11 @@ class NetworkView(BaseView):
         return Pile(labels + buttons)
 
     def additional_menu_select(self, result, sig):
-        self.signal.emit_signal(sig)
+        self.controller.signal.emit_signal(sig)
 
     def on_net_dev_press(self, result):
         log.debug("Selected network dev: {}".format(result.label))
-        self.signal.emit_signal('menu:network:main:configure-interface',
-                                result.label)
+        self.controller.network_configure_interface(result.label)
 
     def show_network_error(self, action):
         if action == 'generate':
@@ -288,7 +287,7 @@ class NetworkView(BaseView):
                                 "please verify your settings.")
 
     def done(self, result):
-        self.signal.emit_signal('network:finish', self.model.render())
+        self.controller.network_finish(self.model.render())
 
     def cancel(self, button):
-        self.signal.emit_signal('prev-screen')
+        self.controller.prev_view()

--- a/subiquitycore/ui/views/network_bond_interfaces.py
+++ b/subiquitycore/ui/views/network_bond_interfaces.py
@@ -24,9 +24,9 @@ log = logging.getLogger('subiquitycore.ui.bond_interfaces')
 
 
 class NetworkBondInterfacesView(BaseView):
-    def __init__(self, model, signal):
+    def __init__(self, model, controller):
         self.model = model
-        self.signal = signal
+        self.controller = controller
         self.bond_iface = None
         self.bond_mode = Selector(self.model.bonding_modes.values())
         self.selected_ifaces = []
@@ -128,8 +128,8 @@ class NetworkBondInterfacesView(BaseView):
             return
 
         log.debug('bond: successful bond creation')
-        self.signal.prev_signal()
+        self.controller.prev_view()
 
     def cancel(self, button):
         log.debug('bond: button_cancel')
-        self.signal.prev_signal()
+        self.controller.prev_view()

--- a/subiquitycore/ui/views/network_configure_interface.py
+++ b/subiquitycore/ui/views/network_configure_interface.py
@@ -24,9 +24,9 @@ log = logging.getLogger('subiquitycore.network.network_configure_interface')
 
 
 class NetworkConfigureInterfaceView(BaseView):
-    def __init__(self, model, signal, iface):
+    def __init__(self, model, controller, iface):
         self.model = model
-        self.signal = signal
+        self.controller = controller
         self.iface = iface
         self.iface_obj = self.model.get_interface(iface)
         self._build_widgets()
@@ -202,27 +202,24 @@ class NetworkConfigureInterfaceView(BaseView):
         self.update_interface()
 
     def show_wlan_configuration(self, btn):
-        self.signal.emit_signal(
-            'menu:network:main:configure-wlan-interface', self.iface)
+        self.contents.network_configure_wlan_interface(self.iface)
 
     def show_ipv4_configuration(self, btn):
-        self.signal.emit_signal(
-            'menu:network:main:configure-ipv4-interface', self.iface)
+        self.controller.network_configure_ipv4_interface(self.iface)
 
     def show_ipv6_configuration(self, btn):
-        log.debug("calling menu:network:main:configure-ipv6-interface")
+        log.debug("calling configure-ipv6-interface")
         # TODO: implement UI for configuring static IPv6.
-        # self.signal.emit_signal(
-        #     'menu:network:main:configure-ipv6-interface', self.iface)
+        # self.network_configure_ipv6_interface(self.iface)
 
     def done(self, result):
-        self.signal.prev_signal()
+        self.controller.prev_view()
 
 
 class NetworkConfigureWLANView(BaseView):
-    def __init__(self, model, signal, iface):
+    def __init__(self, model, controller, iface):
         self.model = model
-        self.signal = signal
+        self.controller = controller
         self.iface = iface
         self.iface_obj = self.model.get_interface(iface)
         self.essid_input = StringEditor(caption="")
@@ -275,7 +272,7 @@ class NetworkConfigureWLANView(BaseView):
         else:
             self.iface_obj.essid = None
         self.iface_obj.wpa_psk = self.psk_input.value
-        self.signal.prev_signal()
+        self.controller.prev_view()
 
     def cancel(self, btn):
-        self.signal.prev_signal()
+        self.controller.prev_view()

--- a/subiquitycore/ui/views/network_configure_interface.py
+++ b/subiquitycore/ui/views/network_configure_interface.py
@@ -204,7 +204,7 @@ class NetworkConfigureInterfaceView(BaseView):
         self.update_interface()
 
     def show_wlan_configuration(self, btn):
-        self.contents.network_configure_wlan_interface(self.iface)
+        self.controller.network_configure_wlan_interface(self.iface)
 
     def show_ipv4_configuration(self, btn):
         self.controller.network_configure_ipv4_interface(self.iface)

--- a/subiquitycore/ui/views/network_configure_ipv4_interface.py
+++ b/subiquitycore/ui/views/network_configure_ipv4_interface.py
@@ -25,9 +25,9 @@ log = logging.getLogger('subiquitycore.network.network_configure_ipv4_interface'
 
 
 class NetworkConfigureIPv4InterfaceView(BaseView):
-    def __init__(self, model, signal, iface):
+    def __init__(self, model, controller, iface):
         self.model = model
-        self.signal = signal
+        self.controller = controller
         self.ifname = iface
         self.iface = self.model.get_interface(self.ifname)
         self.is_gateway = False
@@ -151,8 +151,8 @@ class NetworkConfigureIPv4InterfaceView(BaseView):
             return
 
         # return
-        self.signal.prev_signal()
+        self.controller.prev_view()
 
     def cancel(self, button):
         self.model.default_gateway = None
-        self.signal.prev_signal()
+        self.controller.prev_view()

--- a/subiquitycore/ui/views/network_default_route.py
+++ b/subiquitycore/ui/views/network_default_route.py
@@ -25,10 +25,10 @@ log = logging.getLogger('subiquitycore.network.set_default_route')
 
 
 class NetworkSetDefaultRouteView(BaseView):
-    def __init__(self, model, family, signal):
+    def __init__(self, model, family, controller):
         self.model = model
         self.family = family
-        self.signal = signal
+        self.controller = controller
         self.default_gateway_w = None
         self.gateway_options = Pile(self._build_default_routes())
         body = [
@@ -113,7 +113,6 @@ class NetworkSetDefaultRouteView(BaseView):
             Color.string_input(
                 self.default_gateway_w,
                 focus_map="string_input focus")), self.gateway_options.options())
-        # self.signal.emit_signal('refresh')
 
     def done(self, result):
         log.debug("changing default gw: {}".format(result))
@@ -141,7 +140,7 @@ class NetworkSetDefaultRouteView(BaseView):
             except ValueError:
                 # FIXME: raise UX error message
                 pass
-        self.signal.prev_signal()
+        self.controller.prev_view()
 
     def cancel(self, button):
-        self.signal.prev_signal()
+        self.controller.prev_view()

--- a/subiquitycore/ui/views/welcome.py
+++ b/subiquitycore/ui/views/welcome.py
@@ -29,9 +29,9 @@ log = logging.getLogger("subiquitycore.views.welcome")
 
 
 class CoreWelcomeView(BaseView):
-    def __init__(self, model, signal):
+    def __init__(self, model, controller):
         self.model = model
-        self.signal = signal
+        self.controller = controller
         self.items = []
         # Padding.center_50(self._build_model_inputs()),
         self.body = [
@@ -60,8 +60,4 @@ class CoreWelcomeView(BaseView):
     def confirm(self, result):
         self.model.selected_language = result.label
         log.debug('calling installpath')
-        self.signal.emit_signal('welcome:done')
-
-    def cancel(self, button):
-        raise SystemExit("No language selected, exiting as there are no "
-                         "more previous controllers to render.")
+        self.controller.done()

--- a/subiquitycore/view.py
+++ b/subiquitycore/view.py
@@ -24,9 +24,9 @@ from urwid import WidgetWrap
 class BaseView(WidgetWrap):
     def keypress(self, size, key):
         if key == 'esc':
-            self.signal.prev_signal()
+            self.controller.signal.prev_signal()
             return None
         if key in ['ctrl x']:
-            self.signal.emit_signal('control-x-quit')
+            self.controller.signal.emit_signal('control-x-quit')
 
         return super().keypress(size, key)

--- a/subiquitycore/view.py
+++ b/subiquitycore/view.py
@@ -24,7 +24,7 @@ from urwid import WidgetWrap
 class BaseView(WidgetWrap):
     def keypress(self, size, key):
         if key == 'esc':
-            self.controller.signal.prev_signal()
+            self.controller.cancel()
             return None
         if key in ['ctrl x']:
             self.controller.signal.emit_signal('control-x-quit')


### PR DESCRIPTION
subiquity uses urwid's signals in a lot of places where there can only be one possible receiver. In that case, just call the method on the object directly!
