### PR TITLE
store curtin's output in journald

### DIFF
--- a/subiquity/ui/views/installprogress.py
+++ b/subiquity/ui/views/installprogress.py
@@ -49,9 +49,8 @@ class ProgressView(BaseView):
         self.pile = Pile(body)
         super().__init__(self.pile)
 
-    def add_log_tail(self, text):
-        for line in text.splitlines():
-            self.listwalker.append(Text(line))
+    def add_log_tail(self, line):
+        self.listwalker.append(Text(line))
         self.listwalker.set_focus(len(self.listwalker) - 1)
 
     def clear_log_tail(self):


### PR DESCRIPTION
This changes to put curtin's output into journald and use a
systemd.journal.Reader instance to read it. It's a bit simpler than the current
code, which is nice. It also allows us to play with displaying kernel or other
messages intermixed with the curtin output, which might be interesting to
explore.

This does mean that the curtin output is not on disk anywhere, but as it's
pretty trivially recoverable with `journalctl -t curtin_output -o cat` I think
that's OK.