### PR TITLE
improve scrolling experience

### DIFF
--- a/subiquity/ui/views/filesystem/partition.py
+++ b/subiquity/ui/views/filesystem/partition.py
@@ -162,9 +162,7 @@ class PartitionFormatView(BaseView):
             ]))
 
     def make_body(self):
-        return [
-            self.form.as_rows(self),
-        ]
+        return self.form.as_rows(self)
 
     def cancel(self, button=None):
         self.back()
@@ -213,7 +211,6 @@ class PartitionView(PartitionFormatView):
                 Text(""),
                 button_pile([btn]),
                 ])
-            pass
         return body
 
     def delete(self, sender):

--- a/subiquity/ui/views/identity.py
+++ b/subiquity/ui/views/identity.py
@@ -161,11 +161,11 @@ class IdentityView(BaseView):
 
         self.ssh_import_confirmed = True
 
-        self.form_rows = self.form.as_rows(self)
+        self.form_rows = ListBox(self.form.as_rows(self))
 
         body = Pile([
             ('pack', Text("")),
-            Padding.center_90(ListBox([self.form_rows])),
+            Padding.center_90(self.form_rows),
             ('pack', Pile([
                 ('pack', Text("")),
                 button_pile([self.form.done_btn]),
@@ -187,7 +187,7 @@ class IdentityView(BaseView):
         iu.caption = _ssh_import_captions[val]
         iu.enabled = val is not None
         if val is not None:
-            self.form_rows.focus_position += 1
+            self.form_rows.body.focus += 1
 
     def done(self, result):
         cpassword = self.model.encrypt_password(self.form.password.value)

--- a/subiquity/ui/views/installpath.py
+++ b/subiquity/ui/views/installpath.py
@@ -143,7 +143,7 @@ class MAASView(BaseView):
 
         body = Pile([
             ('pack', Text("")),
-            Padding.center_90(ListBox([self.form.as_rows(self)])),
+            Padding.center_90(ListBox(self.form.as_rows(self))),
             ('pack', Pile([
                 ('pack', Text("")),
                 self.form.buttons,

--- a/subiquity/ui/views/keyboard.py
+++ b/subiquity/ui/views/keyboard.py
@@ -29,10 +29,10 @@ from subiquitycore.ui.container import (
     Pile,
     )
 from subiquitycore.ui.form import (
+    ChoiceField,
     Form,
-    FormField,
     )
-from subiquitycore.ui.selector import Option, Selector
+from subiquitycore.ui.selector import Option
 from subiquitycore.ui.utils import button_pile, Color, Padding
 from subiquitycore.view import BaseView
 
@@ -265,15 +265,6 @@ class ApplyingConfig(WidgetWrap):
                     ('pack', spinner),
                     ])))
 
-
-class ChoiceField(FormField):
-
-    def __init__(self, caption=None, help=None, choices=[]):
-        super().__init__(caption, help)
-        self.choices = choices
-
-    def _make_widget(self, form):
-        return Selector(self.choices)
 
 class KeyboardForm(Form):
 

--- a/subiquity/ui/views/keyboard.py
+++ b/subiquity/ui/views/keyboard.py
@@ -297,9 +297,7 @@ class KeyboardView(BaseView):
             # Don't crash on pre-existing invalid config.
             pass
 
-        self._rows = self.form.as_rows(self)
-
-        lb_contents = [self._rows]
+        lb_contents = self.form.as_rows(self)
         if not self.opts.run_on_serial:
             lb_contents.extend([
                 Text(""),
@@ -316,7 +314,6 @@ class KeyboardView(BaseView):
                 Text(""),
                 ])),
             ])
-        lb._select_last_selectable()
         pile.focus_position = 2
         super().__init__(pile)
 

--- a/subiquitycore/ui/form.py
+++ b/subiquitycore/ui/form.py
@@ -202,6 +202,8 @@ class BoundFormField(object):
     @caption.setter
     def caption(self, val):
         self._caption = val
+        if self.pile:
+            self.pile[0][0].set_text(val)
 
     def _cols(self):
         text = Text(self.caption, align="right")

--- a/subiquitycore/ui/form.py
+++ b/subiquitycore/ui/form.py
@@ -35,6 +35,7 @@ from subiquitycore.ui.interactive import (
     IntegerEditor,
     StringEditor,
     )
+from subiquitycore.ui.selector import Selector
 from subiquitycore.ui.utils import button_pile, Color
 
 log = logging.getLogger("subiquitycore.ui.form")
@@ -256,6 +257,17 @@ def simple_field(widget_maker):
 StringField = simple_field(StringEditor)
 PasswordField = simple_field(PasswordEditor)
 IntegerField = simple_field(IntegerEditor)
+
+
+class ChoiceField(FormField):
+
+    def __init__(self, caption=None, help=None, choices=[]):
+        super().__init__(caption, help)
+        self.choices = choices
+
+    def _make_widget(self, form):
+        return Selector(self.choices)
+
 
 class MetaForm(MetaSignals):
 

--- a/subiquitycore/ui/form.py
+++ b/subiquitycore/ui/form.py
@@ -331,7 +331,7 @@ class Form(object, metaclass=MetaForm):
         rows = []
         for field in self._fields:
             rows.append(field.as_row(view, longest_caption))
-        return Pile(rows)
+        return rows
 
     def validated(self):
         in_error = False

--- a/subiquitycore/ui/views/network.py
+++ b/subiquitycore/ui/views/network.py
@@ -112,14 +112,14 @@ class NetworkView(BaseView):
         self.controller = controller
         self.items = []
         self.error = Text("", align='center')
-        self.model_inputs = Pile(self._build_model_inputs())
+        self.model_inputs = self._build_model_inputs()
         self.additional_options = Pile(self._build_additional_options())
-        self.body = [
-            self.model_inputs,
+        self.body = self.model_inputs + [
             Padding.center_79(self.additional_options),
             Padding.line_break(""),
         ]
         self.lb = Padding.center_90(ListBox(self.body))
+        self.lb.original_widget.focus_position = 1
         self.footer = Pile([
                 Text(""),
                 self._build_buttons(),
@@ -130,7 +130,6 @@ class NetworkView(BaseView):
             ('pack', Text("")),
             self.lb,
             ('pack', self.footer)])
-        self.lb.original_widget._select_last_selectable()
         self.frame.focus_position = 2
         super().__init__(self.frame)
 

--- a/subiquitycore/ui/views/network_configure_manual_interface.py
+++ b/subiquitycore/ui/views/network_configure_manual_interface.py
@@ -136,7 +136,7 @@ class BaseNetworkConfigureManualView(BaseView):
         #self.set_as_default_gw_button = Pile(self._build_set_as_default_gw_button())
         body = Pile([
             ('pack', Text("")),
-            Padding.center_79(ListBox([self.form.as_rows(self)])),
+            Padding.center_79(ListBox(self.form.as_rows(self))),
             #Padding.line_break(""),
             #Padding.center_79(self.set_as_default_gw_button),
             ('pack', Pile([


### PR DESCRIPTION
Before this change, subiquity has lots of ListBoxes that just contain a single
Pile containing all their contents. This is (a) a bit silly (b) make some parts
of the scrolling experience a bit poor, for example urwid tries to scroll all
of a ListBox element into view when it gets focus but this is defeated by
shoving all the elements into a Pile (this causes
https://bugs.launchpad.net/subiquity/+bug/1750058 and a few other strange
bits).

The fix for this is obvious (don't wrap ListBox elements in a Pile) but this
breaks some aspects of tab cycling (when you shift tab back into a listbox you
want the last element of the box to be both selected and scrolled into view,
that sort of thing). Fixing all these bits of broken behaviour required
rewriting the tab cycling implementation to the point of copy/paste/hack-ing
the Pile.keypress method. Rather than doing the same for Columns, I just
prevent the creation of Columns with more than 1 selectable, which as we want
subiquity to be navigable with up/down/return does not seem so bad.

As penitence for all this, I've added a bunch of commentary explaining what is
going on.