### PR TITLE
Add jsonschema dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ install_deps:
 	sudo apt-get install -y python3-urwid python3-pyudev python3-nose python3-flake8 \
 		python3-yaml python3-coverage python3-dev pkg-config libnl-genl-3-dev \
 		libnl-route-3-dev python3-attr python3-distutils-extra python3-requests \
-		python3-requests-unixsocket
+		python3-requests-unixsocket python3-jsonschema
 
 i18n:
 	$(PYTHON) setup.py build


### PR DESCRIPTION
Fixes this error:

```
python3 -m subiquity --dry-run --uefi
Traceback (most recent call last):
  File "/usr/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/seth/src/canonicalltd/subiquity/subiquity/__main__.py", line 4, in <module>
    from subiquity.cmd.tui import main
  File "/home/seth/src/canonicalltd/subiquity/subiquity/cmd/tui.py", line 25, in <module>
    from subiquitycore.core import ApplicationError
  File "/home/seth/src/canonicalltd/subiquity/subiquitycore/core.py", line 29, in <module>
    from subiquitycore.prober import Prober, ProberException
  File "/home/seth/src/canonicalltd/subiquity/subiquitycore/prober.py", line 18, in <module>
    from probert.network import (StoredDataObserver,
  File "/home/seth/src/canonicalltd/subiquity/probert/probert/network.py", line 20, in <module>
    import jsonschema
ModuleNotFoundError: No module named 'jsonschema'
```