### PR TITLE
change how ssh import field works

### DIFF
--- a/subiquity/ui/views/keyboard.py
+++ b/subiquity/ui/views/keyboard.py
@@ -29,10 +29,10 @@ from subiquitycore.ui.container import (
     Pile,
     )
 from subiquitycore.ui.form import (
+    ChoiceField,
     Form,
-    FormField,
     )
-from subiquitycore.ui.selector import Option, Selector
+from subiquitycore.ui.selector import Option
 from subiquitycore.ui.utils import button_pile, Color, Padding
 from subiquitycore.view import BaseView
 
@@ -265,15 +265,6 @@ class ApplyingConfig(WidgetWrap):
                     ('pack', spinner),
                     ])))
 
-
-class ChoiceField(FormField):
-
-    def __init__(self, caption=None, help=None, choices=[]):
-        super().__init__(caption, help)
-        self.choices = choices
-
-    def _make_widget(self, form):
-        return Selector(self.choices)
 
 class KeyboardForm(Form):
 

--- a/subiquitycore/ui/form.py
+++ b/subiquitycore/ui/form.py
@@ -202,6 +202,8 @@ class BoundFormField(object):
     @caption.setter
     def caption(self, val):
         self._caption = val
+        if self.pile:
+            self.pile[0][0].set_text(val)
 
     def _cols(self):
         text = Text(self.caption, align="right")

--- a/subiquitycore/ui/form.py
+++ b/subiquitycore/ui/form.py
@@ -35,6 +35,7 @@ from subiquitycore.ui.interactive import (
     IntegerEditor,
     StringEditor,
     )
+from subiquitycore.ui.selector import Selector
 from subiquitycore.ui.utils import button_pile, Color
 
 log = logging.getLogger("subiquitycore.ui.form")
@@ -256,6 +257,17 @@ def simple_field(widget_maker):
 StringField = simple_field(StringEditor)
 PasswordField = simple_field(PasswordEditor)
 IntegerField = simple_field(IntegerEditor)
+
+
+class ChoiceField(FormField):
+
+    def __init__(self, caption=None, help=None, choices=[]):
+        super().__init__(caption, help)
+        self.choices = choices
+
+    def _make_widget(self, form):
+        return Selector(self.choices)
+
 
 class MetaForm(MetaSignals):
 


### PR DESCRIPTION
This is the only place in subiquity today where we have selectable fields side
by side, which contradicts the goal to be able to navigate subiquity with up,
down and enter keys only. Replace the existing fancy widget with two fields,
one to select the import source and one to enter the username.

Also remove the "Ubuntu SSO" option as that has never worked.

https://asciinema.org/a/bpddtZbxMiGXpQNDbhkZ5omqD