### PR TITLE
do not show full curtin log output by default

### DIFF
--- a/scripts/replay-curtin-log.py
+++ b/scripts/replay-curtin-log.py
@@ -17,7 +17,7 @@ logger.addHandler(handler)
 
 json_file = sys.argv[1]
 
-c = {'subiquity': {'type': 'journald'}, 'print': {'type': 'print'}}
+c = {'subiquity': {'type': 'journald', 'identifier': sys.argv[2]}, 'print': {'type': 'print'}}
 
 reporter.update_configuration(c)
 

--- a/subiquity/controllers/identity.py
+++ b/subiquity/controllers/identity.py
@@ -33,9 +33,7 @@ class IdentityController(BaseController):
     def default(self):
         title = _("Profile setup")
         excerpt = _("Enter the username and password (or ssh identity) you will use to log in to the system.")
-        footer = ""
         self.ui.set_header(title, excerpt)
-        self.ui.set_footer(footer)
         self.ui.set_body(IdentityView(self.model, self, self.opts))
         if 'realname' in self.answers and \
             'username' in self.answers and \

--- a/subiquity/controllers/installprogress.py
+++ b/subiquity/controllers/installprogress.py
@@ -90,7 +90,11 @@ class InstallProgressController(BaseController):
         return cp.returncode
 
     def curtin_event(self, event):
-        #log.debug("curtin_event received %r", event)
+        e = {}
+        for k, v in event.items():
+            if k.startswith("CURTIN_"):
+                e[k] = v
+        log.debug("curtin_event received %r", e)
         event_type = event.get("CURTIN_EVENT_TYPE")
         if event_type not in ['start', 'finish']:
             return
@@ -99,7 +103,6 @@ class InstallProgressController(BaseController):
             if self.progress_view is None:
                 self.footer_description.set_text(message)
                 self._event_log.append(self._event_indent + message)
-                log.debug("_event_log %r", self._event_log)
             else:
                 self.progress_view.add_event(self._event_indent + message)
             self._event_indent += "  "

--- a/subiquity/controllers/installprogress.py
+++ b/subiquity/controllers/installprogress.py
@@ -154,7 +154,7 @@ class InstallProgressController(BaseController):
         self.install_state = InstallState.RUNNING
         self.footer_description = urwid.Text("starting...")
         self.footer_spinner = Spinner(self.loop)
-        self.ui.set_footer(urwid.Columns([('pack', urwid.Text("Install in progress:")), ('pack', self.footer_description), ('pack', self.footer_spinner)], dividechars=1))
+        self.ui.set_footer(urwid.Columns([('pack', urwid.Text("Install in progress:")), (self.footer_description), ('pack', self.footer_spinner)], dividechars=1))
 
         self.journal_listener_handle = self.start_journald_listener(self._syslog_identifier, self.curtin_event)
 

--- a/subiquity/controllers/installprogress.py
+++ b/subiquity/controllers/installprogress.py
@@ -171,7 +171,6 @@ class InstallProgressController(BaseController):
     def curtin_install_completed(self, fut):
         returncode = fut.result()
         log.debug('curtin_install: returncode: {}'.format(returncode))
-        self.loop.remove_watch_file(self.journal_listener_handle)
         if returncode > 0:
             self.install_state = InstallState.ERROR
             self.curtin_error()

--- a/subiquity/models/subiquity.py
+++ b/subiquity/models/subiquity.py
@@ -95,7 +95,7 @@ class SubiquityModel:
             with open(path, 'w') as fp:
                 fp.write(content)
 
