### PR TITLE
implement proper tab cycling

### DIFF
--- a/console_conf/ui/views/identity.py
+++ b/console_conf/ui/views/identity.py
@@ -15,8 +15,9 @@
 
 import logging
 
-from urwid import (Pile, Columns, Text, ListBox)
+from urwid import Text
 from subiquitycore.ui.buttons import done_btn, cancel_btn
+from subiquitycore.ui.container import Columns, ListBox, Pile
 from subiquitycore.ui.interactive import EmailEditor
 from subiquitycore.ui.utils import Padding, Color
 from subiquitycore.view import BaseView

--- a/console_conf/ui/views/login.py
+++ b/console_conf/ui/views/login.py
@@ -20,9 +20,10 @@ Login provides user with language selection
 """
 import logging
 
-from urwid import (ListBox, Pile, Text)
+from urwid import Text
 
 from subiquitycore.ui.buttons import finish_btn
+from subiquitycore.ui.container import ListBox, Pile
 from subiquitycore.ui.utils import Padding, Color
 from subiquitycore.view import BaseView
 

--- a/console_conf/ui/views/welcome.py
+++ b/console_conf/ui/views/welcome.py
@@ -19,8 +19,8 @@ Welcome provides user with language selection
 
 """
 import logging
-from urwid import ListBox, Pile
 from subiquitycore.ui.buttons import ok_btn
+from subiquitycore.ui.container import ListBox, Pile
 from subiquitycore.ui.utils import Padding, Color
 from subiquitycore.view import BaseView
 

--- a/subiquity/ui/views/bcache.py
+++ b/subiquity/ui/views/bcache.py
@@ -14,10 +14,11 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-from urwid import Text, Pile, ListBox
+from urwid import Text
 
 from subiquitycore.view import BaseView
 from subiquitycore.ui.buttons import cancel_btn, done_btn
+from subiquitycore.ui.container import ListBox, Pile
 from subiquitycore.ui.interactive import Selector
 from subiquitycore.ui.utils import Color, Padding
 

--- a/subiquity/ui/views/ceph.py
+++ b/subiquity/ui/views/ceph.py
@@ -14,10 +14,11 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-from urwid import Text, Columns, Pile, ListBox
+from urwid import Text
 
 from subiquitycore.view import BaseView
 from subiquitycore.ui.buttons import cancel_btn, done_btn
+from subiquitycore.ui.container import Columns, ListBox, Pile
 from subiquitycore.ui.interactive import StringEditor
 from subiquitycore.ui.utils import Color, Padding
 

--- a/subiquity/ui/views/filesystem/add_format.py
+++ b/subiquity/ui/views/filesystem/add_format.py
@@ -14,10 +14,11 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-from urwid import ListBox, Pile, Text, Columns
+from urwid import Text
 
 from subiquitycore.ui.buttons import done_btn, cancel_btn
 from subiquitycore.ui.utils import Padding, Color
+from subiquitycore.ui.container import Columns, ListBox, Pile
 from subiquitycore.ui.interactive import Selector, MountEditor
 from subiquitycore.view import BaseView
 

