### PR TITLE
convert ScrollBarListBox to decoration rather than subclass

### DIFF
--- a/subiquity/ui/views/identity.py
+++ b/subiquity/ui/views/identity.py
@@ -301,7 +301,7 @@ class IdentityView(BaseView):
         iu.widget.error_invalid_char = _(data['error_invalid_char'])
         iu.enabled = val is not None
         if val is not None:
-            self.form_rows.body.focus += 2
+            self.form_rows.base_widget.body.focus += 2
         self.form.ssh_import_id_value = val
         if iu.value != "" or val is None:
             iu.validate()

--- a/subiquity/ui/views/installprogress.py
+++ b/subiquity/ui/views/installprogress.py
@@ -17,7 +17,6 @@ import logging
 from urwid import (
     LineBox,
     Text,
-    SimpleFocusListWalker,
     )
 
 from subiquitycore.view import BaseView
@@ -42,8 +41,7 @@ class ProgressView(BaseView):
         self.controller = controller
         self.spinner = Spinner(controller.loop)
 
-        self.event_listwalker = SimpleFocusListWalker([])
-        self.event_listbox = ListBox(self.event_listwalker)
+        self.event_listbox = ListBox()
         self.event_linebox = MyLineBox(self.event_listbox)
         self.event_buttons = button_pile([other_btn(_("View full log"), on_press=self.view_log)])
         event_body = [
@@ -55,8 +53,7 @@ class ProgressView(BaseView):
         ]
         self.event_pile = Pile(event_body)
 
-        self.log_listwalker = SimpleFocusListWalker([])
-        self.log_listbox = ListBox(self.log_listwalker)
+        self.log_listbox = ListBox()
         log_linebox = MyLineBox(self.log_listbox, _("Full installer output"))
         log_body = [
             ('weight', 1, log_linebox),
@@ -66,21 +63,26 @@ class ProgressView(BaseView):
 
         super().__init__(self.event_pile)
 
-    def add_event(self, text):
-        at_end = len(self.event_listwalker) == 0 or self.event_listbox.focus_position == len(self.event_listwalker) - 1
-        if len(self.event_listwalker) > 0:
-            self.event_listwalker[-1] = self.event_listwalker[-1][0]
-        self.event_listwalker.append(Columns([('pack', Text(text)), ('pack', self.spinner)], dividechars=1))
+    def _add_line(self, lb, line):
+        lb = lb.base_widget
+        walker = lb.body
+        at_end = len(walker) == 0 or lb.focus_position == len(walker) - 1
+        walker.append(line)
         if at_end:
-            self.event_listbox.set_focus(len(self.event_listwalker) - 1)
-            self.event_listbox.set_focus_valign('bottom')
+            lb.set_focus(len(walker) - 1)
+            lb.set_focus_valign('bottom')
+
+    def add_event(self, text):
+        walker = self.event_listbox.base_widget.body
+        if len(walker) > 0:
+            # Remove the spinner from the line it is currently on, if there is one.
+            walker[-1] = walker[-1][0]
+        # Add spinner to the line we are inserting.
+        new_line = Columns([('pack', Text(text)), ('pack', self.spinner)], dividechars=1)
+        self._add_line(self.event_listbox, new_line)
 
     def add_log_line(self, text):
-        at_end = len(self.log_listwalker) == 0 or self.log_listbox.focus_position == len(self.log_listwalker) - 1
-        self.log_listwalker.append(Text(text))
-        if at_end:
-            self.log_listbox.set_focus(len(self.log_listwalker) - 1)
-            self.log_listbox.set_focus_valign('bottom')
+        self._add_line(self.log_listbox, Text(text))
 
     def set_status(self, text):
         self.event_linebox.set_title(text)

--- a/subiquitycore/ui/container.py
+++ b/subiquitycore/ui/container.py
@@ -386,41 +386,46 @@ class FocusTrackingListBox(TabCyclingListBox):
 Columns = FocusTrackingColumns
 Pile = FocusTrackingPile
 
+class ScrollBarListBox(urwid.WidgetDecoration):
 
-class ScrollBarListBox(FocusTrackingListBox):
-
-    def __init__(self, walker=None):
+    def __init__(self, lb):
         def f(char, attr):
             return urwid.AttrMap(urwid.SolidFill(char), attr)
         self.boxes = [
-            urwid.AttrMap(urwid.SolidFill("\N{FULL BLOCK}"), 'scrollbar_bg'),
-            urwid.AttrMap(urwid.SolidFill("\N{FULL BLOCK}"), 'scrollbar_fg'),
+            f("\N{FULL BLOCK}", 'scrollbar_bg'),
+            f("\N{FULL BLOCK}", 'scrollbar_fg'),
             ]
         self.bar = Pile([
             ('weight', 1, f("\N{BOX DRAWINGS LIGHT VERTICAL}", 'scrollbar_bg')),
             ('weight', 1, self.boxes[0]),
             ('weight', 1, f("\N{BOX DRAWINGS LIGHT VERTICAL}", 'scrollbar_bg')),
             ])
-        super().__init__(walker)
+        super().__init__(lb)
+
+    def keypress(self, size, key):
+        visible = self.original_widget.ends_visible(size, True)
+        if len(visible) != 2:
+            size = (size[0]-1, size[1])
+        return self.original_widget.keypress(size, key)
 
     def render(self, size, focus=False):
-        visible = self.ends_visible(size, focus)
+        visible = self.original_widget.ends_visible(size, focus)
         if len(visible) == 2:
-            return super().render(size, focus)
+            return self.original_widget.render(size, focus)
         else:
             # This implementation assumes that the number of rows is
             # not too large (and in particular is finite). That's the
             # case for all the listboxes we have in subiquity today.
             maxcol, maxrow = size
 
-            offset, inset = self.get_focus_offset_inset((maxcol - 1, maxrow))
+            offset, inset = self.original_widget.get_focus_offset_inset((maxcol - 1, maxrow))
 
             seen_focus = False
             height = height_before_focus = 0
-            focus_widget, focus_pos = self.body.get_focus()
+            focus_widget, focus_pos = self.original_widget.body.get_focus()
             # Scan through the rows calculating total height and the
             # height of the rows before the focus widget.
-            for widget in self.body:
+            for widget in self.original_widget.body:
                 rows = widget.rows((maxcol - 1,))
                 if widget is focus_widget:
                     seen_focus = True
@@ -459,10 +464,17 @@ class ScrollBarListBox(FocusTrackingListBox):
                 (self.bar.contents[2][0], self.bar.options('weight', bottom)),
                 ]
             canvases = [
-                (super().render((maxcol - 1, maxrow), focus), self.focus_position, True, maxcol - 1),
+                (self.original_widget.render((maxcol - 1, maxrow), focus), self.original_widget.focus_position, True, maxcol - 1),
                 (self.bar.render((1, maxrow)), None, False, 1)
                 ]
             return urwid.CanvasJoin(canvases)
 
 
