### PR TITLE
add a trivial oneshot service we can order the subiquity.service in t…

### DIFF
--- a/bin/started
+++ b/bin/started
@@ -1,0 +1,2 @@
+#!/bin/sh
+true

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -13,6 +13,9 @@ apps:
     command: usr/bin/console-conf
   probert:
     command: bin/probert
+  started:
+    command: usr/bin/started
+    daemon: oneshot
 
 parts:
   subiquity:
@@ -44,6 +47,7 @@ parts:
       'bin/subiquity-tui': usr/bin/subiquity
       'bin/subiquity-loadkeys': usr/bin/subiquity-loadkeys
       'bin/curtin-journald-forwarder': usr/bin/curtin-journald-forwarder
+      'bin/started': usr/bin/started
     prime:
       - usr/bin
   probert:


### PR DESCRIPTION
…he install after to ensure the mounts are set up

This is part of my workaround/fix for https://bugs.launchpad.net/subiquity/+bug/1721414