--- a/subiquity/ui/views/filesystem/add_partition.py
+++ b/subiquity/ui/views/filesystem/add_partition.py
@@ -21,9 +21,10 @@ configuration.
 """
 import logging
 import re
-from urwid import connect_signal, ListBox, Pile, Text, Columns, Padding as UrwidPadding, WidgetDisable
+from urwid import connect_signal, Text, Padding as UrwidPadding, WidgetDisable
 
 from subiquitycore.ui.buttons import done_btn, cancel_btn
+from subiquitycore.ui.container import Columns, ListBox, Pile
 from subiquitycore.ui.utils import Padding, Color
 from subiquitycore.ui.interactive import (StringEditor, IntegerEditor,
                                           Selector, MountEditor)

--- a/subiquity/ui/views/filesystem/disk_info.py
+++ b/subiquity/ui/views/filesystem/disk_info.py
@@ -14,10 +14,11 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-from urwid import Pile, Text
+from urwid import Text
 
 from subiquitycore.ui.lists import SimpleList
 from subiquitycore.ui.buttons import done_btn
+from subiquitycore.ui.container import Pile
 from subiquitycore.ui.utils import Padding, Color
 from subiquitycore.view import BaseView
 

--- a/subiquity/ui/views/filesystem/disk_partition.py
+++ b/subiquity/ui/views/filesystem/disk_partition.py
@@ -14,10 +14,11 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-from urwid import ListBox, Pile, BoxAdapter, Text, Columns
+from urwid import BoxAdapter, Text
 
 from subiquitycore.ui.lists import SimpleList
 from subiquitycore.ui.buttons import done_btn, cancel_btn, menu_btn
+from subiquitycore.ui.container import Columns, ListBox, Pile
 from subiquitycore.ui.utils import Padding, Color
 from subiquitycore.view import BaseView
 

--- a/subiquity/ui/views/filesystem/filesystem.py
+++ b/subiquity/ui/views/filesystem/filesystem.py
@@ -20,13 +20,14 @@ configuration.
 
 """
 import logging
-from urwid import (ListBox, Pile, BoxAdapter, Text, Columns)
+from urwid import BoxAdapter, Text
 
 from subiquitycore.ui.lists import SimpleList
 from subiquitycore.ui.buttons import (done_btn,
                                       reset_btn,
                                       cancel_btn,
                                       menu_btn)
+from subiquitycore.ui.container import Columns, ListBox, Pile
 from subiquitycore.ui.utils import Padding, Color
 from subiquitycore.view import BaseView
 

--- a/subiquity/ui/views/identity.py
+++ b/subiquity/ui/views/identity.py
@@ -15,13 +15,14 @@
 
 import logging
 
-from urwid import Pile, Columns, Text, ListBox
+from urwid import Text
 
 from subiquitycore.ui.buttons import done_btn, cancel_btn
 from subiquitycore.ui.interactive import (PasswordEditor,
                                           RealnameEditor,
                                           StringEditor,
                                           UsernameEditor)
+from subiquitycore.ui.container import Columns, ListBox, Pile
 from subiquitycore.ui.utils import Padding, Color
 from subiquitycore.view import BaseView
 

