### PR TITLE
Implement zfsroot support

### DIFF
--- a/examples/zfsroot-answers.yaml
+++ b/examples/zfsroot-answers.yaml
@@ -1,0 +1,24 @@
+Welcome:
+  lang: en_US
+Keyboard:
+  layout: us
+Installpath:
+  path: ubuntu
+Network:
+  accept-default: yes
+Proxy:
+  proxy: ""
+Filesystem:
+  guided: yes
+  guided-index: 0
+  guided-fstype: zfsroot
+Identity:
+  realname: Ubuntu
+  username: ubuntu
+  hostname: ubuntu-server
+  # ubuntu
+  password: '$6$wdAcoXrU039hKYPd$508Qvbe7ObUnxoj15DRCkzC3qO7edjH0VV7BPNRDYK4QR8ofJaEEF2heacn0QgD.f8pO8SNp83XNdWG6tocBM1'
+  ssh_import_id: lp:mwhudson
+InstallProgress:
+  reboot: yes
+

--- a/subiquity/controllers/filesystem.py
+++ b/subiquity/controllers/filesystem.py
@@ -69,7 +69,8 @@ class FilesystemController(BaseController):
         if self.answers['guided']:
             index = self.answers['guided-index']
             disk = self.model.all_disks()[index]
-            v.choose_disk(None, disk)
+            fstype = self.answers.get('guided-fstype')
+            v.choose_disk(None, disk, fstype=fstype)
 
     def reset(self):
         log.info("Resetting Filesystem model")

--- a/subiquity/ui/views/filesystem/guided.py
+++ b/subiquity/ui/views/filesystem/guided.py
@@ -103,11 +103,13 @@ class GuidedDiskSelectionView(BaseView):
     def cancel(self, btn=None):
         self.controller.default()
 
-    def choose_disk(self, btn, disk):
+    def choose_disk(self, btn, disk, fstype=None):
         self.model.reset()
+        if not fstype:
+            fstype = 'ext4'
         result = {
             "size": disk.free,
-            "fstype": self.model.fs_by_name["ext4"],
+            "fstype": self.model.fs_by_name[fstype],
             "mount": "/",
         }
         self.controller.partition_disk_handler(disk, None, result)


### PR DESCRIPTION
Curtin supports a ZFS on Root mode where users can configure their rootfs
as a ZFS filesystem.  This is experimental and restricts use of ZFS only
to the rootfs volume.  This patch adds 'zfsroot' to the supported filesystem
list and enforces the requirements of only one zfsroot and only mounted at
'/'.  Add some code to blank out zfsroot if one is already selected.

This patch also adds a guided answer file for zfsroot.  One small change
to the guided path allowing the answers to supply the filesystem value for
the rootfs.