### PR TITLE
add a way to run console-conf or subiquity with a subset of the screens

### DIFF
--- a/bin/console-conf-tui
+++ b/bin/console-conf-tui
@@ -52,6 +52,7 @@ def parse_options(argv):
     parser.add_argument('--machine-config', metavar='CONFIG',
                         dest='machine_config',
                         help="Don't Probe. Use probe data file")
+    parser.add_argument('--screens', action='append', dest='screens', default=[])
     return parser.parse_args(argv)
 
 

--- a/bin/subiquity-tui
+++ b/bin/subiquity-tui
@@ -63,6 +63,7 @@ def parse_options(argv):
     parser.add_argument('--uefi', action='store_true',
                         dest='uefi',
                         help='run in uefi support mode')
+    parser.add_argument('--screens', action='append', dest='screens', default=[])
     return parser.parse_args(argv)
 
 

--- a/subiquitycore/core.py
+++ b/subiquitycore/core.py
@@ -98,6 +98,8 @@ class Application:
             "loop": None,
             "pool": futures.ThreadPoolExecutor(1),
         }
+        if opts.screens:
+            self.controllers = [c for c in self.controllers if c in opts.screens]
         ui.progress_completion = len(self.controllers)
         self.common['controllers'] = dict.fromkeys(self.controllers)
         self.controller_index = -1

--- a/subiquitycore/ui/frame.py
+++ b/subiquitycore/ui/frame.py
@@ -29,7 +29,7 @@ class SubiquityUI(WidgetWrap):
     def __init__(self):
         self.header = Header()
         self.body = Body()
-        self.footer = Footer("", 0, 0)
+        self.footer = Footer("", 0, 1)
         self.frame = Frame(self.body, header=self.header, footer=self.footer)
         self.progress_current = 0
         self.progress_completion = 0


### PR DESCRIPTION
You can break things this way but it's also super helpful when hacking on the identity screen's validation to be able to jump straight there...

Mostly PRing this for visibility but reviews welcome too :)