### PR TITLE
Buttons

### DIFF
--- a/console_conf/ui/views/identity.py
+++ b/console_conf/ui/views/identity.py
@@ -91,12 +91,9 @@ class IdentityView(BaseView):
         return Pile(sl)
 
     def _build_buttons(self):
-        cancel = cancel_btn(on_press=self.cancel)
-        done = done_btn(on_press=self.done)
-
         buttons = [
-            Color.button(done),
-            Color.button(cancel),
+            done_btn(on_press=self.done),
+            cancel_btn(on_press=self.cancel),
         ]
         return Pile(buttons)
 

--- a/console_conf/ui/views/login.py
+++ b/console_conf/ui/views/login.py
@@ -22,9 +22,9 @@ import logging
 
 from urwid import Text
 
-from subiquitycore.ui.buttons import finish_btn
+from subiquitycore.ui.buttons import done_btn
 from subiquitycore.ui.container import ListBox, Pile
-from subiquitycore.ui.utils import Padding, Color
+from subiquitycore.ui.utils import Padding
 from subiquitycore.view import BaseView
 
 log = logging.getLogger("subiquitycore.views.login")
@@ -46,7 +46,7 @@ class LoginView(BaseView):
 
     def _build_buttons(self):
         self.buttons = [
-            Color.button(finish_btn(on_press=self.done)),
+            done_btn(on_press=self.done),
         ]
         return Pile(self.buttons)
 

--- a/console_conf/ui/views/welcome.py
+++ b/console_conf/ui/views/welcome.py
@@ -21,7 +21,7 @@ Welcome provides user with language selection
 import logging
 from subiquitycore.ui.buttons import ok_btn
 from subiquitycore.ui.container import ListBox, Pile
-from subiquitycore.ui.utils import Padding, Color
+from subiquitycore.ui.utils import Padding
 from subiquitycore.view import BaseView
 
 log = logging.getLogger("console_conf.views.welcome")
@@ -37,7 +37,7 @@ class WelcomeView(BaseView):
 
     def _build_buttons(self):
         self.buttons = [
-            Color.button(ok_btn(on_press=self.confirm)),
+            ok_btn(on_press=self.confirm),
         ]
         return Pile(self.buttons)
 

--- a/subiquity/ui/views/bcache.py
+++ b/subiquity/ui/views/bcache.py
@@ -114,12 +114,9 @@ class BcacheView(BaseView):
 
     def _build_buttons(self):
         log.debug('bcache: _build_buttons')
-        cancel = cancel_btn(on_press=self.cancel)
-        done = done_btn(on_press=self.done)
-
         buttons = [
-            Color.button(done),
-            Color.button(cancel)
+            done_btn(on_press=self.done),
+            cancel_btn(on_press=self.cancel),
         ]
         return Pile(buttons)
 

--- a/subiquity/ui/views/ceph.py
+++ b/subiquity/ui/views/ceph.py
@@ -68,12 +68,9 @@ class CephDiskView(BaseView):
         return Pile(items)
 
     def _build_buttons(self):
-        cancel = cancel_btn(on_press=self.cancel)
-        done = done_btn(on_press=self.done)
-
         buttons = [
-            Color.button(done),
-            Color.button(cancel)
+            done_btn(on_press=self.done),
+            cancel_btn(on_press=self.cancel),
         ]
         return Pile(buttons)
 

--- a/subiquity/ui/views/filesystem/filesystem.py
+++ b/subiquity/ui/views/filesystem/filesystem.py
@@ -58,7 +58,7 @@ class FilesystemConfirmationView(WidgetWrap):
         pile = Pile([
             UrwidPadding(Text(confirmation_text), left=2, right=2),
             Padding.fixed_15(cancel_btn(label="No", on_press=self.cancel)),
-            Padding.fixed_15(danger_btn(label="Continue", on_press=self.ok)),
+            Padding.fixed_15(danger_btn(on_press=self.ok)),
             Text(""),
             ])
         lb = LineBox(pile, title="Confirm destructive action")

--- a/subiquity/ui/views/filesystem/partition.py
+++ b/subiquity/ui/views/filesystem/partition.py
@@ -22,7 +22,7 @@ configuration.
 import logging
 from urwid import connect_signal, Text
 