-    def render(self, target):
+    def render(self, target, syslog_identifier):
         config = {
             'install': {
                 'target': target,
@@ -117,6 +117,7 @@ class SubiquityModel:
             'reporting': {
                 'subiquity': {
                     'type': 'journald',
+                    'identifier': syslog_identifier,
                     },
                 },
 

--- a/subiquity/ui/views/installprogress.py
+++ b/subiquity/ui/views/installprogress.py
@@ -82,6 +82,9 @@ class ProgressView(BaseView):
             self.listbox.set_focus(len(self.listwalker) - 1)
             self.listbox.set_focus_valign('bottom')
 
+    def add_log_line(self, text):
+        pass
+
     def set_status(self, text):
         self.linebox.set_title(text)
 

--- a/subiquity/ui/views/installprogress.py
+++ b/subiquity/ui/views/installprogress.py
@@ -34,6 +34,29 @@ class MyLineBox(LineBox):
         else:
             return ""
 
+class Spinner(Text):
+    def __init__(self, loop):
+        self.loop = loop
+        self.spin_index = 0
+        self.spin_text = r'-\|/'
+        super().__init__('')
+        self.handle = None
+
+    def _advance(self, sender=None, user_data=None):
+        self.spin_index = (self.spin_index + 1)%len(self.spin_text)
+        self.set_text(self.spin_text[self.spin_index])
+        self.handle = self.loop.set_alarm_in(0.1, self._advance)
+
+    def start(self):
+        self.stop()
+        self._advance()
+
+    def stop(self):
+        self.set_text('')
+        if self.handle is not None:
+            self.loop.remove_alarm(self.handle)
+            self.handle = None
+
 
 class ProgressView(BaseView):
     def __init__(self, controller):

--- a/subiquity/ui/views/installprogress.py
+++ b/subiquity/ui/views/installprogress.py
@@ -59,9 +59,9 @@ class Spinner(Text):
 
 
 class ProgressView(BaseView):
-    def __init__(self, controller, spinner):
+    def __init__(self, controller):
         self.controller = controller
-        self.spinner = spinner
+        self.spinner = Spinner(controller.loop)
 
         self.event_listwalker = SimpleFocusListWalker([])
         self.event_listbox = ListBox(self.event_listwalker)

--- a/subiquity/ui/views/installprogress.py
+++ b/subiquity/ui/views/installprogress.py
@@ -22,7 +22,7 @@ from urwid import (
 
 from subiquitycore.view import BaseView
 from subiquitycore.ui.buttons import cancel_btn, ok_btn
-from subiquitycore.ui.container import ListBox, Pile
+from subiquitycore.ui.container import Columns, ListBox, Pile
 from subiquitycore.ui.utils import button_pile, Padding
 
 log = logging.getLogger("subiquity.views.installprogress")
@@ -59,8 +59,9 @@ class Spinner(Text):
 
 
 class ProgressView(BaseView):
-    def __init__(self, controller):
+    def __init__(self, controller, spinner):
         self.controller = controller
+        self.spinner = spinner
         self.listwalker = SimpleFocusListWalker([])
         self.listbox = ListBox(self.listwalker)
         self.linebox = MyLineBox(self.listbox)
@@ -72,16 +73,14 @@ class ProgressView(BaseView):
         self.pile = Pile(body)
         super().__init__(self.pile)
 
-    def add_log_tail(self, text):
+    def add_event(self, text):
         at_end = len(self.listwalker) == 0 or self.listbox.focus_position == len(self.listwalker) - 1
-        for line in text.splitlines():
-            self.listwalker.append(Text(line))
+        if len(self.listwalker) > 0:
+            self.listwalker[-1] = self.listwalker[-1][0]
+        self.listwalker.append(Columns([('pack', Text(text)), ('pack', self.spinner)], dividechars=1))
         if at_end:
             self.listbox.set_focus(len(self.listwalker) - 1)
             self.listbox.set_focus_valign('bottom')
-
-    def clear_log_tail(self):
-        self.listwalker[:] = []
 
     def set_status(self, text):
         self.linebox.set_title(text)

--- a/subiquity/ui/views/installprogress.py
+++ b/subiquity/ui/views/installprogress.py
@@ -66,7 +66,7 @@ class ProgressView(BaseView):
         self.event_listwalker = SimpleFocusListWalker([])
         self.event_listbox = ListBox(self.event_listwalker)
         self.event_linebox = MyLineBox(self.event_listbox)
-        self.event_buttons = button_pile([other_btn("View full log")])
+        self.event_buttons = button_pile([other_btn("View full log", on_press=self.view_log)])
         event_body = [
             ('pack', Text("")),
             ('weight', 1, Padding.center_79(self.event_linebox)),
@@ -75,6 +75,15 @@ class ProgressView(BaseView):
             ('pack', Text("")),
         ]
         self.event_pile = Pile(event_body)
+
+        self.log_listwalker = SimpleFocusListWalker([])
+        self.log_listbox = ListBox(self.log_listwalker)
+        log_linebox = MyLineBox(self.log_listbox, _("Full installer output"))
+        log_body = [
+            ('weight', 1, log_linebox),
+            ('pack', button_pile([other_btn(_("Close"), on_press=self.close_log)])),
+            ]
+        self.log_pile = Pile(log_body)
 
         super().__init__(self.event_pile)
 
@@ -88,7 +97,11 @@ class ProgressView(BaseView):
             self.event_listbox.set_focus_valign('bottom')
 
     def add_log_line(self, text):
-        pass
+        at_end = len(self.log_listwalker) == 0 or self.log_listbox.focus_position == len(self.log_listwalker) - 1
+        self.log_listwalker.append(Text(text))
+        if at_end:
+            self.log_listbox.set_focus(len(self.log_listwalker) - 1)
+            self.log_listbox.set_focus_valign('bottom')
 
     def set_status(self, text):
         self.event_linebox.set_title(text)
@@ -113,3 +126,9 @@ class ProgressView(BaseView):
 
     def quit(self, btn):
         self.controller.quit()
+
+    def view_log(self, btn):
+        self._w = self.log_pile
+
+    def close_log(self, btn):
+        self._w = self.event_pile

--- a/subiquity/ui/views/tests/test_installprogress.py
+++ b/subiquity/ui/views/tests/test_installprogress.py
@@ -11,15 +11,16 @@ class IdentityViewTests(unittest.TestCase):
 
     def make_view(self):
         controller = mock.create_autospec(spec=InstallProgressController)
+        controller.loop = None
         return ProgressView(controller)
 
     def test_initial_focus(self):
         view = self.make_view()
         for w in reversed(view_helpers.get_focus_path(view)):
-            if w is view.listbox:
+            if w is view.event_listbox:
                 return
         else:
-            self.fail("listbox widget not focus")
+            self.fail("event listbox widget not focus")
 
     def test_show_complete(self):
         view = self.make_view()

--- a/subiquitycore/ui/anchors.py
+++ b/subiquitycore/ui/anchors.py
@@ -55,7 +55,10 @@ class Footer(WidgetWrap):
     """
 
     def __init__(self, message, current, complete):
-        message_widget = Padding.center_79(Text(message))
+        if isinstance(message, str):
+            message_widget = Padding.center_79(Text(message))
+        else:
+            message_widget = Padding.center_79(message)
         progress_bar = Padding.center_60(
             StepsProgressBar(normal='progress_incomplete',
                              complete='progress_complete',


### PR DESCRIPTION
https://asciinema.org/a/fBAnH8LdWTeEDOYjQg5Umiuz1

This changes the final view to just show the events curtin reports to subiquity by default, with a dose of indentation and a spinner that hopefully conveys a feeling of progress.

It also improves the display of install progress in the footer, simplifies some logic in the installprogress controller and switches to storing curtin output in the journal, because it just makes life easier that way.