### PR TITLE
handle non-latin keyboard layouts more intelligently

### DIFF
--- a/subiquity/controllers/keyboard.py
+++ b/subiquity/controllers/keyboard.py
@@ -65,7 +65,7 @@ class KeyboardController(BaseController):
             self._done)
 
     def _done(self, fut):
-        self.signal.emit_signal('next-screen')
+        self.loop.set_alarm_in(0.0, lambda loop, ud: self.signal.emit_signal('next-screen'))
 
     def cancel(self):
         self.signal.emit_signal('prev-screen')

--- a/subiquity/controllers/keyboard.py
+++ b/subiquity/controllers/keyboard.py
@@ -17,6 +17,7 @@ import logging
 
 from subiquitycore.controller import BaseController
 
+from subiquity.models.keyboard import KeyboardSetting
 from subiquity.ui.views import KeyboardView
 
 log = logging.getLogger('subiquity.controllers.keyboard')
@@ -57,11 +58,11 @@ class KeyboardController(BaseController):
         if 'layout' in self.answers:
             layout = self.answers['layout']
             variant = self.answers.get('variant', '')
-            self.done(layout, variant)
+            self.done(KeyboardSetting(layout=layout, variant=variant))
 
-    def done(self, layout, variant):
+    def done(self, setting):
         self.run_in_bg(
-            lambda: self.model.set_keyboard(layout, variant),
+            lambda: self.model.set_keyboard(setting),
             self._done)
 
     def _done(self, fut):

--- a/subiquity/models/keyboard.py
+++ b/subiquity/models/keyboard.py
@@ -26,7 +26,7 @@ BACKSPACE="guess"
 @attr.s
 class KeyboardSetting:
     layout = attr.ib()
-    variant = attr.ib(default=None)
+    variant = attr.ib(default='')
     toggle = attr.ib(default=None)
 
     def render(self):
@@ -34,8 +34,6 @@ class KeyboardSetting:
         if self.toggle:
             options = "grp:" + self.toggle
         variant = self.variant
-        if variant is None:
-            variant = ''
         return etc_default_keyboard_template.format(
             layout=self.layout, variant=variant, options=options)
 

--- a/subiquity/models/keyboard.py
+++ b/subiquity/models/keyboard.py
@@ -104,3 +104,34 @@ class KeyboardModel:
             run_command(['/snap/bin/subiquity.subiquity-loadkeys'])
         else:
             run_command(['sleep', '1'])
+
+    def adjust_layout(self, layout, variant):
+        if layout == 'rs':
+            if variant.startswith('latin'):
+                return 'rs', variant
+            else:
+                if variant == 'yz':
+                    return 'rs,rs', 'latinyz,' + variant
+                elif variant == 'alternatequotes':
+                    return 'rs,rs', 'latinalternatequotes,' + variant
+                else:
+                    return 'rs,rs', 'latin,' + variant
+        elif layout == 'jp':
+            if variant in ('106', 'common', 'OADG109A', 'nicola_f_bs', ''):
+                return 'jp', variant
+            else:
+                return 'jp,jp', ',' + variant
+        elif layout == 'lt':
+            if variant == 'us':
+                return 'lt,lt', 'us,'
+            else:
+                return 'lt,lt', variant + ',us'
+        elif layout == 'me':
+            if variant == 'basic' or variant.startswith('latin'):
+                return 'me', variant
+            else:
+                return 'me,me', variant + ',us'
+        elif layout in ('af', 'am', 'ara', 'ben', 'bd', 'bg', 'bt', 'by', 'et', 'ge', 'gh', 'gr', 'guj', 'guru', 'il', ''in'', 'iq', 'ir', 'iku', 'kan', 'kh', 'kz', 'la', 'lao', 'lk', 'kg', 'ma', 'mk', 'mm', 'mn', 'mv', 'mal', 'np', 'ori', 'pk', 'ru', 'scc', 'sy', 'syr', 'tel', 'th', 'tj', 'tam', 'tib', 'ua', 'ug', 'uz'):
+            return 'us,' + layout, ',' + variant
+        else:
+            return layout, variant

--- a/subiquity/models/subiquity.py
+++ b/subiquity/models/subiquity.py
@@ -129,7 +129,7 @@ class SubiquityModel:
             'write_files': {
                 'etc_default_keyboard': {
                     'path': 'etc/default/keyboard',
-                    'content': self.keyboard.config_content,
+                    'content': self.keyboard.setting.render(),
                     },
                 },
             }

--- a/subiquity/ui/views/keyboard.py
+++ b/subiquity/ui/views/keyboard.py
@@ -418,7 +418,7 @@ class KeyboardView(BaseView):
         if self.form.variant.widget.value is not None:
             variant = self.form.variant.widget.value
         setting = KeyboardSetting(layout=layout, variant=variant)
-        new_setting = self.model.adjust_setting(setting)
+        new_setting = setting.latinizable()
         if new_setting != setting:
             self.show_overlay(ToggleQuestion(self, new_setting), height=('relative', 100))
             return

--- a/subiquity/ui/views/keyboard.py
+++ b/subiquity/ui/views/keyboard.py
@@ -437,10 +437,17 @@ class KeyboardView(BaseView):
     def select_layout(self, sender, layout):
         log.debug("%s", layout)
         opts = []
-        for variant, variant_desc in self.model.variants[layout].items():
+        default_i = -1
+        for i, (variant, variant_desc) in enumerate(self.model.variants[layout].items()):
+            if variant == "":
+                default_i = i
             opts.append(Option((variant_desc, True, variant)))
         opts.sort(key=lambda o:o.label)
