### PR TITLE
account for GPT overhead in a better place

### DIFF
--- a/subiquity/controllers/filesystem.py
+++ b/subiquity/controllers/filesystem.py
@@ -226,11 +226,11 @@ class FilesystemController(BaseController):
 
     def partition_disk_handler(self, disk, partition, spec):
         log.debug('partition_disk_handler: %s %s %s', disk, partition, spec)
-        log.debug('disk.freespace: {}'.format(disk.free))
+        log.debug('disk.freespace: {}'.format(disk.free_for_partitions))
 
         if partition is not None:
             partition.size = align_up(spec['size'])
-            if disk.free < 0:
+            if disk.free_for_partitions < 0:
                 raise Exception("partition size too large")
             self.delete_filesystem(partition.fs())
             self.create_filesystem(partition, spec)
@@ -244,11 +244,11 @@ class FilesystemController(BaseController):
 
             # adjust downward the partition size (if necessary) to accommodate
             # bios/grub partition
-            if spec['size'] > disk.free:
-                log.debug("Adjusting request down:" +
-                          "{} - {} = {}".format(spec['size'], part.size,
-                                                disk.free))
-                spec['size'] = disk.free
+            if spec['size'] > disk.free_for_partitions:
+                log.debug(
+                    "Adjusting request down: %s - %s = %s",
+                    spec['size'], part.size, disk.free_for_partitions)
+                spec['size'] = disk.free_for_partitions
 
         self.create_partition(disk, spec)
 
@@ -263,17 +263,17 @@ class FilesystemController(BaseController):
         # XXX This violates abstractions, needs some thinking.
         for p in self.model._partitions:
             if p.flag in ("bios_grub", "boot"):
-                full = p.device.free == 0
+                full = p.device.free_for_partitions == 0
                 p.device._partitions.remove(p)
                 p.device.grub_device = False
                 if full:
                     largest_part = max((part.size, part)
                                        for part in p.device._partitions)[1]
                     largest_part.size += p.size
-                if disk.free < p.size:
+                if disk.free_for_partitions < p.size:
                     largest_part = max((part.size, part)
                                        for part in disk._partitions)[1]
-                    largest_part.size -= (p.size - disk.free)
+                    largest_part.size -= (p.size - disk.free_for_partitions)
                 disk._partitions.insert(0, p)
                 disk.grub_device = True
                 p.device = disk

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -488,6 +488,8 @@ class FilesystemModel(object):
                 # log.debug('disk={}\n{}'.format(
                 #    path, json.dumps(data, indent=4, sort_keys=True)))
                 info = self.prober.get_storage_info(path)
+                if info.size < self.lower_size_limit:
+                    continue
                 self._available_disks[path] = Disk.from_info(info)
 
     def _use_disk(self, disk):

--- a/subiquity/ui/views/filesystem/filesystem.py
+++ b/subiquity/ui/views/filesystem/filesystem.py
@@ -404,7 +404,7 @@ class DeviceList(WidgetWrap):
                     rows.append(row)
                 if self.show_available and 0 < device.used < device.size:
                     size = device.size
-                    free = device.free
+                    free = device.free_for_partitions
                     percent = str(int(100 * free / size))
                     if percent == "0":
                         percent = "%.2f" % (100 * free / size,)

--- a/subiquity/ui/views/filesystem/guided.py
+++ b/subiquity/ui/views/filesystem/guided.py
@@ -106,7 +106,7 @@ class GuidedDiskSelectionView(BaseView):
     def choose_disk(self, btn, disk):
         self.model.reset()
         result = {
-            "size": disk.free,
+            "size": disk.free_for_partitions,
             "fstype": self.model.fs_by_name["ext4"],
             "mount": "/",
         }

--- a/subiquity/ui/views/filesystem/partition.py
+++ b/subiquity/ui/views/filesystem/partition.py
@@ -164,7 +164,7 @@ class PartitionStretchy(Stretchy):
         self.model = parent.model
         self.controller = parent.controller
         self.parent = parent
-        max_size = disk.free
+        max_size = disk.free_for_partitions
         mountpoint_to_devpath_mapping = (
             self.model.get_mountpoint_to_devpath_mapping())
 


### PR DESCRIPTION
Looking forward to RAID, it makes more sense to account for the GPT overhead in the calculation of how much space there is for partitions rather than lying about the size of a drive so do that, and rename a property to make its meaning clearer. 

Also re-introduce the filter on too-small devices that I lost refactoring the fs views.