### PR TITLE
Add partitions configuration in answers.yaml

### DIFF
--- a/examples/answers-partitions.yaml
+++ b/examples/answers-partitions.yaml
@@ -10,17 +10,13 @@ Filesystem:
               filesystem: fat32
               filesystem-label: boot
               mount: /boot/efi
-            - size: 
-              flag: 
-              filesystem: ext4
+            - filesystem: ext4
               filesystem-label: rootfs
               mount: /
       - /dev/sdh:
             - size: 100G
-              flag: 
               filesystem: ext4
               filesystem-label:
-              mount: /home
             - size: 0
               flag:
               filesystem: ext4

--- a/examples/answers-partitions.yaml
+++ b/examples/answers-partitions.yaml
@@ -34,6 +34,7 @@ Filesystem:
       #        filesystem: ext4
       #        filesystem-label:
       #        mount: /tmp
+      # Fail case
       #- /dev/0ab-3:
       #      - size: 100G
       #        flag:

--- a/examples/answers-partitions.yaml
+++ b/examples/answers-partitions.yaml
@@ -1,0 +1,59 @@
+Welcome:
+  lang: en_US
+Network:
+  accept-default: yes
+Filesystem:
+    #guided: yes
+    #guided-index: 0
+  manual: yes
+  volumes:
+      - disk-0:
+            - size: 768M
+              flag: boot
+              filesystem: fat32
+              filesystem-label: boot
+              mount: /boot/efi
+            - size: 
+              flag: 
+              filesystem: ext4
+              filesystem-label: rootfs
+              mount: /
+      - /dev/sdh:
+            - size: 100G
+              flag: 
+              filesystem: ext4
+              filesystem-label:
+              mount: /home
+            - size: 0
+              flag:
+              filesystem: ext4
+              filesystem-label:
+              mount: /var/
+      - /dev/dm-0:
+            - size: 100G
+              flag:
+              filesystem: ext4
+              filesystem-label:
+              mount: /tmp
+      - /dev/nvme0n1:
+            - size: 100G
+              flag:
+              filesystem: ext4
+              filesystem-label:
+              mount: /tmp
+      - /dev/0ab-3:
+            - size: 100G
+              flag:
+              filesystem: ext4
+              filesystem-label:
+              mount: /tmp
+Identity:
+  realname: Ubuntu
+  username: ubuntu
+  hostname: ubuntu-server
+  # ubuntu
+  password: '$6$wdAcoXrU039hKYPd$508Qvbe7ObUnxoj15DRCkzC3qO7edjH0VV7BPNRDYK4QR8ofJaEEF2heacn0QgD.f8pO8SNp83XNdWG6tocBM1'
+InstallProgress:
+  reboot: yes
+
+

--- a/examples/answers-partitions.yaml
+++ b/examples/answers-partitions.yaml
@@ -3,9 +3,6 @@ Welcome:
 Network:
   accept-default: yes
 Filesystem:
-    #guided: yes
-    #guided-index: 0
-  manual: yes
   volumes:
       - disk-0:
             - size: 768M
@@ -29,24 +26,24 @@ Filesystem:
               filesystem: ext4
               filesystem-label:
               mount: /var/
-      - /dev/dm-0:
-            - size: 100G
-              flag:
-              filesystem: ext4
-              filesystem-label:
-              mount: /tmp
-      - /dev/nvme0n1:
-            - size: 100G
-              flag:
-              filesystem: ext4
-              filesystem-label:
-              mount: /tmp
-      - /dev/0ab-3:
-            - size: 100G
-              flag:
-              filesystem: ext4
-              filesystem-label:
-              mount: /tmp
+      #- /dev/dm-0:
+      #      - size: 100G
+      #        flag:
+      #        filesystem: ext4
+      #        filesystem-label:
+      #        mount: /tmp
+      #- /dev/nvme0n1:
+      #      - size: 100G
+      #        flag:
+      #        filesystem: ext4
+      #        filesystem-label:
+      #        mount: /tmp
+      #- /dev/0ab-3:
+      #      - size: 100G
+      #        flag:
+      #        filesystem: ext4
+      #        filesystem-label:
+      #        mount: /tmp
 Identity:
   realname: Ubuntu
   username: ubuntu

--- a/subiquity/controllers/filesystem.py
+++ b/subiquity/controllers/filesystem.py
@@ -73,11 +73,9 @@ class FilesystemController(BaseController):
         if size is not None and size > disk.free:
             log.debug('Partition size({}) greater than free size({})'.format(size, disk.free))
             return False
-
         if flag is not None and flag != 'boot' and flag != 'bios_grub':
             log.debug('Not supported flag:{}'.format(flag))
             return False
-
         if fslabel is not None:
             if fstype == 'ext4' and len(fslabel) > 16:
                 return False