-from subiquitycore.ui.buttons import danger_btn
+from subiquitycore.ui.buttons import delete_btn
 from subiquitycore.ui.container import ListBox
 from subiquitycore.ui.form import (
     Form,
@@ -162,10 +162,10 @@ class PartitionView(PartitionFormatView):
     def make_body(self):
         body = super().make_body()
         if self.partition is not None:
-            delete_btn = danger_btn("Delete", on_press=self.delete)
+            btn = delete_btn(on_press=self.delete)
             body[-2:-2] = [
                 Text(""),
-                Padding.fixed_10(Color.info_error(delete_btn)),
+                Padding.fixed_10(btn),
                 ]
             pass
         return body

--- a/subiquity/ui/views/installprogress.py
+++ b/subiquity/ui/views/installprogress.py
@@ -21,7 +21,7 @@ from urwid import (
     )
 
 from subiquitycore.view import BaseView
-from subiquitycore.ui.buttons import cancel_btn, confirm_btn
+from subiquitycore.ui.buttons import cancel_btn, ok_btn
 from subiquitycore.ui.container import ListBox, Pile
 from subiquitycore.ui.utils import Padding
 
@@ -62,7 +62,7 @@ class ProgressView(BaseView):
 
     def show_complete(self):
         w = Padding.fixed_20(
-            confirm_btn(label="Reboot Now", on_press=self.reboot))
+            ok_btn(label="Reboot Now", on_press=self.reboot))
 
         z = Padding.fixed_20(
             cancel_btn(label="Quit Installer", on_press=self.quit))

--- a/subiquitycore/ui/buttons.py
+++ b/subiquitycore/ui/buttons.py
@@ -1,4 +1,4 @@
-# Copyright 2015 Canonical, Ltd.
+# Copyright 2017 Canonical, Ltd.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -13,44 +13,34 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from functools import partial
+from urwid import AttrMap, Button, Text
 
-from urwid import AttrWrap, Button, connect_signal, Text
+def _stylized_button(left, right, stocklabel, style):
+    class Btn(Button):
+        button_left = Text(left)
+        button_right = Text(right)
 
-class PlainButton(Button):
-    button_left = Text("[")
-    button_right = Text("]")
+    class StyleAttrMap(AttrMap):
+        def __init__(self, *args, **kwargs):
+            label = kwargs.pop('label', stocklabel)
+            btn = Btn(label, *args, **kwargs)
+            super().__init__(btn, style + '_button', style + '_button focus')
+    return StyleAttrMap
 
-
-class MenuSelectButton(Button):
-    button_left = Text("")
-    button_right = Text(">")
-
-
-def plain_btn(label, color, on_press=None, user_arg=None):
-    button = PlainButton(label=label)
-    if on_press is not None:
-        connect_signal(button, 'click', on_press, user_arg)
-    return AttrWrap(button, color, color + ' focus')
-
-
-start_btn = partial(plain_btn, label="Start", color="save_button")
-save_btn = partial(plain_btn, label="Save", color="save_button")
-finish_btn = partial(plain_btn, label="Finish", color="save_button")
-ok_btn = partial(plain_btn, label="OK", color="save_button")
-confirm_btn = partial(plain_btn, label="Confirm", color="save_button")
-done_btn = partial(plain_btn, label="Done", color="save_button")
-continue_btn = partial(plain_btn, label="Continue", color="save_button")
-
-reset_btn = partial(plain_btn, label="Reset", color="reset_button")
-
-cancel_btn = partial(plain_btn, label="Cancel", color="cancel_button")
-back_btn = partial(plain_btn, label="Back", color="cancel_button")
-
-danger_btn = partial(plain_btn, color="danger_button")
+def stylized_button(stocklabel, style):
+    return _stylized_button('[', ']', stocklabel, style)
 
 def menu_btn(label, on_press=None, user_arg=None):
-    button = MenuSelectButton(label=label)
-    if on_press is not None:
-        connect_signal(button, 'click', on_press, user_arg)
-    return AttrWrap(button, 'menu_button', 'menu_button focus')
+    MenuBtn=_stylized_button('', '>', label, 'menu')
+    return MenuBtn(on_press=on_press, user_data=user_arg)
+
+ok_btn = stylized_button("OK", "save")
+done_btn = stylized_button("Done", "save")
+
+reset_btn = stylized_button("Reset", "reset")
+
+cancel_btn = stylized_button("Cancel", "cancel")
+close_btn = stylized_button("Close", "cancel")
+
+danger_btn = stylized_button("Continue", "danger")
+delete_btn = stylized_button("Delete", "danger")