-        opts.insert(0, Option(("default", True, None)))
+        if default_i < 0:
+            opts.insert(0, Option(("default", True, "")))
         self.form.variant.widget._options = opts
-        self.form.variant.widget.index = 0
+        if default_i < 0:
+            self.form.variant.widget.index = 0
+        else:
+            self.form.variant.widget.index = default_i
         self.form.variant.enabled = len(opts) > 1

--- a/subiquity/ui/views/keyboard.py
+++ b/subiquity/ui/views/keyboard.py
@@ -17,9 +17,9 @@ import logging
 
 from urwid import (
     connect_signal,
-    BoxAdapter,
     LineBox,
     Padding as UrwidPadding,
+    SolidFill,
     Text,
     WidgetWrap,
     )
@@ -313,22 +313,22 @@ class ToggleQuestion(WidgetWrap):
             ListBox([
                 Text(_(toggle_text)),
                 ]),
-            ('pack', Text("")),
+            (1, SolidFill(" ")),
             ('pack', Padding.center_79(Columns([
                 ('pack', Text(_("Shortcut: "))),
                 Color.string_input(selector),
                 ]))),
-            ('pack', Text("")),
+            (1, SolidFill(" ")),
             ('pack', button_pile([
                 ok_btn(label=_("OK"), on_press=self.ok),
                 cancel_btn(label=_("Cancel"), on_press=self.cancel),
                 ])),
             ])
+        pile.focus_position = 4
         super().__init__(
             LineBox(
                 UrwidPadding(
-                    # Don't like having a fixed height box adapter here but urwid has beaten me for now.
-                    BoxAdapter(pile, height=10),
+                    pile,
                     left=1, right=1)))
 
     def ok(self, sender):
@@ -412,7 +412,7 @@ class KeyboardView(BaseView):
             variant = self.form.variant.widget.value
         new_layout, new_variant = self.model.adjust_layout(layout, variant)
         if (new_layout, new_variant) != (layout, variant):
-            self.show_overlay(ToggleQuestion(self, layout, variant))
+            self.show_overlay(ToggleQuestion(self, layout, variant), height=('relative', 100))
             return
         self.really_done(layout, variant)
 

--- a/subiquity/ui/views/keyboard.py
+++ b/subiquity/ui/views/keyboard.py
@@ -335,7 +335,8 @@ class ToggleQuestion(WidgetWrap):
             LineBox(
                 UrwidPadding(
                     pile,
-                    left=1, right=1)))
+                    left=1, right=1),
+                _("Select layout toggle")))
 
     def ok(self, sender):
         self.parent.remove_overlay()

--- a/subiquity/ui/views/keyboard.py
+++ b/subiquity/ui/views/keyboard.py
@@ -309,6 +309,12 @@ class ToggleQuestion(WidgetWrap):
         self.setting = setting
         self.selector = Selector(toggle_options)
         self.selector.value = 'alt_shift_toggle'
+        if self.parent.model.setting.toggle:
+            try:
+               self.selector.value = self.parent.model.setting.toggle
+            except AttributeError:
+                pass
+
         pile = Pile([
             ListBox([
                 Text(_(toggle_text)),

--- a/subiquity/ui/views/keyboard.py
+++ b/subiquity/ui/views/keyboard.py
@@ -370,9 +370,10 @@ class KeyboardView(BaseView):
         connect_signal(self.form, 'cancel', self.cancel)
         connect_signal(self.form.layout.widget, "select", self.select_layout)
         self.form.layout.widget._options = opts
+        setting = model.setting.for_ui()
         try:
-            self.form.layout.widget.value = model.setting.layout
-            self.form.variant.widget.value = model.setting.variant
+            self.form.layout.widget.value = setting.layout
+            self.form.variant.widget.value = setting.variant
         except AttributeError:
             # Don't crash on pre-existing invalid config.
             pass

--- a/subiquitycore/view.py
+++ b/subiquitycore/view.py
@@ -18,7 +18,7 @@
 Contains some default key navigations
 """
 
-from urwid import Columns, Overlay, Pile, Text, WidgetWrap
+from urwid import Columns, Overlay, Pile, SolidFill, Text, WidgetWrap
 
 
 class BaseView(WidgetWrap):
@@ -42,14 +42,20 @@ class BaseView(WidgetWrap):
             if isinstance(kw['width'], int):
                 kw['width'] += 2*PADDING
         args.update(kw)
+        if 'height' in kw:
+            f = SolidFill(" ")
+            p = 1
+        else:
+            f = Text("")
+            p = 'pack'
         top = Pile([
-            ('pack', Text("")),
+            (p, f),
             Columns([
-                (PADDING, Text("")),
+                (PADDING, f),
                 overlay_widget,
-                (PADDING, Text(""))
+                (PADDING, f)
                 ]),
-            ('pack', Text("")),
+            (p, f),
             ])
         self._w = Overlay(top_w=top, bottom_w=self._w, **args)
 


### PR DESCRIPTION
https://asciinema.org/a/IESGmVIzLec6feUMGfKEgGWZH (although as that's recorded in a gnome-terminal of course you can't see the actual effect of changing the keyboard)

The behaviour is entirely stolen from d-i -- when the user chooses a non-latin keyboard layout, they are prompted to choose a key stroke to swap between a latin layout and the one they chose.

I've tested this in KVM, it seems to work.

I spent a bit too long trying to find a way to be notified by the kernel of layout changes so I could display the current layout somewhere but didn't find anything (presumably it's possible by tracking things in /dev/input but brrr)