### PR TITLE
Selector tweaks

### DIFF
--- a/subiquity/ui/mount.py
+++ b/subiquity/ui/mount.py
@@ -14,6 +14,8 @@ from subiquitycore.ui.container import (
     )
 from subiquitycore.ui.form import FormField
 from subiquitycore.ui.interactive import Selector, StringEditor
+from subiquitycore.ui.utils import Color
+
 
 common_mountpoints = [
     '/',
@@ -74,7 +76,7 @@ class MountSelector(WidgetWrap):
     def _showhide_other(self, show):
         if show and not self._other_showing:
             self._w.contents.append(
-                (Padding(Columns([(1, Text("/")), self._other]), left=4),
+                (Columns([(1, Text("/")), Color.string_input(self._other)]),
                  self._w.options('pack')))
             self._other_showing = True
         elif not show and self._other_showing:
@@ -109,6 +111,6 @@ class MountSelector(WidgetWrap):
 
 
 class MountField(FormField):
-
+    takes_default_style = False
     def _make_widget(self, form):
         return MountSelector(form.mountpoint_to_devpath_mapping)

--- a/subiquity/ui/mount.py
+++ b/subiquity/ui/mount.py
@@ -3,7 +3,6 @@ import re
 
 from urwid import (
     connect_signal,
-    Padding,
     Text,
     )
 
@@ -111,6 +110,8 @@ class MountSelector(WidgetWrap):
 
 
 class MountField(FormField):
+
     takes_default_style = False
+
     def _make_widget(self, form):
         return MountSelector(form.mountpoint_to_devpath_mapping)

--- a/subiquity/ui/views/filesystem/partition.py
+++ b/subiquity/ui/views/filesystem/partition.py
@@ -204,7 +204,7 @@ class PartitionStretchy(Stretchy):
                 opts = [
                     Option(("fat32", True, self.model.fs_by_name["fat32"])),
                 ]
-                self.form.fstype.widget._options = opts
+                self.form.fstype.widget.options = opts
                 self.form.fstype.widget.index = 0
                 self.form.mount.enabled = False
                 self.form.fstype.enabled = False

--- a/subiquity/ui/views/filesystem/partition.py
+++ b/subiquity/ui/views/filesystem/partition.py
@@ -47,6 +47,9 @@ log = logging.getLogger('subiquity.ui.filesystem.add_partition')
 
 
 class FSTypeField(FormField):
+
+    takes_default_style = False
+
     def _make_widget(self, form):
         return Selector(opts=FilesystemModel.supported_filesystems)
 

--- a/subiquity/ui/views/keyboard.py
+++ b/subiquity/ui/views/keyboard.py
@@ -389,6 +389,11 @@ class KeyboardView(BaseView):
         setting = model.setting.for_ui()
         try:
             self.form.layout.widget.value = setting.layout
+        except AttributeError:
+            # Don't crash on pre-existing invalid config.
+            pass
+        self.select_layout(None, setting.layout)
+        try:
             self.form.variant.widget.value = setting.variant
         except AttributeError:
             # Don't crash on pre-existing invalid config.

--- a/subiquity/ui/views/keyboard.py
+++ b/subiquity/ui/views/keyboard.py
@@ -385,7 +385,7 @@ class KeyboardView(BaseView):
         connect_signal(self.form, 'submit', self.done)
         connect_signal(self.form, 'cancel', self.cancel)
         connect_signal(self.form.layout.widget, "select", self.select_layout)
-        self.form.layout.widget._options = opts
+        self.form.layout.widget.options = opts
         setting = model.setting.for_ui()
         try:
             self.form.layout.widget.value = setting.layout
@@ -468,7 +468,7 @@ class KeyboardView(BaseView):
         opts.sort(key=lambda o: o.label)
         if default_i < 0:
             opts.insert(0, Option(("default", True, "")))
-        self.form.variant.widget._options = opts
+        self.form.variant.widget.options = opts
         if default_i < 0:
             self.form.variant.widget.index = 0
         else:

--- a/subiquitycore/ui/form.py
+++ b/subiquitycore/ui/form.py
@@ -294,6 +294,8 @@ URLField = simple_field(URLEditor)
 
 class ChoiceField(FormField):
 
+    takes_default_style = False
+
     def __init__(self, caption=None, help=None, choices=[]):
         super().__init__(caption, help)
         self.choices = choices

--- a/subiquitycore/ui/selector.py
+++ b/subiquitycore/ui/selector.py
@@ -32,19 +32,8 @@ from subiquitycore.ui.container import (
 
 
 class _PopUpButton(SelectableIcon):
-    """It looks a bit like a radio button, but it just emits
-       'click' on activation.
-    """
+    """Like Button, but simpler. """
     signals = ['click']
-
-    states = {
-        True: "(+) ",
-        False: "( ) ",
-        }
-
-    def __init__(self, option, state):
-        p = self.states[state]
-        super().__init__(p + option, len(p))
 
     def keypress(self, size, key):
         if self._command_map[key] != ACTIVATE:
@@ -60,12 +49,22 @@ class _PopUpSelectDialog(WidgetWrap):
         group = []
         for i, option in enumerate(self.parent._options):
             if option.enabled:
-                btn = _PopUpButton(option.label, state=(i == cur_index))
+                btn = _PopUpButton(" " + option.label)
                 connect_signal(btn, 'click', self.click, i)
-                group.append(AttrWrap(btn, 'menu_button', 'menu_button focus'))
+                if i == cur_index:
+                    rhs = '\N{BLACK LEFT-POINTING SMALL TRIANGLE} '
+                else:
+                    rhs = '  '
+                btn = Columns([
+                    btn,
+                    (2, Text(rhs)),
+                    ])
+                btn = AttrWrap(btn, 'menu_button', 'menu_button focus')
             else:
-                btn = Text("    " + option.label)
-                group.append(AttrWrap(btn, 'info_minor'))
+                btn = Text(" " + option.label)
+                btn = AttrWrap(btn, 'info_minor')
+            btn = UrwidPadding(btn, width=self.parent._padding.width)
+            group.append(btn)
         list_box = ListBox(group)
         list_box.base_widget.focus_position = cur_index
         super().__init__(LineBox(list_box))

--- a/subiquitycore/ui/selector.py
+++ b/subiquitycore/ui/selector.py
@@ -187,7 +187,7 @@ class Selector(WidgetWrap):
     def value(self, val):
         for i, opt in enumerate(self._options):
             if opt.value == val:
-                self.index = i
+                self._set_index(val)
                 return
         raise AttributeError("cannot set value to %r", val)
 

--- a/subiquitycore/ui/selector.py
+++ b/subiquitycore/ui/selector.py
@@ -139,11 +139,12 @@ class Selector(WidgetWrap):
     signals = ['select']
 
     def __init__(self, opts, index=0):
-        self._options = []
+        options = []
         for opt in opts:
             if not isinstance(opt, Option):
                 opt = Option(opt)
-            self._options.append(opt)
+            options.append(opt)
+        self.options = options
         self._button = SelectableIcon(self._prefix, len(self._prefix))
         self._set_index(index)
         super().__init__(_Launcher(self, self._button))
@@ -166,6 +167,14 @@ class Selector(WidgetWrap):
         self._emit('select', self._options[val].value)
         self._set_index(val)
 
+    @property
+    def options(self):
+        return self._options[:]
+
+    @options.setter
+    def options(self, val):
+        self._options = val
+
     def option_by_label(self, label):
         for opt in self._options:
             if opt.label == label:
@@ -187,7 +196,7 @@ class Selector(WidgetWrap):
     def value(self, val):
         for i, opt in enumerate(self._options):
             if opt.value == val:
-                self._set_index(val)
+                self._set_index(i)
                 return
         raise AttributeError("cannot set value to %r", val)
 


### PR DESCRIPTION
A few tweaks to the selector widget. "(+) option" becomes "[ option  ▾ ]".

This probably requires a new console font to look good in the vt...