### PR TITLE
reduce default padding, tighten scrollable areas

### DIFF
--- a/subiquity/ui/views/filesystem/disk_partition.py
+++ b/subiquity/ui/views/filesystem/disk_partition.py
@@ -18,7 +18,7 @@ from urwid import BoxAdapter, Text
 
 from subiquitycore.ui.lists import SimpleList
 from subiquitycore.ui.buttons import done_btn, cancel_btn, menu_btn
-from subiquitycore.ui.container import Columns, ListBox
+from subiquitycore.ui.container import Columns, ListBox, Pile
 from subiquitycore.ui.utils import button_pile, Padding
 from subiquitycore.view import BaseView
 
@@ -34,14 +34,20 @@ class DiskPartitionView(BaseView):
         self.controller = controller
         self.disk = disk
 
-        self.body = [
-            Padding.center_79(self._build_model_inputs()),
-            Padding.line_break(""),
-            Padding.center_79(self.show_disk_info_w()),
-            Padding.line_break(""),
-            self._build_buttons(),
-        ]
-        super().__init__(ListBox(self.body))
+        self.body = Pile([
+            ('pack', Text("")),
+            Padding.center_79(ListBox(
+                self._build_model_inputs() + [
+                Text(""),
+                self.show_disk_info_w(),
+                ])),
+            ('pack', Pile([
+                ('pack', Text("")),
+                self._build_buttons(),
+                ('pack', Text("")),
+                ])),
+            ])
+        super().__init__(self.body)
 
     def _build_buttons(self):
         cancel = cancel_btn(on_press=self.cancel)
@@ -102,8 +108,7 @@ class DiskPartitionView(BaseView):
             partitioned_disks.append(
                 menu_btn(label=text, on_press=self.format_entire))
 
-        return BoxAdapter(SimpleList(partitioned_disks),
-                          height=len(partitioned_disks))
+        return partitioned_disks
 
     def _click_part(self, sender, part):
         self.controller.edit_partition(self.disk, part)

--- a/subiquity/ui/views/filesystem/filesystem.py
+++ b/subiquity/ui/views/filesystem/filesystem.py
@@ -101,10 +101,11 @@ class FilesystemView(BaseView):
                 Text(""),
                 ])
         self.frame = Pile([
+            ('pack', Text("")),
             self.lb,
             ('pack', self.footer)])
         if self.model.can_install():
-            self.frame.focus_position = 1
+            self.frame.focus_position = 2
         super().__init__(self.frame)
         log.debug('FileSystemView init complete()')
 