--- a/subiquity/ui/views/installpath.py
+++ b/subiquity/ui/views/installpath.py
@@ -19,11 +19,12 @@ Provides high level options for Ubuntu install
 
 """
 import logging
-from urwid import (ListBox, Pile, BoxAdapter)
+from urwid import BoxAdapter
 
 from subiquitycore.ui.lists import SimpleList
 from subiquitycore.ui.buttons import menu_btn, cancel_btn
 from subiquitycore.ui.utils import Padding, Color
+from subiquitycore.ui.container import ListBox, Pile
 from subiquitycore.view import BaseView
 
 log = logging.getLogger('subiquity.installpath')

--- a/subiquity/ui/views/installprogress.py
+++ b/subiquity/ui/views/installprogress.py
@@ -16,14 +16,13 @@
 import logging
 from urwid import (
     LineBox,
-    ListBox,
     Text,
-    Pile,
     SimpleListWalker,
     )
 
 from subiquitycore.view import BaseView
 from subiquitycore.ui.buttons import confirm_btn
+from subiquitycore.ui.container import ListBox, Pile
 from subiquitycore.ui.utils import Padding, Color
 
 log = logging.getLogger("subiquity.views.installprogress")

--- a/subiquity/ui/views/iscsi.py
+++ b/subiquity/ui/views/iscsi.py
@@ -14,10 +14,11 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-from urwid import Text, Columns, Pile, ListBox
+from urwid import Text
 
 from subiquitycore.view import BaseView
 from subiquitycore.ui.buttons import menu_btn
+from subiquitycore.ui.container import Columns, ListBox, Pile
 from subiquitycore.ui.interactive import (StringEditor, YesNo,
                                           PasswordEditor)
 from subiquitycore.ui.utils import Color, Padding

--- a/subiquity/ui/views/lvm.py
+++ b/subiquity/ui/views/lvm.py
@@ -14,10 +14,11 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-from urwid import Text, Columns, Pile, ListBox, CheckBox
+from urwid import Text, CheckBox
 
 from subiquitycore.view import BaseView
 from subiquitycore.ui.buttons import cancel_btn, done_btn
+from subiquitycore.ui.container import Columns, ListBox, Pile
 from subiquitycore.ui.interactive import UsernameEditor
 from subiquitycore.ui.utils import Color, Padding
 

--- a/subiquity/ui/views/raid.py
+++ b/subiquity/ui/views/raid.py
@@ -14,10 +14,11 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-from urwid import Text, Columns, Pile, ListBox, CheckBox
+from urwid import Text, CheckBox
 
 from subiquitycore.view import BaseView
 from subiquitycore.ui.buttons import cancel_btn, done_btn
+from subiquitycore.ui.container import Columns, ListBox, Pile
 from subiquitycore.ui.interactive import (StringEditor, IntegerEditor,
                                           Selector)
 from subiquitycore.ui.utils import Color, Padding

--- a/subiquity/ui/views/welcome.py
+++ b/subiquity/ui/views/welcome.py
@@ -19,9 +19,10 @@ Welcome provides user with language selection
 
 """
 import logging
-from urwid import (ListBox, Pile, BoxAdapter)
+from urwid import BoxAdapter
 from subiquitycore.ui.lists import SimpleList
 from subiquitycore.ui.buttons import menu_btn, ok_btn
+from subiquitycore.ui.container import ListBox, Pile
 from subiquitycore.ui.utils import Padding, Color
 from subiquitycore.view import BaseView
 

--- a/subiquitycore/ui/container.py
+++ b/subiquitycore/ui/container.py
@@ -77,7 +77,7 @@ class TabCyclingMixin:
     def keypress(self, size, key):
         key = super(TabCyclingMixin, self).keypress(size, key)
 
-        if key == 'tab':
+        if self._command_map[key] == 'next selectable':
             next_fp = self.focus_position + 1
             for i, (w, o) in enumerate(self._contents[next_fp:], next_fp):
                 if w.selectable():
@@ -86,7 +86,7 @@ class TabCyclingMixin:
                     return
             self._select_first_selectable()
             return key
-        elif key == 'shift tab':
+        elif self._command_map[key] == 'prev selectable':
             for i, (w, o) in reversed(list(enumerate(self._contents[:self.focus_position]))):
                 if w.selectable():
                     self.set_focus(i)
@@ -149,7 +149,7 @@ class TabCyclingListBox(urwid.ListBox):
     def keypress(self, size, key):
         key = super(TabCyclingListBox, self).keypress(size, key)
 
-        if key == 'tab':
+        if self._command_map[key] == 'next selectable':
             next_fp = self.focus_position + 1
             for i, w in enumerate(self.body[next_fp:], next_fp):
                 if w.selectable():
@@ -158,7 +158,7 @@ class TabCyclingListBox(urwid.ListBox):
                     return
             self._select_first_selectable()
             return key
-        elif key == 'shift tab':
+        elif self._command_map[key] == 'prev selectable':
             for i, w in reversed(list(enumerate(self.body[:self.focus_position]))):
                 if w.selectable():
                     self.set_focus(i)

