### PR TITLE
still use source-type: git even though source: is now .

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -23,9 +23,11 @@ parts:
       - pyudev
       - attrs
     source: .
+    source-type: git
   wrappers:
     plugin: dump
     source: .
+    source-type: git
     organize:
       'bin/console-conf-tui': usr/bin/console-conf
       'bin/subiquity-tui': usr/bin/subiquity


### PR DESCRIPTION
This makes the contents of the snap much more reasonable for reasons I don't entirely
understand

There is still a mystery dh_python in the snap but it's less than half the size now.