--- a/subiquity/ui/views/filesystem/guided.py
+++ b/subiquity/ui/views/filesystem/guided.py
@@ -43,6 +43,7 @@ class GuidedFilesystemView(BaseView):
         manual = ok_btn(label=_("Manual"), on_press=self.manual)
         back = back_btn(on_press=self.cancel)
         lb = ListBox([
+            Padding.center_70(Text("")),
             Padding.center_70(Text(text)),
             Padding.center_70(Text("")),
             button_pile([guided, manual, back]),
@@ -72,6 +73,7 @@ class GuidedDiskSelectionView(BaseView):
                 on_press=self.choose_disk, user_arg=disk)
             disks.append(disk_btn)
         lb = ListBox([
+            Padding.center_70(Text("")),
             Padding.center_70(Text(_("Choose the disk to install to:"))),
             Padding.center_70(Text("")),
             Padding.center_70(Pile(disks)),

--- a/subiquity/ui/views/filesystem/partition.py
+++ b/subiquity/ui/views/filesystem/partition.py
@@ -23,15 +23,14 @@ import logging
 from urwid import connect_signal, Text, WidgetDisable
 
 from subiquitycore.ui.buttons import delete_btn
-from subiquitycore.ui.container import ListBox
+from subiquitycore.ui.container import ListBox, Pile
 from subiquitycore.ui.form import (
     Form,
     FormField,
     IntegerField,
-    StringField,
     )
 from subiquitycore.ui.interactive import Selector, StringEditor
-from subiquitycore.ui.utils import Padding
+from subiquitycore.ui.utils import Color, Padding, button_pile
 from subiquitycore.view import BaseView
 
 from subiquity.models.filesystem import (
@@ -150,13 +149,19 @@ class PartitionFormatView(BaseView):
         connect_signal(self.form, 'cancel', self.cancel)
 
         partition_box = Padding.center_50(ListBox(self.make_body()))
-        super().__init__(partition_box)
+        super().__init__(Pile([
+            ('pack', Text("")),
+            partition_box,
+            ('pack', Pile([
+                ('pack', Text("")),
+                self.form.buttons,
+                ('pack', Text("")),
+                ])),
+            ]))
 
     def make_body(self):
         return [
             self.form.as_rows(self),
-            Padding.line_break(""),
-            self.form.buttons,
         ]
 
     def cancel(self, button=None):
@@ -195,10 +200,10 @@ class PartitionView(PartitionFormatView):
             btn = delete_btn(on_press=self.delete)
             if self.partition.flag == "boot":
                 btn = WidgetDisable(Color.info_minor(btn.original_widget))
-            body[-2:-2] = [
+            body.extend([
                 Text(""),
-                Padding.fixed_10(btn),
-                ]
+                button_pile([btn]),
+                ])
             pass
         return body
 

--- a/subiquity/ui/views/identity.py
+++ b/subiquity/ui/views/identity.py
@@ -30,6 +30,7 @@ from subiquitycore.ui.interactive import (
 from subiquitycore.ui.container import (
     Columns,
     ListBox,
+    Pile,
     )
 from subiquitycore.ui.form import (
     simple_field,
@@ -202,12 +203,16 @@ class IdentityView(BaseView):
 
         self.ssh_import_confirmed = True
 
-        body = [
-            Padding.center_90(self.form.as_rows(self)),
-            Padding.line_break(""),
-            button_pile([self.form.done_btn]),
-        ]
-        super().__init__(ListBox(body))
+        body = Pile([
+            ('pack', Text("")),
+            Padding.center_90(ListBox([self.form.as_rows(self)])),
+            ('pack', Pile([
+                ('pack', Text("")),
+                button_pile([self.form.done_btn]),
+                ('pack', Text("")),
+                ])),
+            ])
+        super().__init__(body)
 
     def _check_password(self, sender, new_text):
         password = self.form.password.value

--- a/subiquity/ui/views/installprogress.py
+++ b/subiquity/ui/views/installprogress.py
@@ -69,10 +69,13 @@ class ProgressView(BaseView):
                 cancel_btn(label=_("Exit To Shell"), on_press=self.quit))
         buttons = button_pile(buttons)
 
-        new_focus = len(self.pile.contents)
-        self.pile.contents.append((buttons, self.pile.options('pack')))
-        self.pile.contents.append((Text(""), self.pile.options('pack')))
-        self.pile.focus_position = new_focus
+        new_pile = Pile([
+                ('pack', Text("")),
+                buttons,
+                ('pack', Text("")),
+            ])
+        self.pile.contents[-1] = (new_pile, self.pile.options('pack'))
+        self.pile.focus_position = len(self.pile.contents) - 1
 
     def reboot(self, btn):
         self.controller.reboot()

--- a/subiquity/ui/views/welcome.py
+++ b/subiquity/ui/views/welcome.py
@@ -19,10 +19,10 @@ Welcome provides user with language selection
 
 """
 import logging
-from urwid import BoxAdapter, Text
+from urwid import Text
 from subiquitycore.ui.lists import SimpleList
 from subiquitycore.ui.buttons import menu_btn
-from subiquitycore.ui.container import ListBox
+from subiquitycore.ui.container import Pile
 from subiquitycore.ui.utils import Padding
 from subiquitycore.view import BaseView
 
@@ -34,15 +34,18 @@ class WelcomeView(BaseView):
     def __init__(self, model, controller):
         self.model = model
         self.controller = controller
-        super().__init__(ListBox([
-            Padding.center_50(self._build_model_inputs())]))
+        super().__init__(Pile([
+            ('pack', Text("")),
+            Padding.center_50(self._build_model_inputs()),
+            ('pack', Text("")),
+            ]))
 
     def _build_model_inputs(self):
         sl = []
         for code, label, native in self.model.get_languages():
             sl.append(menu_btn(label=native, on_press=self.confirm, user_arg=code))
 
-        return BoxAdapter(SimpleList(sl), height=len(sl))
+        return SimpleList(sl)
 
     def confirm(self, sender, code):
         self.model.switch_language(code)

--- a/subiquitycore/ui/anchors.py
+++ b/subiquitycore/ui/anchors.py
@@ -33,17 +33,13 @@ class Header(WidgetWrap):
             widgets.append(
                 Padding.center_79(Text(title)))
             widgets.append(Text(""))
-        w = Color.frame_header(Pile(widgets))
+        widgets = [Color.frame_header(Pile(widgets))]
         if excerpt is not None:
-            widgets = [
+            widgets.extend([
                 Text(""),
                 Padding.center_79(Text(excerpt)),
-                Text(""),
-            ]
-        else:
-            widgets = [Text("")]
-        w = Pile([w] + widgets)
-        super().__init__(w)
+            ])
+        super().__init__(Pile(widgets))
 
 
 class StepsProgressBar(ProgressBar):

--- a/subiquitycore/ui/views/network.py
+++ b/subiquitycore/ui/views/network.py
@@ -127,9 +127,10 @@ class NetworkView(BaseView):
                 ])
         self.error_showing = False
         self.frame = Pile([
+            ('pack', Text("")),
             self.lb,
             ('pack', self.footer)])
-        self.frame.focus_position = 1
+        self.frame.focus_position = 2
         super().__init__(self.frame)
 
     def _build_buttons(self):

--- a/subiquitycore/ui/views/network_configure_interface.py
+++ b/subiquitycore/ui/views/network_configure_interface.py
@@ -13,12 +13,15 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import logging
+
+from urwid import Text
+
 from subiquitycore.view import BaseView
 from subiquitycore.ui.buttons import done_btn, menu_btn
 from subiquitycore.ui.container import ListBox, Pile
 from subiquitycore.ui.utils import button_pile, Padding
 from subiquitycore.ui.views.network import _build_gateway_ip_info_for_version, _build_wifi_info
-import logging
 
 log = logging.getLogger('subiquitycore.network.network_configure_interface')
 
@@ -29,7 +32,15 @@ class NetworkConfigureInterfaceView(BaseView):
         self.controller = controller
         self.dev = self.model.get_netdev_by_name(name)
         self._build_widgets()
-        super().__init__(ListBox(self._build_body()))
+        super().__init__(Pile([
+            ('pack', Text("")),
+            ListBox(self._build_body()),
+            ('pack', Pile([
+                ('pack', Text("")),
+                self._build_buttons(),
+                ('pack', Text("")),
+                ])),
+            ]))
 
     def _build_widgets(self):
         self.ipv4_info = Pile(_build_gateway_ip_info_for_version(self.dev, 4))
@@ -57,7 +68,6 @@ class NetworkConfigureInterfaceView(BaseView):
             Padding.center_79(self.ipv6_info),
             Padding.center_79(self.ipv6_method),
             Padding.line_break(""),
-            self._build_buttons(),
         ])
         return body
 

--- a/subiquitycore/ui/views/network_configure_manual_interface.py
+++ b/subiquitycore/ui/views/network_configure_manual_interface.py
@@ -20,8 +20,8 @@ from urwid import connect_signal, Text
 
 from subiquitycore.view import BaseView
 from subiquitycore.ui.buttons import menu_btn
-from subiquitycore.ui.container import ListBox
-from subiquitycore.ui.utils import button_pile, Padding
+from subiquitycore.ui.container import ListBox, Pile
+from subiquitycore.ui.utils import Padding
 from subiquitycore.ui.interactive import RestrictedEditor, StringEditor
 from subiquitycore.ui.form import Form, FormField, StringField
 
@@ -133,14 +133,18 @@ class BaseNetworkConfigureManualView(BaseView):
         self.form.searchdomains.value = ', '.join(self.dev.configured_searchdomains)
         self.error = Text("", align='center')
         #self.set_as_default_gw_button = Pile(self._build_set_as_default_gw_button())
-        body = [
-            Padding.center_79(self.form.as_rows(self)),
+        body = Pile([
+            ('pack', Text("")),
+            Padding.center_79(ListBox([self.form.as_rows(self)])),
             #Padding.line_break(""),
             #Padding.center_79(self.set_as_default_gw_button),
-            Padding.line_break(""),
-            self.form.buttons,
-        ]
-        super().__init__(ListBox(body))
+            ('pack', Pile([
+                ('pack', Text("")),
+                self.form.buttons,
+                ('pack', Text("")),
+                ])),
+            ])
+        super().__init__(body)
 
     def refresh_model_inputs(self):
         try:

--- a/subiquitycore/ui/views/network_configure_wlan_interface.py
+++ b/subiquitycore/ui/views/network_configure_wlan_interface.py
@@ -71,15 +71,18 @@ class NetworkConfigureWLANView(BaseView):
         self.inputs = Pile(self._build_iface_inputs())
 
         self.error = Text("")
-        self.body = [
-            Padding.center_79(self.inputs),
-            Padding.line_break(""),
-            Padding.center_79(Color.info_error(self.error)),
-            Padding.line_break(""),
-            self.form.buttons,
-        ]
+        self.body = Pile([
+            ('pack', Text("")),
+            ListBox([Padding.center_79(self.inputs)]),
+            ('pack', Pile([
+                ('pack', Text("")),
+                Padding.center_79(Color.info_error(self.error)),
+                self.form.buttons,
+                ('pack', Text("")),
+                ])),
+            ])
         self.orig_w = None
-        super().__init__(ListBox(self.body))
+        super().__init__(self.body)
 
     def show_ssid_list(self, sender):
         self.show_overlay(NetworkList(self, self.dev.actual_ssids))


### PR DESCRIPTION
For a couple of branches I have brewing I want (a) to be able to fill the whole area between the header and footer (b) to add scrollbars, which look very strange if all of the just-mentioned area is what is in the list box.

Fixing the former is easy, just remove the default padding but then of course all existing views need the padding re-adding. While I was doing that I switched most views to a standard layout of

 1 line of padding
 a stretchy listbox containing the bulk of the content
 1 line of padding
 the done/save/cancel/etc buttons
 1 line of padding
