### PR TITLE
add --click, --script arguments to subiquity-tui

### DIFF
--- a/bin/subiquity-tui
+++ b/bin/subiquity-tui
@@ -48,6 +48,10 @@ checks:
             - /usr/bin/curtin
 '''
 
+class ClickAction(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        namespace.scripts.append("c(" + repr(values) + ")")
+
 def parse_options(argv):
     parser = argparse.ArgumentParser(
         description='SUbiquity - Ubiquity for Servers',
@@ -65,6 +69,8 @@ def parse_options(argv):
                         dest='uefi',
                         help='run in uefi support mode')
     parser.add_argument('--screens', action='append', dest='screens', default=[])
+    parser.add_argument('--script', metavar="SCRIPT", action='append', dest='scripts', default=[], help='Execute SCRIPT in a namespace containing view helpers and "ui"')
+    parser.add_argument('--click', metavar="PAT", action=ClickAction, help='Synthesize a click on a button matching PAT')
     parser.add_argument('--answers')
     return parser.parse_args(argv)
 

--- a/subiquitycore/core.py
+++ b/subiquitycore/core.py
@@ -321,12 +321,47 @@ class Application:
     def exit(self):
         raise urwid.ExitMainLoop()
 
-    def run_scripts(self, loop, user_data):
-        scripts, d = user_data
-        script, scripts = scripts[0], scripts[1:]
-        exec(script, d)
-        if scripts:
-            self.common['loop'].set_alarm_in(0.05, self.run_scripts, (scripts, d))
+    def run_scripts(self, scripts):
+        from subiquitycore.testing import view_helpers
+        d = view_helpers.__dict__.copy()
+        def _run_script(*args):
+            scripts = d['scripts']
+            log.debug("running %s", scripts[0])
+            exec(scripts[0], d)
+            if d['waiting']:
+                return
+            d['scripts'] = scripts[1:]
+            if d['scripts']:
+                self.common['loop'].set_alarm_in(0.01, _run_script)
+        def c(pat):
+            but = view_helpers.find_button_matching(self.common['ui'], '.*' + pat + '.*')
+            if not but:
+                d['wait_count'] += 1
+                if d['wait_count'] > 10:
+                    raise Exception("no button found matching %r after waiting for 10 secs"%(pat,))
+                wait(1, func=lambda : c(pat))
+                return
+            d['wait_count'] = 0
+            view_helpers.click(but)
+        def wait(delay, func=None):
+            d['waiting'] = True
+            def next(loop, user_data):
+                d['waiting'] = False
+                if func is not None:
+                    func()
+                if not d['waiting']:
+                    scripts = d['scripts']
+                    d['scripts'] = scripts[1:]
+                    if d['scripts']:
+                        _run_script()
+            self.common['loop'].set_alarm_in(delay, next)
+        d['scripts'] = scripts
+        d['c'] = c
+        d['wait'] = wait
+        d['ui'] = self.common['ui']
+        d['waiting'] = False
+        d['wait_count'] = 0
+        self.common['loop'].set_alarm_in(0.06, _run_script)
 
     def run(self):
         if not hasattr(self, 'loop'):
@@ -346,16 +381,7 @@ class Application:
         try:
             self.common['loop'].set_alarm_in(0.05, self.next_screen)
             if self.common['opts'].scripts:
-                from subiquitycore.testing import view_helpers
-                d = view_helpers.__dict__.copy()
-                def c(pat):
-                    but = view_helpers.find_button_matching(self.common['ui'], '.*' + pat + '.*')
-                    if not but:
-                        raise Exception("no button found matching %r"%(pat,))
-                    view_helpers.click(but)
-                d['c'] = c
-                d['ui'] = self.common['ui']
-                self.common['loop'].set_alarm_in(0.06, self.run_scripts, (self.common['opts'].scripts, d))
+                self.run_scripts(self.common['opts'].scripts)
             controllers_mod = __import__('%s.controllers' % self.project, None, None, [''])
             for k in self.controllers:
                 log.debug("Importing controller: {}".format(k))

--- a/subiquitycore/core.py
+++ b/subiquitycore/core.py
@@ -322,6 +322,18 @@ class Application:
         raise urwid.ExitMainLoop()
 
     def run_scripts(self, scripts):
+        # run_scripts runs (or rather arranges to run, it's all async)
+        # a series of python snippets in a helpful namespace. This is
+        # all in aid of being able to test some part of the UI without
+        # having to click the same buttons over and over again to get
+        # the UI to the part you are working on.
+        #
+        # In the namespace are:
+        #  * everything from view_helpers
+        #  * wait, delay execution of subsequent scripts for a while
+        #  * c, a function that finds a button and clicks it. uses
+        #    wait, above to wait for the button to appear in case it
+        #    takes a while.
         from subiquitycore.testing import view_helpers
         loop = self.common['loop']
 

--- a/subiquitycore/testing/view_helpers.py
+++ b/subiquitycore/testing/view_helpers.py
@@ -4,6 +4,8 @@ import urwid
 
 def find_with_pred(w, pred, return_path=False):
     def _walk(w, path):
+        if not isinstance(w, urwid.Widget):
+            raise RuntimeError("_walk walked to non-widget %r via %r" % (w, path))
         if pred(w):
             return w, path
         if hasattr(w, '_wrapped_widget'):
@@ -12,6 +14,11 @@ def find_with_pred(w, pred, return_path=False):
             return _walk(w.original_widget, (w,) + path)
         if isinstance(w, urwid.ListBox):
             for w in w.body:
+                r, p = _walk(w, (w,) + path)
+                if r:
+                    return r, p
+        elif isinstance(w, urwid.Frame):
+            for w, _ in w.contents.values():
                 r, p = _walk(w, (w,) + path)
                 if r:
                     return r, p


### PR DESCRIPTION
This lets you set up the UI from the command line to avoid RSI inducing stuff when testing a new, somewhat nested, screen. To test the raid screen I'm working on I can run

```
bin/subiquity-tui --dry-run --machine-config examples/mwhudson.json --screens Filesystem --click Man --click RAID
```

to get straight to the "create RAID device" screen.