### PR TITLE
Makefile: Always put PYTHONPATH into environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ PYTHONSRC=$(NAME)
 PYTHONPATH=$(shell pwd):$(shell pwd)/probert
 PROBERTDIR=./probert
 PROBERT_REPO=https://github.com/CanonicalLtd/probert
+export PYTHONPATH
 
 ifneq (,$(MACHINE))
 	MACHARGS=--machine=$(MACHINE)
@@ -28,10 +29,10 @@ dryrun: probert i18n
 	$(MAKE) ui-view DRYRUN="--dry-run --uefi"
 
 ui-view:
-	(PYTHONPATH=$(PYTHONPATH) bin/$(PYTHONSRC)-tui $(DRYRUN) $(MACHARGS))
+	(bin/$(PYTHONSRC)-tui $(DRYRUN) $(MACHARGS))
 
 ui-view-serial:
-	(TERM=att4424 PYTHONPATH=$(PYTHONPATH) bin/$(PYTHONSRC)-tui $(DRYRUN) --serial)
+	(TERM=att4424 bin/$(PYTHONSRC)-tui $(DRYRUN) --serial)
 
 lint:
 	echo "Running flake8 lint tests..."


### PR DESCRIPTION
Just use 'export PYTHONPATH' in the Makefile so that we all targets
have that in their environment.