--- a/subiquitycore/ui/container.py
+++ b/subiquitycore/ui/container.py
@@ -1,0 +1,178 @@
+import logging
+
+import urwid
+
+log = logging.getLogger('subiquitycore.ui.frame')
+
+# This is adapted from
+# https://github.com/pimutils/khal/commit/bd7c5f928a7670de9afae5657e66c6dc846688ac, which has this license:
+#
+# Copyright (c) 2013-2015 Christian Geier et al.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+def _maybe_sfs(w):
+    m = getattr(w.base_widget, "_select_first_selectable", None)
+    if m is not None:
+        m()
+
+def _maybe_sls(w):
+    m = getattr(w.base_widget, "_select_last_selectable", None)
+    if m is not None:
+        m()
+
+class NextMixin:
+    """Implements _select_first_selectable/_select_last_selectable for urwid.Pile and urwid.Columns"""
+
+    def _select_first_selectable(self):
+        """select our first selectable item (recursivly if that item SupportsNext)"""
+        log.debug("%s _select_first_selectable", self.__class__.__name__)
+        i = self._first_selectable()
+        self.set_focus(i)
+        log.debug(" -> first selectable %s", self.contents[i][0])
+        _maybe_sfs(self.contents[i][0])
+
+    def _select_last_selectable(self):
+        """select our last selectable item (recursivly if that item SupportsNext)"""
+        log.debug("%s _select_last_selectable", self.__class__.__name__)
+        i = self._last_selectable()
+        self.set_focus(i)
+        log.debug(" -> last selectable %s", self.contents[i][0])
+        self.set_focus(i)
+        _maybe_sls(self.contents[i][0])
+
+    def _first_selectable(self):
+        """return sequence number of self.contents last selectable item"""
+        for j in range(0, len(self._contents)):
+            if self._contents[j][0].selectable():
+                return j
+        return False
+
+    def _last_selectable(self):
+        """return sequence number of self._contents last selectable item"""
+        for j in range(len(self._contents) - 1, - 1, - 1):
+            if self._contents[j][0].selectable():
+                return j
+        return False
+
+    def keypress(self, size, key):
+        key = super(NextMixin, self).keypress(size, key)
+
+        if key == 'tab':
+            if self.focus_position == self._last_selectable():
+                self._select_first_selectable()
+                return key
+            else:
+                for i in range(self.focus_position + 1, len(self._contents)):
+                    if self._contents[i][0].selectable():
+                        self.set_focus(i)
+                        _maybe_sfs(self._contents[i][0])
+                        break
+                else:  # no break
+                    return key
+        elif key == 'shift tab':
+            if self.focus_position == self._first_selectable():
+                self._select_last_selectable()
+                return key
+            else:
+                for i in range(self.focus_position - 1, 0 - 1, -1):
+                    if self._contents[i][0].selectable():
+                        self.set_focus(i)
+                        _maybe_sls(self._contents[i][0])
+                        break
+                else:  # no break
+                    return key
+        else:
+            return key
+
+
+class NPile(NextMixin, urwid.Pile):
+    pass
+
+class NColumns(NextMixin, urwid.Columns):
+    pass
+
+
+class NListBox(urwid.ListBox):
+    def __init__(self, body):
+        if getattr(body, 'get_focus', None) is None:
+            body = urwid.SimpleListWalker(body)
+        super().__init__(body)
+
+    def _select_first_selectable(self):
+        """select our first selectable item (recursivly if that item SupportsNext)"""
+        log.debug("%s _select_first_selectable", self.__class__.__name__)
+        i = self._first_selectable()
+        # We call set_focus twice because otherwise the listbox
+        # attempts to do the minimal amount of scrolling required to
+        # get the new focus widget into view, which is not what we
+        # want, as if our first widget is a compound widget it results
+        # its last widget being focused -- not at all what we want!
+        self.set_focus(i)
+        self.set_focus(i)
+        # I don't really understand why this is required but it seems it is.
+        self._invalidate()
+        log.debug(" -> first selectable %s", self.body[i])
+        _maybe_sfs(self.body[i])
+
+    def _select_last_selectable(self):
+        """select our last selectable item (recursivly if that item SupportsNext)"""
+        log.debug("%s _select_last_selectable", self.__class__.__name__)
+        i = self._last_selectable()
+        # See comment in _select_first_selectable for why we call this twice.
+        self.set_focus(i)
+        self.set_focus(i)
+        self._invalidate()
+        log.debug(" -> last selectable %s", self.body[i])
+        _maybe_sls(self.body[i])
+
+    def _first_selectable(self):
+        """return sequence number of self._contents last selectable item"""
+        for j in range(0, len(self.body)):
+            if self.body[j].selectable():
+                return j
+        return False
+
+    def _last_selectable(self):
+        """return sequence number of self.contents last selectable item"""
+        for j in range(len(self.body) - 1, - 1, - 1):
+            if self.body[j].selectable():
+                return j
+        return False
+
+    def keypress(self, size, key):
+        key = super().keypress(size, key)
+        if key == 'tab':
+            if self.focus_position == self._last_selectable():
+                self._select_first_selectable()
+                return key
+            else:
+                self._keypress_down(size)
+        elif key == 'shift tab':
+            if self.focus_position == self._first_selectable():
+                self._select_last_selectable()
+                return key
+            else:
+                self._keypress_up(size)
+        else:
+            return key
+
+Columns = NColumns
+Pile = NPile
+ListBox = NListBox

