### PR TITLE
Setup orange for fbterm too

### DIFF
--- a/subiquity/palette.py
+++ b/subiquity/palette.py
@@ -46,7 +46,7 @@ STYLES = [
     ('redbutton',           white,      '',            '', white,      ''),
     ('redbutton focus',     black,      dark_red,      '', black,      dark_red),
     ('amberbutton',         white,      '',            '', white,      ''),
-    ('amberbutton focus',   black,      yellow,        '', black,      yellow),
+    ('amberbutton focus',   black,      dark_cyan,     '', black,      dark_cyan),
     ('info_primary',        white,      '',            '', white,      ''),
     ('info_major',          light_gray, '',            '', light_gray, ''),
     ('info_minor',          dark_gray,  '',            '', dark_gray,  ''),


### PR DESCRIPTION
So urwid does not appear to be using terminfo/curses hence our struggles with orange.

However, for improved i18n support I want to use full unicode, Ubuntu Mono fonts, etc. Thus I've looked into running subiquity under fbterm. It usually reports itself as 'linux', but one can set `TERM=fbterm` for better handling by terminfo / detection. So I piggy back onto that, and use fbterm escape codes api to set orange.