### PR TITLE
Add storage configuration for auto install

### DIFF
--- a/bin/subiquity-tui
+++ b/bin/subiquity-tui
@@ -66,12 +66,14 @@ def parse_options(argv):
                         help='run in uefi support mode')
     parser.add_argument('--screens', action='append', dest='screens', default=[])
     parser.add_argument('--answers')
+    parser.add_argument('--storage', dest='storage_conf')
     return parser.parse_args(argv)
 
 
 LOGDIR = "/var/log/installer/"
 
 AUTO_ANSWERS_FILE = "/subiquity_config/answers.yaml"
+STORAGE_CONFIG_FILE = "/subiquity_config/subiquity-config-storage.yaml"
 
 def main():
     opts = parse_options(sys.argv[1:])
@@ -95,6 +97,10 @@ def main():
     if opts.answers is None and os.path.exists(AUTO_ANSWERS_FILE):
         logger.debug("Autoloading answers from %s", AUTO_ANSWERS_FILE)
         opts.answers = AUTO_ANSWERS_FILE
+
+    if opts.storage_conf is None and os.path.exists(STORAGE_CONFIG_FILE):
+        logger.debug("Storage config file from %s", STORAGE_CONFIG_FILE)
+        opts.storage_conf = STORAGE_CONFIG_FILE
 
     ui = SubiquityUI()
 

--- a/examples/subiquity-config-storage.yaml
+++ b/examples/subiquity-config-storage.yaml
@@ -1,0 +1,11 @@
+storage:
+  config:
+  - {id: disk-0, type: disk, ptable: gpt, serial: QEMU_HARDDISK_QM00001, path: /dev/sda,
+    model: QEMU_HARDDISK}
+  - {id: part-0, type: partition, number: 1, device: disk-0, size: 805306368, flag: boot}
+  - {id: part-1, type: partition, number: 2, device: disk-0, size: 3487563776}
+  - {id: fs-0, type: format, fstype: fat32, volume: part-0, label: ESP}
+  - {id: fs-1, type: format, fstype: ext4, volume: part-1, label: rootfs}
+  - {id: mount-1, type: mount, device: fs-1, path: /}
+  - {id: mount-0, type: mount, device: fs-0, path: /boot/efi}
+  version: 1

--- a/subiquity/controllers/filesystem.py
+++ b/subiquity/controllers/filesystem.py
@@ -60,7 +60,9 @@ class FilesystemController(BaseController):
         self.ui.set_header(title)
         self.ui.set_footer(footer)
         self.ui.set_body(GuidedFilesystemView(self))
-        if self.answers['guided']:
+        if self.opts.storage_conf is not None:
+            self.finish()
+        elif self.answers['guided']:
             self.guided()
         elif self.answers['manual']:
             self.manual()

--- a/subiquity/models/subiquity.py
+++ b/subiquity/models/subiquity.py
@@ -79,27 +79,30 @@ class SubiquityModel:
                 },
             }
 
-    def render(self, install_step, reporting_url=None):
-        disk_actions = self.filesystem.render()
-        if install_step == "postinstall":
-            for a in disk_actions:
-                a['preserve'] = True
+    def render(self, install_step, reporting_url=None, storage_conf=None):
         config = {
-            'partitioning_commands': {
-                'builtin': 'curtin block-meta custom',
-                },
-
-            'reporting': {
+	   'reporting': {
                 'subiquity': {
                     'type': 'print',
                     },
                 },
-
-            'storage': {
-                'version': 1,
-                'config': disk_actions,
-                },
             }
+        if storage_conf is None:
+            disk_actions = self.filesystem.render()
+            if install_step == "postinstall":
+                for a in disk_actions:
+                    a['preserve'] = True
+            config.update({
+                'partitioning_commands': {
+                    'builtin': 'curtin block-meta custom',
+                    },
+
+                'storage': {
+                    'version': 1,
+                    'config': disk_actions,
+                    },
+            })
+
         if install_step == "install":
             config.update(self.network.render())
         else:


### PR DESCRIPTION
Currently, the answers.yaml supports auto installation, but the partitioning function only supports guided mode. Here to add a "--storage" argument in subiquity-tui, or the default yaml file in /subiquity_config/subiquity-config-storage.yaml

The yaml format is same as curtin storage which as:
http://curtin.readthedocs.io/en/latest/topics/storage.html

When the storage config yaml file presents, the storage partition setting in UI would be skipped.


