### PR TITLE
Missing french translation?

### DIFF
--- a/subiquity/models/locale.py
+++ b/subiquity/models/locale.py
@@ -33,6 +33,7 @@ class LocaleModel(object):
         ('hr_HR', 'Croatian'),
         ('nl_NL', 'Dutch'),
         ('fi_FI', 'Finnish'),
+        ('fr_FR', 'French'),
         ('de_DE', 'German'),
         ('el_GR', 'Greek, Modern (1453-)'),
 #        ('he_IL', 'Hebrew'), # disabled as it does not render correctly on a vt with default font


### PR DESCRIPTION
All translations are include in subiquity/models/locale.py excepting french. 