### PR TITLE
Vorlon/fix up tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ yaml
 testtools
 mock
 attr
+systemd

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,7 @@ nose-cov
 nose
 flake8
 python3-parted
+yaml
+testtools
+mock
+attr

--- a/subiquitycore/ui/form.py
+++ b/subiquitycore/ui/form.py
@@ -26,6 +26,7 @@ from urwid import (
     WidgetWrap,
     )
 
+from subiquitycore.i18n import *
 from subiquitycore.ui.buttons import cancel_btn, done_btn
 from subiquitycore.ui.container import Columns, Pile
 from subiquitycore.ui.interactive import (


### PR DESCRIPTION
Partial fixes for failing tests.

Running 'nosetests3' fails in the subiquity tree with a number of failures due to missing modules, undefined functions, etc.  This is a partial fix for these problems.

The test suite still fails with errors around the removed 'blockdev' module.  I'm not sure if those tests should be ported to something else, or if they should be dropped.