### PR TITLE
do not show wlan interfaces in server installer

### DIFF
--- a/console_conf/models/console_conf.py
+++ b/console_conf/models/console_conf.py
@@ -6,5 +6,5 @@ class ConsoleConfModel:
     """The overall model for console-conf."""
 
     def __init__(self, common):
-        self.network = NetworkModel()
+        self.network = NetworkModel(support_wlan=True)
         self.identity = IdentityModel()

--- a/subiquity/models/subiquity.py
+++ b/subiquity/models/subiquity.py
@@ -45,7 +45,7 @@ class SubiquityModel:
         self.locale = LocaleModel(common['signal'])
         self.keyboard = KeyboardModel(root)
         self.installpath = InstallpathModel()
-        self.network = NetworkModel()
+        self.network = NetworkModel(support_wlan=False)
         self.filesystem = FilesystemModel(common['prober'])
         self.identity = IdentityModel()
 

--- a/subiquitycore/models/network.py
+++ b/subiquitycore/models/network.py
@@ -380,7 +380,8 @@ class NetworkModel(object):
         6: 'balance-alb',
     }
 
-    def __init__(self):
+    def __init__(self, support_wlan=True):
+        self.support_wlan = support_wlan
         self.devices = {} # Maps ifindex to Networkdev
         self.devices_by_name = {} # Maps interface names to Networkdev
         self.default_v4_gateway = None
@@ -410,6 +411,8 @@ class NetworkModel(object):
 
     def new_link(self, ifindex, link):
         if link.type in NETDEV_IGNORED_IFACE_TYPES:
+            return
+        if not self.support_wlan and link.type == "wlan":
             return
         if link.name in NETDEV_IGNORED_IFACE_NAMES:
             return


### PR DESCRIPTION
This is basically the simplest possible thing, we could show wlan interfaces but have them be disabled which might be less confusing but also I don't think I care very much.