### PR TITLE
move help to an overlay

### DIFF
--- a/subiquity/ui/views/filesystem/add_format.py
+++ b/subiquity/ui/views/filesystem/add_format.py
@@ -56,7 +56,7 @@ class AddFormatView(BaseView):
 
         body = [
             Padding.line_break(""),
-            self.form.as_rows(),
+            self.form.as_rows(self),
             Padding.line_break(""),
             Padding.fixed_10(self.form.buttons)
         ]

--- a/subiquity/ui/views/filesystem/add_partition.py
+++ b/subiquity/ui/views/filesystem/add_partition.py
@@ -120,7 +120,7 @@ class AddPartitionView(BaseView):
                 ]
             ),
             Padding.line_break(""),
-            self.form.as_rows(),
+            self.form.as_rows(self),
             Padding.line_break(""),
             Padding.fixed_10(self.form.buttons),
         ]

--- a/subiquity/ui/views/identity.py
+++ b/subiquity/ui/views/identity.py
@@ -108,7 +108,7 @@ class IdentityView(BaseView):
         self.ssh_import_confirmed = True
 
         body = [
-            Padding.center_90(self.form.as_rows()),
+            Padding.center_90(self.form.as_rows(self)),
             Padding.line_break(""),
             Padding.fixed_10(self.form.buttons),
         ]

--- a/subiquitycore/controllers/network.py
+++ b/subiquitycore/controllers/network.py
@@ -410,7 +410,7 @@ class NetworkController(BaseController):
         self.acw.advance()
 
     def task_error(self, stage, info=None):
-        self.ui.frame.body.remove_overlay(self.acw)
+        self.ui.frame.body.remove_overlay()
         self.ui.frame.body.show_network_error(stage, info)
 
     def tasks_finished(self):

--- a/subiquitycore/ui/interactive.py
+++ b/subiquitycore/ui/interactive.py
@@ -35,7 +35,9 @@ from urwid import (
     WidgetWrap,
     )
 
+from subiquitycore.ui.buttons import PlainButton
 from subiquitycore.ui.container import Pile
+from subiquitycore.ui.utils import Color, Padding
 
 log = logging.getLogger("subiquitycore.ui.input")
 
@@ -226,3 +228,29 @@ class YesNo(Selector):
     def __init__(self):
         opts = ['Yes', 'No']
         super().__init__(opts)
+
+
+class _HelpDisplay(WidgetWrap):
+    def __init__(self, closer, help_text):
+        self._closer = closer
+        button = Color.button(PlainButton(label="Close", on_press=lambda btn:self._closer()))
+        super().__init__(LineBox(Pile([Text(help_text), Padding.fixed_10(button)]), title="Help"))
+    def keypress(self, size, key):
+        if key == 'esc':
+            self._closer()
+        else:
+            return super().keypress(size, key)
+
+
+class Help(WidgetWrap):
+
+    def __init__(self, view, help_text):
+        self._view = view
+        self._help_text = help_text
+        self._button = Padding.fixed_3(Color.button(SelectableIcon("[?]", 1)))
+        super().__init__(self._button)
+
+    def keypress(self, size, key):
+        if self._command_map[key] != ACTIVATE:
+            return key
+        self._view.show_overlay(_HelpDisplay(self._view.remove_overlay, self._help_text))

--- a/subiquitycore/ui/views/network.py
+++ b/subiquitycore/ui/views/network.py
@@ -129,21 +129,6 @@ class NetworkView(BaseView):
         self.lb.set_focus(4)  # _build_buttons
         super().__init__(self.lb)
 
-    def show_overlay(self, overlay_widget):
-        self.orig_w = self._w
-        self._w = Overlay(top_w=overlay_widget,
-                          bottom_w=self._w,
-                          align='center',
-                          width=('relative', 60),
-                          min_width=80,
-                          valign='middle',
-                          height='pack')
-
-    def remove_overlay(self, overlay_widget):
-        # urwid note: we could also get orig_w as
-        # self._w.contents[0][0], but this is clearer:
-        self._w = self.orig_w
-
     def _build_buttons(self):
         cancel = Color.button(cancel_btn(on_press=self.cancel))
         done = Color.button(done_btn(on_press=self.done))

--- a/subiquitycore/ui/views/network_configure_manual_interface.py
+++ b/subiquitycore/ui/views/network_configure_manual_interface.py
@@ -132,7 +132,7 @@ class BaseNetworkConfigureManualView(BaseView):
         self.error = Text("", align='center')
         #self.set_as_default_gw_button = Pile(self._build_set_as_default_gw_button())
         body = [
-            Padding.center_79(self.form.as_rows()),
+            Padding.center_79(self.form.as_rows(self)),
             #Padding.line_break(""),
             #Padding.center_79(self.set_as_default_gw_button),
             Padding.line_break(""),

--- a/subiquitycore/ui/views/network_configure_wlan_interface.py
+++ b/subiquitycore/ui/views/network_configure_wlan_interface.py
@@ -59,20 +59,6 @@ class NetworkConfigureWLANView(BaseView):
                 return
         return super().keypress(size, key)
 
-    def show_overlay(self, overlay_widget):
-        self.orig_w = self._w
-        self._w = Overlay(top_w=overlay_widget,
-                          bottom_w=self._w,
-                          align='center',
-                          width=('relative', 60),
-                          min_width=80,
-                          valign='middle',
-                          height='pack')
-
-    def remove_overlay(self):
-        self._w = self.orig_w
-        self.orig_w = None
-
     def show_ssid_list(self, sender):
         self.show_overlay(NetworkList(self, self.dev.actual_ssids))
 

--- a/subiquitycore/view.py
+++ b/subiquitycore/view.py
@@ -18,10 +18,26 @@
 Contains some default key navigations
 """
 
-from urwid import WidgetWrap
+from urwid import Overlay, WidgetWrap
 
 
 class BaseView(WidgetWrap):
+    def show_overlay(self, overlay_widget, **kw):
+        self.orig_w = self._w
+        args = dict(
+            align='center',
+            width=('relative', 60),
+            min_width=80,
+            valign='middle',
+            height='pack'
+            )
+        args.update(kw)
+        self._w = Overlay(top_w=overlay_widget, bottom_w=self._w, **args)
+
+    def remove_overlay(self):
+        self._w = self.orig_w
+        self.orig_w = None
+
     def keypress(self, size, key):
         if key == 'esc':
             self.controller.cancel()

--- a/subiquitycore/view.py
+++ b/subiquitycore/view.py
@@ -39,10 +39,11 @@ class BaseView(WidgetWrap):
         self.orig_w = None
 
     def keypress(self, size, key):
+        if key in ['ctrl x']:
+            self.controller.signal.emit_signal('control-x-quit')
+            return None
+        key = super().keypress(size, key)
         if key == 'esc':
             self.controller.cancel()
             return None
-        if key in ['ctrl x']:
-            self.controller.signal.emit_signal('control-x-quit')
-
-        return super().keypress(size, key)
+        return key


### PR DESCRIPTION
This branch hides the hints we currently give on forms away behind a small button. The idea is that then we can write much longer documentation without worrying about how much screen space we'll take up. You can see me playing with it at https://asciinema.org/a/d24p02yrlz1jrgy96mriviahk

This is a bit of an experiment, I'm not sure if this is better or not.