### PR TITLE
add a border to all overlays to make them more readable

### DIFF
--- a/subiquity/ui/views/keyboard.py
+++ b/subiquity/ui/views/keyboard.py
@@ -206,12 +206,11 @@ class Detector:
         self.seen_steps = []
 
     def start(self):
-        o = AutoDetectIntro(self, None)
-        self.keyboard_view.show_overlay(o)
+        self.overlay = AutoDetectIntro(self, None)
+        self.keyboard_view.show_overlay(self.overlay)
 
     def abort(self):
-        overlay = self.keyboard_view._w.top_w
-        overlay.stop()
+        self.overlay.stop()
         self.keyboard_view.remove_overlay()
 
     step_cls_to_view_cls = {
@@ -241,14 +240,14 @@ class Detector:
         try:
             step = self.pc105tree.steps[step_index]
         except KeyError:
-            view = AutoDetectFailed(self, None)
+            self.overlay = AutoDetectFailed(self, None)
         else:
             self.seen_steps.append(step_index)
             log.debug("step: %s", repr(step))
-            view = self.step_cls_to_view_cls[type(step)](self, step)
+            self.overlay = self.step_cls_to_view_cls[type(step)](self, step)
 
-        view.start()
-        self.keyboard_view.show_overlay(view)
+        self.overlay.start()
+        self.keyboard_view.show_overlay(self.overlay)
 
 
 class ChoiceField(FormField):

--- a/subiquitycore/view.py
+++ b/subiquitycore/view.py
@@ -18,7 +18,7 @@
 Contains some default key navigations
 """
 
-from urwid import Overlay, WidgetWrap
+from urwid import Columns, Overlay, Pile, Text, WidgetWrap
 
 
 class BaseView(WidgetWrap):
@@ -37,7 +37,16 @@ class BaseView(WidgetWrap):
             height='pack'
             )
         args.update(kw)
-        self._w = Overlay(top_w=overlay_widget, bottom_w=self._w, **args)
+        top = Pile([
+            ('pack', Text("")),
+            Columns([
+                (3, Text("")),
+                overlay_widget,
+                (3, Text(""))
+                ]),
+            ('pack', Text("")),
+            ])
+        self._w = Overlay(top_w=top, bottom_w=self._w, **args)
 
     def remove_overlay(self):
         self._w = self.orig_w


### PR DESCRIPTION
This gives a padding of one row above and below the overlay and 3 characters to the left and right: https://asciinema.org/a/rIYPrq81zOY8kgZE9fF5ajriW