--- a/subiquitycore/ui/dummy.py
+++ b/subiquitycore/ui/dummy.py
@@ -35,8 +35,7 @@ class DummyView(WidgetWrap):
 
     def _build_buttons(self):
         buttons = [
-            Color.button(cancel_btn(label="Back to Start",
-                                    on_press=self.cancel)),
+            cancel_btn(label="Back to Start", on_press=self.cancel),
         ]
         return Pile(buttons)
 

--- a/subiquitycore/ui/error.py
+++ b/subiquitycore/ui/error.py
@@ -40,8 +40,7 @@ class ErrorView(WidgetWrap):
 
     def _build_buttons(self):
         buttons = [
-            Color.button(cancel_btn(label="Back to Start",
-                                    on_press=self.cancel)),
+            cancel_btn(label="Back to Start", on_press=self.cancel),
         ]
         return Pile(buttons)
 

--- a/subiquitycore/ui/interactive.py
+++ b/subiquitycore/ui/interactive.py
@@ -30,7 +30,7 @@ from urwid import (
     WidgetWrap,
     )
 
-from subiquitycore.ui.buttons import PlainButton
+from subiquitycore.ui.buttons import close_btn
 from subiquitycore.ui.container import Pile
 from subiquitycore.ui.selector import Selector
 from subiquitycore.ui.utils import Color, Padding
@@ -118,7 +118,7 @@ class YesNo(Selector):
 class _HelpDisplay(WidgetWrap):
     def __init__(self, closer, help_text):
         self._closer = closer
-        button = Color.button(PlainButton(label="Close", on_press=lambda btn:self._closer()))
+        button = close_btn(on_press=lambda btn:self._closer())
         super().__init__(LineBox(Pile([Text(help_text), Padding.fixed_10(button)]), title="Help"))
 
 

