### PR TITLE
tox: Support running tests and flake8 in tox.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,8 +63,8 @@ logs/*
 venv
 .pybuild
 
-# probert as its pulled externally
-probert
+# probert as its pulled externally, ignore top level only.
+/probert/
 
 # installer isos
 *.iso

--- a/fake_deps/probert/network.py
+++ b/fake_deps/probert/network.py
@@ -1,0 +1,6 @@
+from unittest import mock
+
+StoredDataObserver = mock.Mock()
+UdevObserver = mock.Mock()
+NetworkEventReceiver = mock.Mock()
+IFF_UP = 0x1

--- a/fake_deps/probert/storage.py
+++ b/fake_deps/probert/storage.py
@@ -1,0 +1,4 @@
+from unittest import mock
+
+Storage = mock.Mock()
+StorageInfo = mock.Mock()

--- a/fake_deps/systemd/__init__.py
+++ b/fake_deps/systemd/__init__.py
@@ -1,0 +1,3 @@
+from unittest import mock
+
+journal = mock.Mock()

--- a/setup.py
+++ b/setup.py
@@ -23,11 +23,17 @@ Ubuntu Server Installer
 """
 
 from setuptools import setup, find_packages
-from DistUtilsExtra.command import build_extra
-from DistUtilsExtra.command import build_i18n
 
 import os
 import sys
+
+setup_kwargs = {}
+if sys.argv[1] == "build":
+    from DistUtilsExtra.command import build_extra
+    from DistUtilsExtra.command import build_i18n
+    setup_kwargs['cmdclass'] = {'build': build_extra.build_extra,
+                                'build_i18n': build_i18n.build_i18n}
+
 
 with open(os.path.join(os.path.dirname(__file__), 'subiquitycore', '__init__.py')) as init:
     lines = [line for line in init if 'i18n' not in line]
@@ -49,6 +55,5 @@ setup(name='subiquity',
       url='https://github.com/CanonicalLtd/subiquity',
       license="AGPLv3+",
       packages=find_packages(exclude=["tests"]),
-      cmdclass={'build': build_extra.build_extra,
-                'build_i18n': build_i18n.build_i18n, },
-      data_files=[])
+      data_files=[],
+      **setup_kwargs)

--- a/subiquity/models/keyboard.py
+++ b/subiquity/models/keyboard.py
@@ -86,7 +86,7 @@ class KeyboardSetting:
         content = open(config_file).read()
 
         def optval(opt, default):
-            match = re.search('(?m)^\s*%s=(.*)$' % (opt,), content)
+            match = re.search(r'(?m)^\s*%s=(.*)$' % (opt,), content)
             if match:
                 r = match.group(1).strip('"')
                 if r != '':

--- a/subiquity/ui/views/filesystem/tests/test_partition.py
+++ b/subiquity/ui/views/filesystem/tests/test_partition.py
@@ -1,9 +1,8 @@
 import unittest
 from unittest import mock
+from collections import namedtuple
 
 import urwid
-
-from probert.storage import StorageInfo
 
 from subiquitycore.testing import view_helpers
 
@@ -17,17 +16,19 @@ from subiquity.models.filesystem import (
 from subiquity.ui.views.filesystem.partition import PartitionView
 
 
+FakeStorageInfo = namedtuple(
+    'FakeStorageInfo', ['name', 'size', 'free', 'serial', 'model'])
+FakeStorageInfo.__new__.__defaults__ = (None,) * len(FakeStorageInfo._fields)
+
+
 class PartitionViewTests(unittest.TestCase):
 
     def make_view(self, partition=None):
         controller = mock.create_autospec(spec=FilesystemController)
         model = mock.create_autospec(spec=FilesystemModel)
         model.fs_by_name = FilesystemModel.fs_by_name
-        info = mock.create_autospec(spec=StorageInfo)
-        info.name = 'disk-name'
-        info.size = 100*(2**20)
-        info.free = 50*(2**20)
-        disk = Disk.from_info(info)
+        disk = Disk.from_info(FakeStorageInfo(
+            name='disk-name', size=100*(2**20), free=50*(2**20)))
         return PartitionView(model, controller, disk, partition)
 
     def test_initial_focus(self):

--- a/subiquity/ui/views/identity.py
+++ b/subiquity/ui/views/identity.py
@@ -196,7 +196,7 @@ class IdentityForm(Form):
         elif self.ssh_import_id_value == 'gh':
             if username.startswith('-') or (username.endswith('-') or
                                             '--' in username or
-                                            not re.match('^[a-zA-Z0-9\-]+$',
+                                            not re.match(r'^[a-zA-Z0-9\-]+$',
                                                          username)):
                 return _("A Github username may only contain alphanumeric "
                          "characters or single hyphens, and cannot begin or "

--- a/subiquity/ui/views/installpath.py
+++ b/subiquity/ui/views/installpath.py
@@ -22,8 +22,6 @@ import binascii
 import logging
 import re
 
-import lsb_release
-
 from urwid import connect_signal
 
 from subiquitycore.ui.buttons import back_btn, forward_btn
@@ -44,6 +42,7 @@ from subiquitycore.ui.form import (
     WantsToKnowFormField,
 )
 
+from subiquitycore.lsb_release import lsb_release
 
 log = logging.getLogger('subiquity.installpath')
 
@@ -60,7 +59,7 @@ class InstallpathView(BaseView):
 
     def __init__(self, model, controller):
         self.title = self.title.format(
-            lsb_release.get_distro_information()['RELEASE'])
+            lsb_release().get('release', 'Unknown Release'))
         self.model = model
         self.controller = controller
         self.items = []

--- a/subiquitycore/i18n.py
+++ b/subiquitycore/i18n.py
@@ -29,9 +29,13 @@ syslog.syslog('Final localedir is ' + localedir)
 
 
 def switch_language(code='en_US'):
-    if code != 'en_US' and 'FAKE_TRANSLATE' in os.environ:
+    fake_trans = os.environ.get("FAKE_TRANSLATE", "0")
+    if code != 'en_US' and fake_trans == "mangle":
         def my_gettext(message):
             return "_(%s)" % message
+    elif fake_trans not in ("0", ""):
+        def my_gettext(message):
+            return message
     elif code:
         translation = gettext.translation('subiquity', localedir=localedir,
                                           languages=[code])

--- a/subiquitycore/lsb_release.py
+++ b/subiquitycore/lsb_release.py
@@ -1,0 +1,29 @@
+# This file is part of subiquity. See LICENSE file for license information.
+import shlex
+
+LSB_RELEASE_FILE = "/etc/lsb-release"
+
+
+def lsb_release(path=None):
+    """return a dictionary of values from /etc/lsb-release.
+    keys are lower case with DISTRIB_ prefix removed."""
+    if path is None:
+        path = LSB_RELEASE_FILE
+
+    ret = {}
+    try:
+        with open(path, "r") as fp:
+            content = fp.read()
+    except FileNotFoundError:
+        return ret
+
+    for tok in shlex.split(content):
+        k, _, v = tok.partition("=")
+        if not k.startswith("DISTRIB_") or not v:
+            continue
+        ret[k.replace("DISTRIB_", "").lower()] = v
+    return ret
+
+
+if __name__ == '__main__':
+    print(lsb_release())

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,50 @@
+[tox]
+envlist =
+    coverage
+    flake8
+recreate = True
+
+[testenv]
+basepython = python3
+setenv =
+    FAKE_TRANSLATE = always
+    PYTHONPATH = {toxinidir}/fake_deps
+
+deps =
+    urwid==1.2.1
+    PyYAML
+    attrs
+    jsonschema
+    pyudev
+    requests
+    requests-unixsocket
+
+[testenv:flake8]
+deps =
+    flake8==3.5.0
+    pycodestyle==2.3.1
+    pyflakes==1.6.0
+
+commands = {envpython} -m flake8 \
+    {posargs:subiquity/ subiquitycore/ console_conf/ bin/}
+
+[testenv:py3]
+deps =
+    {[testenv]deps}
+    nose
+commands = {envpython} -m nose \
+    {posargs:subiquity/ subiquitycore/ console_conf/ bin/}
+
+[testenv:coverage]
+deps = {[testenv:py3]deps}
+    nose-timer
+    coverage
+commands = {envpython} -m nose \
+    --with-timer --timer-top-n 10 \
+    --with-coverage --cover-erase --cover-branches --cover-inclusive \
+    --cover-package=subiquity --cover-package=subiquitycore \
+    {posargs:subiquity/ subiquitycore/ console_conf/ bin/}
+
+[flake8]
+# gettext inserts _ into builtin path.
+builtins = _


### PR DESCRIPTION
tox: Support running tests and flake8 in tox.

This puts into place a tox.ini for running unit tests without
a large amount of deps installed into the system. For example,
we did not want to need libnl-route-3-dev or build-essential installed
in the system in order to run unit tests.

In order avoid import errors in the modules due to these missing
dependencies, we have added a 'fake_deps/' directory that provides
mock'd objects of the dependencies that were used.

The only installed packages necessary for this to run should be
tox itself and its dependencies (pip and friends).  From a clean new
container we can then do:
  apt-get install tox
  git clone ...
  tox

Also adjust setup.py to only need the DistUtilsExtra during 'build'
which is not done in tox.

