### PR TITLE
Do not specify partitioning commands in curtin config.

### DIFF
--- a/subiquity/models/subiquity.py
+++ b/subiquity/models/subiquity.py
@@ -141,10 +141,6 @@ class SubiquityModel:
 
             'verbosity': 3,
 
-            'partitioning_commands': {
-                'builtin': 'curtin block-meta custom',
-                },
-
             'pollinate': {
                 'user_agent': {
                     'subiquity': "%s_%s" % (os.environ.get("SNAP_VERSION",


### PR DESCRIPTION
Subiquity was specifying the partitioning command to curtin like this:
    'partitioning_commands': {
        'builtin': 'curtin block-meta custom',
    },

That is not necessary, because the built-in config from curtin
is to do ['curtin', 'block-meta', 'simple'] which does the right thing
if storage config is provided.

In addition to that, because we specified a string, but curtin
was expecting an array, the log/status message that curtin would report
would show:
   running 'c u r t i n  b l o c k' ....
rather than:
   running 'curtin block-meta simple'