### PR TITLE
Add support for --source on command line.

### DIFF
--- a/subiquity/cmd/tui.py
+++ b/subiquity/cmd/tui.py
@@ -80,7 +80,7 @@ def parse_options(argv):
     parser.add_argument('--answers')
     parser.add_argument('--source', default=[], action='append',
                         dest='sources', metavar='URL',
-                        help='install from url instead default.')
+                        help='install from url instead of default.')
     parser.add_argument(
         '--snaps-from-examples', action='store_true',
         help=("Load snap details from examples/snaps instead of store. "

--- a/subiquity/cmd/tui.py
+++ b/subiquity/cmd/tui.py
@@ -78,6 +78,9 @@ def parse_options(argv):
     parser.add_argument('--click', metavar="PAT", action=ClickAction,
                         help='Synthesize a click on a button matching PAT')
     parser.add_argument('--answers')
+    parser.add_argument('--source', default=[], action='append',
+                        dest='sources', metavar='URL',
+                        help='install from url instead default.')
     parser.add_argument(
         '--snaps-from-examples', action='store_true',
         help=("Load snap details from examples/snaps instead of store. "

--- a/subiquity/controllers/installpath.py
+++ b/subiquity/controllers/installpath.py
@@ -54,6 +54,10 @@ class InstallpathController(BaseController):
         log.debug("Installing Ubuntu path chosen.")
         self.signal.emit_signal('next-screen')
 
+    def install_cmdline(self):
+        log.debug("Installing from command line sources.")
+        self.signal.emit_signal('next-screen')
+
     def install_maas_region(self):
         # show region questions, seed model
         title = "MAAS Region Controller Setup"

--- a/subiquity/models/installpath.py
+++ b/subiquity/models/installpath.py
@@ -29,7 +29,6 @@ class InstallpathModel(object):
     path = 'ubuntu'
     # update() is not run, upon selecting the default choice...
     curtin = {}
-    cmdline_sources = None
 
     def __init__(self, sources=None):
         self.cmdline_sources = sources

--- a/subiquity/models/subiquity.py
+++ b/subiquity/models/subiquity.py
@@ -49,7 +49,7 @@ class SubiquityModel:
             root = os.path.abspath(".subiquity")
         self.locale = LocaleModel(common['signal'])
         self.keyboard = KeyboardModel(root)
-        self.installpath = InstallpathModel()
+        self.installpath = InstallpathModel(sources=common['opts'].sources)
         self.network = NetworkModel(support_wlan=False)
         self.filesystem = FilesystemModel(common['prober'])
         self.identity = IdentityModel()
@@ -135,9 +135,7 @@ class SubiquityModel:
                     '/var/log/installer/curtin-install.log',
                 },
 
-            'sources': {
-                'rofs': 'cp://%s' % self.installpath.source,
-                },
+            'sources': self.installpath.sources,
 
             'verbosity': 3,
 


### PR DESCRIPTION
This provides the ability to install from a different source
by providing it on the command line.  So we can boot into a system,
and then run:
  subiquity --source=/tmp/xenial-server-cloudimg-amd64.squashfs
or
  subiquity --source=http://cloud-images.ubuntu.com/.../some.squashfs

And install that image rather than the hard coded paths.