-ListBox = ScrollBarListBox
+def ListBox(body=None):
+    # urwid.ListBox converts an arbitrary sequence argument to a
+    # PollingListWalker, which doesn't work with our code.
+    if body is None:
+        body = []
+    if body is getattr(body, 'get_focus', None) is None:
+        body = urwid.SimpleFocusListWalker(body)
+    return ScrollBarListBox(FocusTrackingListBox(body))

--- a/subiquitycore/ui/selector.py
+++ b/subiquitycore/ui/selector.py
@@ -62,7 +62,7 @@ class _PopUpSelectDialog(WidgetWrap):
                 btn = Text("    " + option.label)
                 group.append(AttrWrap(btn, 'info_minor'))
         list_box = ListBox(group)
-        list_box.focus_position = cur_index
+        list_box.base_widget.focus_position = cur_index
         super().__init__(LineBox(list_box))
 
     def click(self, btn, index):

--- a/subiquitycore/ui/stretchy.py
+++ b/subiquitycore/ui/stretchy.py
@@ -130,7 +130,7 @@ class StretchyOverlay(urwid.Widget):
 
     def keypress(self, size, key):
         top_size, scrollbar_visible = self._top_size(size, True)
-        self.listbox._selectable = scrollbar_visible or self.stretchy.stretchy_w.selectable()
+        self.listbox.base_widget._selectable = scrollbar_visible or self.stretchy.stretchy_w.selectable()
         return self.top_w.keypress(top_size, key)
 
     def render(self, size, focus):

--- a/subiquitycore/ui/views/network.py
+++ b/subiquitycore/ui/views/network.py
@@ -197,7 +197,7 @@ class NetworkView(BaseView):
             Padding.center_79(self.additional_options),
             Padding.line_break(""),
         ]
-        self.listbox.body[:] = widgets
+        self.listbox.base_widget.body[:] = widgets
         self.additional_options.contents = [ (obj, ('pack', None)) for obj in self._build_additional_options() ]
 
     def _build_additional_options(self):


### PR DESCRIPTION
for all the usual reasons why composition is better than inheritance,
but in particular because I want to have a listbox that has a scrollbar
but not our custom tab behaviour in another branch. decoration in urwid
is not as transparent as it sometimes seems it should be but luckily
there's only one view that does much with its listbox and it was due
for some cleanup anyway.