--- a/subiquitycore/ui/views/login.py
+++ b/subiquitycore/ui/views/login.py
@@ -20,7 +20,7 @@ Login provides user with language selection
 """
 import logging
 from urwid import Text
-from subiquitycore.ui.buttons import finish_btn
+from subiquitycore.ui.buttons import done_btn
 from subiquitycore.ui.container import Pile, ListBox
 from subiquitycore.ui.utils import Padding, Color
 from subiquitycore.view import BaseView
@@ -46,7 +46,7 @@ class LoginView(BaseView):
 
     def _build_buttons(self):
         self.buttons = [
-            Color.button(finish_btn(on_press=self.done)),
+            done_btn(on_press=self.done),
         ]
         return Pile(self.buttons)
 

--- a/subiquitycore/ui/views/network_configure_interface.py
+++ b/subiquitycore/ui/views/network_configure_interface.py
@@ -62,16 +62,14 @@ class NetworkConfigureInterfaceView(BaseView):
     def _build_ipv4_method_buttons(self):
         button_padding = 70
 
-        buttons = []
-        btn = menu_btn(label="Use a static IPv4 configuration",
-                       on_press=self.show_ipv4_configuration)
-        buttons.append(Color.menu_button(btn))
-        btn = menu_btn(label="Use DHCPv4 on this interface",
-                       on_press=self.enable_dhcp4)
-        buttons.append(Color.menu_button(btn))
-        btn = menu_btn(label="Do not use",
-                       on_press=self.clear_ipv4)
-        buttons.append(Color.menu_button(btn))
+        buttons = [
+            menu_btn(label="Use a static IPv4 configuration",
+                    on_press=self.show_ipv4_configuration),
+            menu_btn(label="Use DHCPv4 on this interface",
+                    on_press=self.enable_dhcp4),
+            menu_btn(label="Do not use",
+                    on_press=self.clear_ipv4),
+        ]
 
         padding = getattr(Padding, 'left_{}'.format(button_padding))
         buttons = [ padding(button) for button in buttons ]
@@ -81,16 +79,14 @@ class NetworkConfigureInterfaceView(BaseView):
     def _build_ipv6_method_buttons(self):
         button_padding = 70
 
-        buttons = []
-        btn = menu_btn(label="Use a static IPv6 configuration",
-                       on_press=self.show_ipv6_configuration)
-        buttons.append(Color.menu_button(btn))
-        btn = menu_btn(label="Use DHCPv6 on this interface",
-                       on_press=self.enable_dhcp6)
-        buttons.append(Color.menu_button(btn))
-        btn = menu_btn(label="Do not use",
-                       on_press=self.clear_ipv6)
-        buttons.append(Color.menu_button(btn))
+        buttons = [
+            menu_btn(label="Use a static IPv6 configuration",
+                    on_press=self.show_ipv6_configuration),
+            menu_btn(label="Use DHCPv6 on this interface",
+                    on_press=self.enable_dhcp6),
+            menu_btn(label="Do not use",
+                    on_press=self.clear_ipv6),
+        ]
 
         padding = getattr(Padding, 'left_{}'.format(button_padding))
         buttons = [ padding(button) for button in buttons ]
@@ -100,13 +96,11 @@ class NetworkConfigureInterfaceView(BaseView):
 
     def _build_wifi_config(self):
         btn = menu_btn(label="Configure WIFI settings", on_press=self.show_wlan_configuration)
-        return [Padding.left_70(Color.menu_button(btn))]
+        return [Padding.left_70(btn)]
 
     def _build_buttons(self):
-        done = done_btn(on_press=self.done)
-
         buttons = [
-            Color.button(done),
+            done_btn(on_press=self.done)
         ]
         return Pile(buttons)
 

--- a/subiquitycore/ui/views/network_configure_wlan_interface.py
+++ b/subiquitycore/ui/views/network_configure_wlan_interface.py
@@ -20,10 +20,7 @@ class NetworkList(WidgetWrap):
     def __init__(self, parent, ssids):
         self.parent = parent
         button = cancel_btn(on_press=self.do_cancel)
-        ssid_list = [
-            Color.menu_button(
-                Button(label=ssid, on_press=self.do_network))
-            for ssid in ssids]
+        ssid_list = [menu_btn(label=ssid, on_press=self.do_network) for ssid in ssids]
         p = Pile([BoxAdapter(ListBox(ssid_list), height=10), Padding.fixed_10(button)])
         box = LineBox(p, title="Select a network")
         super().__init__(box)
@@ -95,8 +92,7 @@ class NetworkConfigureWLANView(BaseView):
 
     def _build_iface_inputs(self):
         if len(self.dev.actual_ssids) > 0:
-            networks_btn = Color.menu_button(
-                menu_btn("Choose a visible network", on_press=self.show_ssid_list))
+            networks_btn = menu_btn("Choose a visible network", on_press=self.show_ssid_list)
         else:
             networks_btn = Color.info_minor(Columns(
                 [
@@ -106,8 +102,7 @@ class NetworkConfigureWLANView(BaseView):
                 ], dividechars=1))
 
         if not self.dev.scan_state:
-            scan_btn = Color.menu_button(
-                menu_btn("Scan for networks", on_press=self.start_scan))
+            scan_btn = menu_btn("Scan for networks", on_press=self.start_scan)
         else:
             scan_btn = Color.info_minor(Columns(
                 [

--- a/subiquitycore/ui/views/network_default_route.py
+++ b/subiquitycore/ui/views/network_default_route.py
@@ -78,30 +78,26 @@ class NetworkSetDefaultRouteView(BaseView):
         log.debug('gateway providers: {}'.format(providers))
         items = []
         items.append(Padding.center_79(
-            Color.menu_button(menu_btn(label="None", on_press=self.done))))
+            menu_btn(label="None", on_press=self.done)))
         for (gw, ifaces) in providers.items():
             if gw is None:
                 continue
             items.append(Padding.center_79(
-                Color.menu_button(menu_btn(
+                menu_btn(
                     label="{gw} ({ifaces})".format(
                         gw=gw,
                         ifaces=(",".join(ifaces))),
-                    on_press=self.done))))
+                    on_press=self.done)))
 
         items.append(Padding.center_79(
-            Color.menu_button(
-                menu_btn(label="Specify the default route manually",
-                         on_press=self.show_edit_default_route))))
+            menu_btn(label="Specify the default route manually",
+                    on_press=self.show_edit_default_route)))
         return items
 
     def _build_buttons(self):
-        cancel = cancel_btn(on_press=self.cancel)
-        done = done_btn(on_press=self.done)
-
         buttons = [
-            Color.button(done),
-            Color.button(cancel)
+            done_btn(on_press=self.done),
+            cancel_btn(on_press=self.cancel),
         ]
         return Pile(buttons)
 


### PR DESCRIPTION
Best read from scratch....

`ok_btn=` et.al. are now proper Classes. I guess they should be renamed into `OkButton` or some such.

They are almost a perfect replacement for `Button()`. Current difference is that they only accept a keyword argument `label=` instead of accepting it as a positional one as well. And even that can be fixed if need be.

Minimize amount of buttons used.

Unwrap the not needed `Color.some_btn(some_btn` pattern.