@@ -89,14 +87,12 @@ class FilesystemController(BaseController):
                 return False
             elif fstype == 'xfs' and len(fslabel) > 12:
                 return False
-
         if fstype is None and mount is not None:
             log.debug('Mounted partition({}) but without filesystem'.format(mount))
             return False
         elif fstype == 'swap' and mount is not None:
             log.debug('swap partition is not allow to be mounted')
             return False
-
         if mount is None:
             return True
         else:
@@ -135,11 +131,9 @@ class FilesystemController(BaseController):
                     disk = self.model.all_disks()[int(index)]
                 elif r_devpath.match(d) is not None:
                     disk = self.model.get_disk(d)
-
                 if disk is None:
                     self._force_manual(reason='Unknown volume: {}'.format(d))
                     return
-
                 partnum = 0
                 for p in parts:
                     # if size leaves as empty, using remain space as partition size
@@ -147,33 +141,27 @@ class FilesystemController(BaseController):
                         size = dehumanize_size(str(disk.free))
                     else:
                         size = dehumanize_size(str(p['size']))
-
                     if 'flag' in p:
                         flag = p['flag']
                     else:
                         flag = None
-
                     try:
                         fstype = self.model.fs_by_name[p['filesystem']]
                     except KeyError:
                         fstype = None
-
                     if 'mount' in p:
                         mount = p['mount']
                     else:
                         mount = None
-
                     if 'filesystem-label' in p:
                         fslabel = p['filesystem-label']
                     else:
                         fslabel = None
-
                     if not self._validate_volumes_input(disk, size, flag, fstype, fslabel, mount):
                         self._force_manual(reason=
                                 'Invalid partition attributes: size:{}, flag:{}, fstype: {}, fslabel: {}, mount:{}'
                                 .format(size, flag, fstype, fslabel, mount))
                         return
-
                     partnum += 1
                     part = self.model.add_partition(disk=disk, partnum=partnum, size=size, flag=flag)
                     spec = {

--- a/subiquity/controllers/filesystem.py
+++ b/subiquity/controllers/filesystem.py
@@ -125,19 +125,25 @@ class FilesystemController(BaseController):
                 partnum = 0
                 for p in parts:
                     # if size leaves as empty, using remain space as partition size
-                    if None is p['size']:
+                    if 'size' not in p or None is p['size']:
                         size = dehumanize_size(str(disk.free))
                     else:
                         size = dehumanize_size(str(p['size']))
 
-                    flag = p['flag']
+                    if 'flag' in p:
+                        flag = p['flag']
+                    else:
+                        flag = None
 
                     try:
                         fstype = self.model.fs_by_name[p['filesystem']]
                     except KeyError:
                         fstype = None
 
-                    mount = p['mount']
+                    if 'mount' in p:
+                        mount = p['mount']
+                    else:
+                        mount = None
 
                     if not self._validate_volumes_input(disk, size, flag, fstype, mount):
                         self._force_manual(reason='Invalid partition attributes: size:{}, flag:{}, mount:{}'.format(size, flag, fstype, mount))

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -354,7 +354,7 @@ class FilesystemModel(object):
         self._partitions.append(p)
         return p
 
-    def add_filesystem(self, volume, fstype):
+    def add_filesystem(self, volume, fstype, fslabel=""):
         log.debug("adding %s to %s", fstype, volume)
         if not volume.available:
             if not (isinstance(volume, Partition) and volume.flag == 'bios_grub' and fstype == 'fat32'):
@@ -363,7 +363,7 @@ class FilesystemModel(object):
             self._use_disk(volume)
         if volume._fs is not None:
             raise Exception("%s is already formatted")
-        volume._fs = fs = Filesystem(volume=volume, fstype=fstype)
+        volume._fs = fs = Filesystem(volume=volume, fstype=fstype, label=fslabel)
         self._filesystems.append(fs)
         return fs
 


### PR DESCRIPTION
Currently, the answers.yaml supports auto installation, but the partitioning function only supports guided mode. Here to add a "volumes" in answers.yaml for pre-partitioning configs.

The "volumes" can use either disk number(disk-[0-9]) or partition path (/dev/<device node of disk>) to identify the disk.
Each disk can be configured by the following attributes:
- size
  The partition size with human readable units : 'B', 'K', 'M', 'G', 'T', 'P'
  Leave size as empty, it would use disk free space as partition size
- flag
  The flag attribute is optional. It can be set to 'boot' or 'grub_bios' for boot partition.
- filesystem
  The filesystem type: 'ext4', 'fat32', 'btrfs', 'swap', 'xfs'
- filesystem-label
  The 'filesystem-label' is optional. Add this attribute to set label of filesystem.
- mount
  The mount attribute is optional. Leave empty for unmounted, or set mount path for partition.

Please see the example file: examples/answers-partitions.yaml

If any volumes attributes are invalid, the auto installation would fall back to manual mode.
The error can be check in log file.

