### PR TITLE
rewrite Selector to work like an HTML <select> widget

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,7 @@ subiquity (0.0.27) UNRELEASED; urgency=medium
   * Many fixes to get subiquity operation again.
   * Fix header of WIFI config screen (LP: #1651119)
   * Fix partion size rounding to correctly round to 1M boundaries, not 1G.
+  * Improve widget used to select filesystem type. (LP: #1654387)
 
  -- Michael Hudson-Doyle <michael.hudson@ubuntu.com>  Mon, 09 Jan 2017 21:59:32 +1300
 

--- a/subiquity/ui/views/bcache.py
+++ b/subiquity/ui/views/bcache.py
@@ -70,7 +70,7 @@ class BcacheView(BaseView):
 
         selector = Selector(avail_devs)
         self.selected_disks[section] = selector
-        items.append(Color.string_input(Pile(selector.group),
+        items.append(Color.string_input(selector,
                                         focus_map="string_input focus"))
 
         return Pile(items)

--- a/subiquity/ui/views/filesystem/add_format.py
+++ b/subiquity/ui/views/filesystem/add_format.py
@@ -53,16 +53,13 @@ class AddFormatView(BaseView):
         ]
         return Pile(buttons)
 
-    def _format_edit(self):
-        return Pile(self.fstype.group)
-
     def _container(self):
         total_items = [
             Columns(
                 [
                     ("weight", 0.2, Text("Format", align="right")),
                     ("weight", 0.3,
-                     Color.string_input(self._format_edit(),
+                     Color.string_input(self.fstype,
                                         focus_map="string_input focus"))
                 ], dividechars=4
             ),

--- a/subiquity/ui/views/filesystem/add_partition.py
+++ b/subiquity/ui/views/filesystem/add_partition.py
@@ -88,9 +88,6 @@ class AddPartitionView(BaseView):
         ]
         return Pile(buttons)
 
-    def _format_edit(self):
-        return Pile(self.fstype.group)
-
     def _container(self):
         total_items = [
             Columns(
@@ -115,7 +112,7 @@ class AddPartitionView(BaseView):
                 [
                     ("weight", 0.2, Text("Format", align="right")),
                     ("weight", 0.3,
-                     Color.string_input(self._format_edit(),
+                     Color.string_input(self.fstype,
                                         focus_map="string_input focus"))
                 ], dividechars=4
             ),

--- a/subiquity/ui/views/raid.py
+++ b/subiquity/ui/views/raid.py
@@ -85,7 +85,7 @@ class RaidView(BaseView):
                 [
                     ("weight", 0.2, Text("RAID Level", align="right")),
                     ("weight", 0.3,
-                     Color.string_input(Pile(self.raid_level.group),
+                     Color.string_input(self.raid_level,
                                         focus_map="string_input focus"))
                 ],
                 dividechars=4

--- a/subiquitycore/core.py
+++ b/subiquitycore/core.py
@@ -130,7 +130,8 @@ class Application:
             additional_opts = {
                 'screen': urwid.raw_display.Screen(),
                 'unhandled_input': self.header_hotkeys,
-                'handle_mouse': False
+                'handle_mouse': False,
+                'pop_ups': True,
             }
             if self.common['opts'].run_on_serial:
                 palette = STYLES_MONO

--- a/subiquitycore/ui/views/network_bond_interfaces.py
+++ b/subiquitycore/ui/views/network_bond_interfaces.py
@@ -74,7 +74,7 @@ class NetworkBondInterfacesView(BaseView):
                 [
                     ("weight", 0.2, Text("Bonding Mode", align="right")),
                     ("weight", 0.3,
-                     Color.string_input(Pile(self.bond_mode.group),
+                     Color.string_input(self.bond_mode,
                                         focus_map="string_input focus"))
                 ],
                 dividechars=4


### PR DESCRIPTION
This was way way harder than it seemed like it should be, but it seems a lot
nicer to me.

For https://bugs.launchpad.net/ubuntu/+source/subiquity/+bug/1654387