### PR TITLE
set umask in console-conf-tui to make log files private

### DIFF
--- a/bin/console-conf-tui
+++ b/bin/console-conf-tui
@@ -17,6 +17,7 @@
 import argparse
 import sys
 import logging
+import os
 import signal
 from subiquitycore.log import setup_logger
 from subiquitycore import __version__ as VERSION
@@ -64,6 +65,7 @@ def parse_options(argv):
 LOGDIR = "/var/log/console-conf/"
 
 def main():
+    os.umask(0o0077)
     opts = parse_options(sys.argv[1:])
     global LOGDIR
     if opts.dry_run:


### PR DESCRIPTION
this would also affect any other files console-conf creates, but afaict
that's only the netplan config which (a) should be private too and (b)
is handled specially anyway