### PR TITLE
add our own version of WidgetWrap

### DIFF
--- a/subiquity/ui/views/snaplist.py
+++ b/subiquity/ui/views/snaplist.py
@@ -23,11 +23,16 @@ from urwid import (
     SelectableIcon,
     SimpleFocusListWalker,
     Text,
-    WidgetWrap,
     )
 
 from subiquitycore.ui.buttons import ok_btn, cancel_btn, other_btn
-from subiquitycore.ui.container import Columns, ListBox, Pile, ScrollBarListBox
+from subiquitycore.ui.container import (
+    Columns,
+    ListBox,
+    Pile,
+    ScrollBarListBox,
+    WidgetWrap,
+    )
 from subiquitycore.ui.utils import button_pile, Color, screen
 from subiquitycore.view import BaseView
 
@@ -66,12 +71,6 @@ class SnapInfoView(WidgetWrap):
     # (which can both be arbitrarily long or short). If both are long,
     # the channel list is given a third of the space. If there is
     # space for both, they are packed into the upper part of the view.
-
-    def _select_first_selectable(self):
-        self._w._select_first_selectable()
-
-    def _select_last_selectable(self):
-        self._w._select_last_selectable()
 
     def __init__(self, parent, snap, cur_channel):
         self.parent = parent

--- a/subiquitycore/ui/container.py
+++ b/subiquitycore/ui/container.py
@@ -62,6 +62,7 @@ too many elements in the ListBox.
 """
 
 import logging
+import operator
 
 import urwid
 
@@ -496,3 +497,22 @@ def ListBox(body=None):
     if body is getattr(body, 'get_focus', None) is None:
         body = urwid.SimpleFocusListWalker(body)
     return ScrollBarListBox(FocusTrackingListBox(body))
+
+
+get_delegate = operator.attrgetter("_wrapped_widget")
+
+
+class OurWidgetWrap(urwid.WidgetWrap):
+    # A wrapped widget needs to have a _select_first/last_selectable
+    # method if and only if the widget being wrapped does, so we
+    # define our own WidgetWrap class that uses the same technique to
+    # forward these methods along if present as urwid's WidgetWrap
+    # does.
+
+    _select_first_selectable = property(
+        lambda self: get_delegate(self)._select_first_selectable)
+    _select_last_selectable = property(
+        lambda self: get_delegate(self)._select_last_selectable)
+
+
+WidgetWrap = OurWidgetWrap


### PR DESCRIPTION
urwid doesn't know about the _select_first/last_selectable methods our
containers use to make tab-cycling work so its WidgetWrap doesn't
forward them along. So add a WidgetWrap that does, and use it in the one
place that it matters so far (more coming soon!).