--- a/subiquitycore/ui/frame.py
+++ b/subiquitycore/ui/frame.py
@@ -24,7 +24,6 @@ log = logging.getLogger('subiquitycore.ui.frame')
 
 
 class SubiquityUI(WidgetWrap):
-    key_conversion_map = {'tab': 'down', 'shift tab': 'up'}
 
     def __init__(self, header=None, body=None, footer=None):
         self.header = header if header else Header()
@@ -34,7 +33,6 @@ class SubiquityUI(WidgetWrap):
         super().__init__(self.frame)
 
     def keypress(self, size, key):
-        key = self.key_conversion_map.get(key, key)
         return super().keypress(size, key)
 
     def set_header(self, title=None, excerpt=None):

--- a/subiquitycore/ui/interactive.py
+++ b/subiquitycore/ui/interactive.py
@@ -24,7 +24,6 @@ from urwid import (
     Filler,
     IntEdit,
     LineBox,
-    Pile,
     PopUpLauncher,
     SelectableIcon,
     Text,
@@ -33,6 +32,8 @@ from urwid import (
     )
 import logging
 import re
+
+from subiquitycore.ui.container import Pile
 
 log = logging.getLogger("subiquitycore.ui.input")
 

--- a/subiquitycore/ui/lists.py
+++ b/subiquitycore/ui/lists.py
@@ -13,7 +13,9 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from urwid import ListBox, SimpleListWalker, WidgetWrap
+from urwid import SimpleListWalker, WidgetWrap
+
+from subiquitycore.ui.container import ListBox
 
 
 class SimpleList(WidgetWrap):

--- a/subiquitycore/ui/views/login.py
+++ b/subiquitycore/ui/views/login.py
@@ -19,8 +19,9 @@ Login provides user with language selection
 
 """
 import logging
-from urwid import (ListBox, Pile, Text)
+from urwid import Text
 from subiquitycore.ui.buttons import finish_btn
+from subiquitycore.ui.container import Pile, ListBox
 from subiquitycore.ui.utils import Padding, Color
 from subiquitycore.view import BaseView
 

--- a/subiquitycore/ui/views/network.py
+++ b/subiquitycore/ui/views/network.py
@@ -22,11 +22,16 @@ Provides network device listings and extended network information
 import logging
 import textwrap
 
-from urwid import (ListBox, Pile,
-                   Text, Columns, Overlay,
-                   LineBox, ProgressBar, WidgetWrap)
+from urwid import (
+    LineBox,
+    Overlay,
+    ProgressBar,
+    Text,
+    WidgetWrap,
+    )
 
 from subiquitycore.ui.buttons import cancel_btn, menu_btn, done_btn
+from subiquitycore.ui.container import Columns, ListBox, Pile
 from subiquitycore.ui.utils import Padding, Color
 from subiquitycore.view import BaseView
 

--- a/subiquitycore/ui/views/network_bond_interfaces.py
+++ b/subiquitycore/ui/views/network_bond_interfaces.py
@@ -13,9 +13,10 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from urwid import Text, Columns, Pile, ListBox, CheckBox
+from urwid import Text, CheckBox
 from subiquitycore.view import BaseView
 from subiquitycore.ui.buttons import cancel_btn, done_btn
+from subiquitycore.ui.container import Columns, ListBox, Pile
 from subiquitycore.ui.interactive import Selector
 from subiquitycore.ui.utils import Color, Padding
 import logging

--- a/subiquitycore/ui/views/network_configure_interface.py
+++ b/subiquitycore/ui/views/network_configure_interface.py
@@ -13,9 +13,9 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from urwid import Pile, ListBox
 from subiquitycore.view import BaseView
 from subiquitycore.ui.buttons import done_btn, menu_btn
+from subiquitycore.ui.container import ListBox, Pile
 from subiquitycore.ui.utils import Color, Padding
 from subiquitycore.ui.views.network import _build_gateway_ip_info_for_version, _build_wifi_info
 import logging
@@ -39,7 +39,6 @@ class NetworkConfigureInterfaceView(BaseView):
         if self.dev.type == 'wlan':
             self.wifi_info = Pile(_build_wifi_info(self.dev))
             self.wifi_method = Pile(self._build_wifi_config())
-
 
     def _build_body(self):
         body = []

--- a/subiquitycore/ui/views/network_configure_manual_interface.py
+++ b/subiquitycore/ui/views/network_configure_manual_interface.py
@@ -16,10 +16,11 @@
 import logging
 import ipaddress
 
-from urwid import Text, Pile, ListBox, Columns
+from urwid import Text
 
 from subiquitycore.view import BaseView
 from subiquitycore.ui.buttons import done_btn, menu_btn, cancel_btn
+from subiquitycore.ui.container import Columns, ListBox, Pile
 from subiquitycore.ui.utils import Color, Padding
 from subiquitycore.ui.interactive import StringEditor
 

--- a/subiquitycore/ui/views/network_configure_wlan_interface.py
+++ b/subiquitycore/ui/views/network_configure_wlan_interface.py
@@ -1,6 +1,7 @@
-from urwid import Text, Pile, ListBox, Columns, Overlay, WidgetWrap, LineBox, Button, BoxAdapter
+from urwid import Text, Overlay, WidgetWrap, LineBox, Button, BoxAdapter
 from subiquitycore.view import BaseView
 from subiquitycore.ui.buttons import cancel_btn, done_btn, menu_btn
+from subiquitycore.ui.container import Columns, ListBox, Pile
 from subiquitycore.ui.interactive import PasswordEditor, StringEditor
 from subiquitycore.ui.utils import Color, Padding
 import logging

--- a/subiquitycore/ui/views/network_default_route.py
+++ b/subiquitycore/ui/views/network_default_route.py
@@ -16,10 +16,11 @@
 import logging
 import socket
 
-from urwid import Text, Pile, ListBox
+from urwid import Text
 
 from subiquitycore.view import BaseView
 from subiquitycore.ui.buttons import cancel_btn, done_btn, menu_btn
+from subiquitycore.ui.container import ListBox, Pile
 from subiquitycore.ui.utils import Color, Padding
 from subiquitycore.ui.interactive import StringEditor
 


### PR DESCRIPTION
I know we said this wasn't a priority but I couldn't resist one more crack and actually I was really nearly there. This makes 'tab' and 'shift tab' move to next and previous widgets respectively and cycles around as needed.