### PR TITLE
stop showing >s on network config choices that do not lead to a new screen

### DIFF
--- a/subiquitycore/ui/views/network_configure_interface.py
+++ b/subiquitycore/ui/views/network_configure_interface.py
@@ -112,6 +112,8 @@ class NetworkConfigureInterfaceView(BaseView):
             menu_btn(label="    %s" % _("Do not use"),
                     on_press=self.clear_ipv4),
         ]
+        for btn in buttons:
+            btn.original_widget._label._cursor_position = 1
         padding = getattr(Padding, 'left_{}'.format(button_padding))
         buttons = [ padding(button) for button in buttons ]
 
@@ -128,6 +130,9 @@ class NetworkConfigureInterfaceView(BaseView):
             menu_btn(label="    %s" % _("Do not use"),
                     on_press=self.clear_ipv6),
         ]
+
+        for btn in buttons:
+            btn.original_widget._label._cursor_position = 1
 
         padding = getattr(Padding, 'left_{}'.format(button_padding))
         buttons = [ padding(button) for button in buttons ]

--- a/subiquitycore/ui/views/network_configure_interface.py
+++ b/subiquitycore/ui/views/network_configure_interface.py
@@ -18,13 +18,14 @@ import logging
 from urwid import Text
 
 from subiquitycore.view import BaseView
-from subiquitycore.ui.buttons import done_btn, menu_btn
+from subiquitycore.ui.buttons import done_btn, menu_btn, _stylized_button
 from subiquitycore.ui.container import ListBox, Pile
 from subiquitycore.ui.utils import button_pile, Padding
 from subiquitycore.ui.views.network import _build_gateway_ip_info_for_version, _build_wifi_info
 
 log = logging.getLogger('subiquitycore.network.network_configure_interface')
 
+choice_btn = _stylized_button("", "", "menu")
 
 class NetworkConfigureInterfaceView(BaseView):
     def __init__(self, model, controller, name):
@@ -107,9 +108,9 @@ class NetworkConfigureInterfaceView(BaseView):
         buttons = [
             menu_btn(label="    %s" % _("Use a static IPv4 configuration"),
                     on_press=self.show_ipv4_configuration),
-            menu_btn(label="    %s" % _("Use DHCPv4 on this interface"),
+            choice_btn(label="    %s" % _("Use DHCPv4 on this interface"),
                     on_press=self.enable_dhcp4),
-            menu_btn(label="    %s" % _("Do not use"),
+            choice_btn(label="    %s" % _("Do not use"),
                     on_press=self.clear_ipv4),
         ]
         for btn in buttons:
@@ -125,9 +126,9 @@ class NetworkConfigureInterfaceView(BaseView):
         buttons = [
             menu_btn(label="    %s" % _("Use a static IPv6 configuration"),
                     on_press=self.show_ipv6_configuration),
-            menu_btn(label="    %s" % _("Use DHCPv6 on this interface"),
+            choice_btn(label="    %s" % _("Use DHCPv6 on this interface"),
                     on_press=self.enable_dhcp6),
-            menu_btn(label="    %s" % _("Do not use"),
+            choice_btn(label="    %s" % _("Do not use"),
                     on_press=self.clear_ipv6),
         ]
 


### PR DESCRIPTION
for https://bugs.launchpad.net/subiquity/+bug/1750050