### PR TITLE
console-conf identity: do not hard-code the core version

### DIFF
--- a/console_conf/controllers/identity.py
+++ b/console_conf/controllers/identity.py
@@ -40,7 +40,7 @@ def get_core_version():
     version = None
     for line in shlex.split(content):
         key, _, value = line.partition("=")
-        if key == "NAME" and value != "Ubuntu Core":
+        if key == "ID" and value != "ubuntu-core":
             return None
         if key == "VERSION_ID":
             version = value

--- a/console_conf/controllers/identity.py
+++ b/console_conf/controllers/identity.py
@@ -188,7 +188,8 @@ def write_login_details_standalone():
     if len(ips) == 0:
         tty_name = os.ttyname(0)[5:]
         version = get_core_version() or "16"
-        print(login_details_tmpl_no_ip.format(tty_name=tty_name))
+        print(login_details_tmpl_no_ip.format(tty_name=tty_name,
+                                              version=version))
         return 2
     write_login_details(sys.stdout, owner['username'], ips)
     return 0

--- a/console_conf/controllers/identity.py
+++ b/console_conf/controllers/identity.py
@@ -162,7 +162,7 @@ def write_login_details(fp, username, ips):
                                            host_key_info=host_key_info(),
                                            tty_name=tty_name,
                                            first_ip=first_ip,
-                                           version=version)
+                                           version=version))
 
 
 def write_login_details_standalone():


### PR DESCRIPTION
Reuse the login_details_tmpl_no_ip template in standalone, use os-release to determine the Ubuntu Core version as we now support both 16 and 18.