### PR TITLE
better validation for add partition view

### DIFF
--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -587,6 +587,14 @@ class FilesystemModel(object):
 
         return mounts
 
+    def get_mounts2(self):
+        r = {}
+        for dev in self.get_all_disks():
+            for k, v in dev._mounts.items():
+                r[v] = k
+
+        return r
+
     def get_disk_action(self, disk):
         return self.devices[disk].get_actions()
 

--- a/subiquity/ui/mount.py
+++ b/subiquity/ui/mount.py
@@ -13,7 +13,6 @@ common_mountpoints = [
     '/usr',
     '/var',
     '/var/lib',
-    ('other', True, None)
     ]
 
 class _MountEditor(StringEditor):
@@ -30,8 +29,21 @@ class _MountEditor(StringEditor):
         return super().keypress(size, key)
 
 class MountSelector(WidgetWrap):
-    def __init__(self):
-        self._selector = Selector(opts=common_mountpoints)
+    def __init__(self, model):
+        mounts = model.get_mounts2()
+        opts = []
+        first_opt = None
+        max_len = max(map(len, common_mountpoints))
+        for i, mnt in enumerate(common_mountpoints):
+            devpath = mounts.get(mnt)
+            if devpath is None:
+                if first_opt is None:
+                    first_opt = i
+                opts.append((mnt, True, mnt))
+            else:
+                opts.append(("%-*s (%s)"%(max_len, mnt, devpath), False, None))
+        opts.append(('other', True, None))
+        self._selector = Selector(opts, first_opt)
         connect_signal(self._selector, 'select', self._select_mount)
         self._other = _MountEditor(caption='', edit_text='/')
         super().__init__(Pile([self._selector]))

--- a/subiquity/ui/mount.py
+++ b/subiquity/ui/mount.py
@@ -1,0 +1,56 @@
+
+import re
+
+from urwid import connect_signal, Padding, Pile, WidgetWrap
+
+from subiquitycore.ui.interactive import Selector, StringEditor
+
+common_mountpoints = [
+    '/',
+    '/boot',
+    '/home',
+    '/srv',
+    '/usr',
+    '/var',
+    '/var/lib',
+    ('other', True, None)
+    ]
+
+class _MountEditor(StringEditor):
+    """ Mountpoint input prompt with input rules
+    """
+
+    def keypress(self, size, key):
+        ''' restrict what chars we allow for mountpoints '''
+
+        mountpoint = r'[a-zA-Z0-9_/\.\-]'
+        if re.match(mountpoint, key) is None:
+            return False
+
+        return super().keypress(size, key)
+
+class MountSelector(WidgetWrap):
+    def __init__(self):
+        self._selector = Selector(opts=common_mountpoints)
+        connect_signal(self._selector, 'select', self._select_mount)
+        self._other = _MountEditor(caption='', edit_text='/')
+        super().__init__(Pile([self._selector]))
+
+    def _showhide_other(self, show):
+        if show:
+            self._w.contents.append((Padding(self._other, left=4), self._w.options('pack')))
+        else:
+            del self._w.contents[-1]
+
+    def _select_mount(self, sender, value):
+        if (self._selector.value == None) != (value == None):
+            self._showhide_other(value==None)
+        if value == None:
+            self._w.focus_position = 1
+
+    @property
+    def value(self):
+        if self._selector.value is None:
+            return self._other.value
+        else:
+            return self._selector.value

--- a/subiquity/ui/views/filesystem/add_format.py
+++ b/subiquity/ui/views/filesystem/add_format.py
@@ -36,7 +36,7 @@ class AddFormatView(BaseView):
         self.selected_disk = selected_disk
         self.disk_obj = self.model.get_disk(selected_disk)
 
-        self.mountpoint = MountSelector()
+        self.mountpoint = MountSelector(self.model)
         self.fstype = Selector(opts=self.model.supported_filesystems)
         connect_signal(self.fstype, 'select', self.select_fstype)
         self.pile = self._container()

--- a/subiquity/ui/views/filesystem/add_partition.py
+++ b/subiquity/ui/views/filesystem/add_partition.py
@@ -220,7 +220,7 @@ class AddPartitionView(BaseView):
             self.button_pile[0].disable()
             self.button_pile.focus_position = 1
         else:
-            self.done_btn.enable()
+            self.button_pile[0].enable()
 
     def select_fstype(self, sender, fs):
         if fs.is_mounted != sender.value.is_mounted:

--- a/subiquity/ui/views/filesystem/add_partition.py
+++ b/subiquity/ui/views/filesystem/add_partition.py
@@ -221,8 +221,8 @@ class AddPartitionView(BaseView):
         error = False
         for w in self.all_vws:
             if w.has_error():
-                log.debug("%s has error", w)
                 error = True
+                break
         if error:
             self.buttons[0].disable()
             self.buttons.focus_position = 1

--- a/subiquity/ui/views/filesystem/add_partition.py
+++ b/subiquity/ui/views/filesystem/add_partition.py
@@ -141,10 +141,10 @@ class AddPartitionView(BaseView):
 
     def _build_buttons(self):
         cancel = cancel_btn(on_press=self.cancel)
-        self.done_btn = Toggleable(done_btn(on_press=self.done), 'button')
+        done = done_btn(on_press=self.done)
 
         buttons = [
-            self.done_btn,
+            Toggleable(done, 'button'),
             Color.button(cancel, focus_map='button focus')
         ]
         return Pile(buttons)
@@ -217,7 +217,7 @@ class AddPartitionView(BaseView):
                 log.debug("%s has error", w)
                 error = True
         if error:
-            self.done_btn.disable()
+            self.button_pile[0].disable()
             self.button_pile.focus_position = 1
         else:
             self.done_btn.enable()

--- a/subiquitycore/ui/interactive.py
+++ b/subiquitycore/ui/interactive.py
@@ -123,20 +123,6 @@ class UsernameEditor(StringEditor):
         return super().keypress(size, key)
 
 
-class MountEditor(StringEditor):
-    """ Mountpoint input prompt with input rules
-    """
-
-    def keypress(self, size, key):
-        ''' restrict what chars we allow for mountpoints '''
-
-        mountpoint = r'[a-zA-Z0-9_/\.\-]'
-        if re.match(mountpoint, key) is None:
-            return False
-
-        return super().keypress(size, key)
-
-
 class IntegerEditor(WidgetWrap):
     """ IntEdit input class
     """

--- a/subiquitycore/ui/lists.py
+++ b/subiquitycore/ui/lists.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from urwid import SimpleListWalker, WidgetWrap
+from urwid import SimpleFocusListWalker, WidgetWrap
 
 from subiquitycore.ui.container import ListBox
 
@@ -25,7 +25,7 @@ class SimpleList(WidgetWrap):
         super().__init__(self._build_widget())
 
     def _build_widget(self):
-        lw = SimpleListWalker(list(self.contents))
+        lw = SimpleFocusListWalker(list(self.contents))
 
         return ListBox(lw)
 


### PR DESCRIPTION
This all started because @raharper noticed that you could enter the same mountpoint twice for different partitions. This is clearly something that should be prevented, but doing it in a tasteful way (and also the validation of the input size) required me to build up a slightly improbable amount of machinery. Oh well it works now:

https://asciinema.org/a/31wn2g453sayriogqyd75ttia

and will be useful to improve the validation of the other (identity, manual network configuration) views tomorrow.