### PR TITLE
Raid simplifications

### DIFF
--- a/examples/answers-raid.yaml
+++ b/examples/answers-raid.yaml
@@ -31,7 +31,7 @@ Filesystem:
         mount: null
     - action: create-raid
       data:
-        name: md11
+        name: md1
         level: 1
         devices:
           - [disk index 0, part 1]
@@ -40,6 +40,11 @@ Filesystem:
           - active
           - [disk index 0, part 3]
           - spare
+    - obj: [raid name md1]
+      action: FORMAT
+      data:
+        fstype: ext4
+        mount: /
     - action: done
 Identity:
   realname: Ubuntu

--- a/subiquity/controllers/filesystem.py
+++ b/subiquity/controllers/filesystem.py
@@ -254,7 +254,6 @@ class FilesystemController(BaseController):
             spec['level'].value,
             spec['devices'],
             spec['spare_devices'])
-        self.create_filesystem(raid, spec)
         return raid
 
     def delete_raid(self, raid):

--- a/subiquity/controllers/filesystem.py
+++ b/subiquity/controllers/filesystem.py
@@ -303,8 +303,17 @@ class FilesystemController(BaseController):
     def raid_handler(self, existing, spec):
         log.debug("raid_handler %s %s", existing, spec)
         if existing is not None:
-            raise Exception("erk")
-        self.create_raid(spec)
+            for d in existing.devices | existing.spare_devices:
+                d._constructed_device = None
+            for d in spec['devices'] | spec['spare_devices']:
+                self.delete_filesystem(d.fs())
+                d._constructed_device = existing
+            existing.name = spec['name']
+            existing.raidlevel = spec['level'].value
+            existing.devices = spec['devices']
+            existing.spare_devices = spec['spare_devices']
+        else:
+            self.create_raid(spec)
 
     def make_boot_disk(self, new_boot_disk):
         boot_partition = None

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -167,8 +167,52 @@ class DeviceAction(enum.Enum):
     PARTITION = _("Add Partition")
     CREATE_LV = _("Create Logical Volume")
     FORMAT = _("Format")
+    REMOVE = _("Remove from RAID")
     DELETE = _("Delete")
     MAKE_BOOT = _("Make Boot Device")
+
+
+def _generic_can_EDIT(obj):
+    cd = obj.constructed_device()
+    if cd is None:
+        return True
+    return _(
+        "Cannot edit {selflabel} as it is part of the {cdtype} "
+        "{cdname}.").format(
+            selflabel=obj.label,
+            cdtype=cd.desc(),
+            cdname=cd.label)
+
+
+def _generic_can_REMOVE(obj):
+    cd = obj.constructed_device()
+    if cd is None:
+        return False
+    assert isinstance(cd, Raid)
+    if obj in cd.spare_devices:
+        return True
+    min_devices = raidlevels_by_value[cd.raidlevel].min_devices
+    if len(cd.devices) == min_devices:
+        return _(
+            "Removing {selflabel} would leave the {cdtype} {cdlabel} with less"
+            " than {min_devices} devices.").format(
+                selflabel=obj.label,
+                cdtype=cd.desc(),
+                cdlabel=cd.label,
+                min_devices=min_devices)
+    return True
+
+
+def _generic_can_DELETE(obj):
+    cd = obj.constructed_device()
+    if cd is None:
+        return True
+    return _(
+        "Cannot delete {selflabel} as it is part of the {cdtype} "
+        "{cdname}.").format(
+            selflabel=obj.label,
+            cdtype=cd.desc(),
+            cdname=cd.label)
 
 
 @attr.s(cmp=False)
@@ -359,6 +403,7 @@ class Disk(_Device):
         DeviceAction.INFO,
         DeviceAction.PARTITION,
         DeviceAction.FORMAT,
+        DeviceAction.REMOVE,
         DeviceAction.MAKE_BOOT,
         ]
     _can_INFO = True
@@ -366,36 +411,13 @@ class Disk(_Device):
     _can_FORMAT = property(
         lambda self: len(self._partitions) == 0 and
         self._constructed_device is None)
+    _can_REMOVE = property(_generic_can_REMOVE)
     _can_MAKE_BOOT = property(
         lambda self:
         not self.grub_device and self._fs is None
         and self._constructed_device is None)
 
     ok_for_raid = _can_FORMAT
-
-
-def _generic_can_DELETE(obj):
-    cd = obj.constructed_device()
-    if cd is None:
-        return True
-    return _(
-        "Cannot delete {selflabel} as it is part of the {cdtype} "
-        "{cdname}.").format(
-            selflabel=obj.label,
-            cdtype=cd.desc(),
-            cdname=cd.label)
-
-
-def _generic_can_EDIT(obj):
-    cd = obj.constructed_device()
-    if cd is None:
-        return True
-    return _(
-        "Cannot edit {selflabel} as it is part of the {cdtype} "
-        "{cdname}.").format(
-            selflabel=obj.label,
-            cdtype=cd.desc(),
-            cdname=cd.label)
 
 
 @attr.s(cmp=False)
@@ -435,10 +457,12 @@ class Partition(_Formattable):
 
     supported_actions = [
         DeviceAction.EDIT,
+        DeviceAction.REMOVE,
         DeviceAction.DELETE,
         ]
 
     _can_EDIT = property(_generic_can_EDIT)
+    _can_REMOVE = property(_generic_can_REMOVE)
 
     @property
     def _can_DELETE(self):
@@ -482,6 +506,7 @@ class Raid(_Device):
         DeviceAction.EDIT,
         DeviceAction.PARTITION,
         DeviceAction.FORMAT,
+        DeviceAction.REMOVE,
         DeviceAction.DELETE,
         ]
 
@@ -498,6 +523,7 @@ class Raid(_Device):
     _can_FORMAT = property(
         lambda self: len(self._partitions) == 0 and
         self._constructed_device is None)
+    _can_REMOVE = property(_generic_can_REMOVE)
 
     @property
     def _can_DELETE(self):

--- a/subiquity/ui/views/filesystem/delete.py
+++ b/subiquity/ui/views/filesystem/delete.py
@@ -14,118 +14,14 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-from urwid import Text, WidgetDisable
+from urwid import Text
 
 from subiquitycore.ui.buttons import danger_btn, other_btn
-from subiquitycore.ui.utils import button_pile, Color
+from subiquitycore.ui.utils import button_pile
 from subiquitycore.ui.stretchy import Stretchy
-
-from subiquity.models.filesystem import (
-    _Device,
-    Raid,
-    raidlevels_by_value,
-)
 
 
 log = logging.getLogger('subiquity.ui.filesystem.disk_info')
-
-
-def can_delete(obj, obj_desc=_("it")):
-    if isinstance(obj, _Device):
-        for p in obj.partitions():
-            ok, reason = can_delete(
-                p, obj_desc=_("partition {}").format(p._number))
-            if not ok:
-                return False, reason
-    cd = obj.constructed_device()
-    if cd is None:
-        return True, ""
-    if isinstance(cd, Raid):
-        rl = raidlevels_by_value[cd.raidlevel]
-        if len(cd.devices) > rl.min_devices:
-            return True, ""
-        else:
-            reason = _("deleting {obj} would leave the {desc} {label} with "
-                       "less than {min_devices} devices.").format(
-                        obj=_(obj_desc),
-                        desc=cd.desc(),
-                        label=cd.label,
-                        min_devices=rl.min_devices)
-            return False, reason
-    else:
-        raise Exception("unexpected constructed device {}".format(cd.label))
-
-
-def make_device_remover(cd, obj):
-
-    def remover():
-        cd.devices.remove(obj)
-        obj._constructed_device = None
-    return remover
-
-
-def make_device_deleter(controller, obj):
-    meth = getattr(controller, 'delete_' + obj.type)
-
-    def remover():
-        meth(obj)
-    return remover
-
-
-def delete_consequences(controller, obj, obj_desc=_("It")):
-    log.debug("building consequences for deleting %s", obj.label)
-    deleter = (
-        "delete {} {}".format(obj.type, obj.label),
-        make_device_deleter(controller, obj),
-    )
-    if isinstance(obj, _Device):
-        if len(obj.partitions()) > 0:
-            lines = [_("Proceeding will delete the following partitions:"), ""]
-            delete_funcs = []
-            for p in obj.partitions():
-                desc = _("Partition {}, which").format(p._number)
-                new_lines, new_delete_funcs = delete_consequences(
-                    controller, p, desc)
-                lines.extend(new_lines)
-                lines.append("")
-                delete_funcs.extend(new_delete_funcs)
-            return lines[:-1], delete_funcs + [deleter]
-        unused_desc = _("{} is not formatted, partitioned, or part of any "
-                        "constructed device.").format(obj_desc)
-    else:
-        unused_desc = _("{} is not formatted or part of any constructed "
-                        "device.").format(obj_desc)
-    fs = obj.fs()
-    cd = obj.constructed_device()
-    if fs is not None:
-        desc = _("{} is formatted as {}").format(obj_desc, fs.fstype)
-        if fs.mount():
-            desc += _(" and mounted at {}.").format(fs.mount().path)
-        else:
-            desc += _(" and not mounted.")
-        return [desc], [deleter]
-    elif cd is not None:
-        if isinstance(cd, Raid):
-            delete_funcs = [(
-                "remove {} from {}".format(obj.label, cd.name),
-                make_device_remover(cd, obj),
-                ),
-                deleter,
-            ]
-            return [
-                _("{} is part of the {} {}. {} will be left with {} "
-                  "devices.").format(
-                    obj_desc,
-                    cd.desc(),
-                      cd.label,
-                      cd.label,
-                      len(cd.devices) - 1),
-                ], delete_funcs
-        else:
-            raise Exception(
-                "unexpected constructed device {}".format(cd.label))
-    else:
-        return [unused_desc], [deleter]
 
 
 class ConfirmDeleteStretchy(Stretchy):
@@ -134,27 +30,28 @@ class ConfirmDeleteStretchy(Stretchy):
         self.parent = parent
         self.obj = obj
 
-        delete_ok, reason = can_delete(obj)
-        if delete_ok:
-            title = _("Confirm deletion of {}").format(obj.desc())
+        title = _("Confirm deletion of {}").format(obj.desc())
 
-            lines = [
-                _("Do you really want to delete {}?").format(obj.label),
-                "",
-            ]
-            new_lines, delete_funcs = delete_consequences(
-                self.parent.controller, obj)
-            lines.extend(new_lines)
-            self.delete_funcs = delete_funcs
+        lines = [
+            _("Do you really want to delete {}?").format(obj.label),
+            "",
+        ]
+        fs = obj.fs()
+        if fs is not None:
+            m = fs.mount()
+            if m is not None:
+                lines.append(_(
+                    "It is formatted as {fstype} and mounted at "
+                    "{path}").format(
+                        fstype=fs.fstype,
+                        path=m.path))
+            else:
+                lines.append(_(
+                    "It is formatted as {fstype} and not mounted.").format(
+                        fstype=fs.fstype))
         else:
-            title = "Cannot delete {}".format(obj.desc())
-            lines = [
-                _("Cannot delete {} because {}").format(obj.label, reason)]
+            lines.append(_("It is not formatted or mounted."))
         delete_btn = danger_btn(label=_("Delete"), on_press=self.confirm)
-        if not delete_ok:
-            delete_btn = WidgetDisable(
-                Color.info_minor(
-                    delete_btn.original_widget))
         widgets = [
             Text("\n".join(lines)),
             Text(""),
@@ -166,9 +63,7 @@ class ConfirmDeleteStretchy(Stretchy):
         super().__init__(title, widgets, 0, 2)
 
     def confirm(self, sender=None):
-        for desc, func in self.delete_funcs:
-            log.debug("executing delete_func %s", desc)
-            func()
+        getattr(self.parent.controller, 'delete_' + self.obj.type)(self.obj)
         self.parent.refresh_model_inputs()
         self.parent.remove_overlay()
 

--- a/subiquity/ui/views/filesystem/filesystem.py
+++ b/subiquity/ui/views/filesystem/filesystem.py
@@ -40,6 +40,7 @@ from subiquitycore.ui.buttons import (
     danger_btn,
     done_btn,
     menu_btn,
+    other_btn,
     reset_btn,
     )
 from subiquitycore.ui.container import (
@@ -67,7 +68,7 @@ from subiquity.models.filesystem import (
     humanize_size,
     )
 
-from .delete import can_delete, ConfirmDeleteStretchy
+from .delete import ConfirmDeleteStretchy
 from .disk_info import DiskInfoStretchy
 from .partition import PartitionStretchy, FormatEntireStretchy
 from .raid import RaidStretchy
@@ -257,6 +258,35 @@ def _stretchy_shower(cls):
     return impl
 
 
+class WhyNotStretchy(Stretchy):
+
+    def __init__(self, parent, obj, action, whynot):
+        self.parent = parent
+        self.obj = obj
+
+        title = "Cannot {action} {type}".format(
+            action=_(action.value).lower(),
+            type=obj.desc())
+        widgets = [
+            Text(whynot),
+            Text(""),
+            button_pile([
+                other_btn(label=_("Close"), on_press=self.close),
+                ]),
+        ]
+        super().__init__(title, widgets, 0, 2)
+
+    def close(self, sender=None):
+        self.parent.remove_overlay()
+
+
+def _whynot_shower(view, action, whynot):
+    def impl(obj):
+        view.show_stretchy_overlay(WhyNotStretchy(view, obj, action, whynot))
+    impl.opens_dialog = True
+    return impl
+
+
 class DeviceList(WidgetWrap):
 
     def __init__(self, parent, show_available):
@@ -293,33 +323,31 @@ class DeviceList(WidgetWrap):
     _raid_FORMAT = _disk_FORMAT
     _raid_DELETE = _partition_DELETE
 
-    def _action(self, sender, action, device):
-        log.debug('_action %s %s', action, device)
-        meth_name = '_{}_{}'.format(device.type, action.name)
-        getattr(self, meth_name)(device)
+    def _action(self, sender, value, device):
+        action, meth = value
+        log.debug('_action %s %s', action, device.id)
+        meth(device)
 
     def _action_menu_for_device(self, device):
         device_actions = []
-        can_delete_device = can_delete(device)[0]
         for action in device.supported_actions:
-            if action == DeviceAction.DELETE:
+            label = _(action.value)
+            enabled, whynot = device.action_possible(action)
+            if whynot:
+                assert not enabled
                 enabled = True
-                if can_delete_device:
-                    label = Color.danger_button(
-                        ActionMenuOpenButton(_("Delete")))
-                else:
-                    label = _("Delete *")
+                label += " *"
+                meth = _whynot_shower(self.parent, action, whynot)
             else:
-                label = _(action.value)
-                enabled = device.action_possible(action)
-            meth_name = '_{}_{}'.format(device.type, action.name)
-            meth = getattr(self, meth_name)
-            opens_dialog = getattr(meth, 'opens_dialog', False)
+                meth_name = '_{}_{}'.format(device.type, action.name)
+                meth = getattr(self, meth_name)
+            if not whynot and action == DeviceAction.DELETE:
+                label = Color.danger_button(ActionMenuOpenButton(label))
             device_actions.append(Action(
                 label=label,
                 enabled=enabled,
-                value=action,
-                opens_dialog=opens_dialog))
+                value=(action, meth),
+                opens_dialog=getattr(meth, 'opens_dialog', False)))
         menu = ActionMenu(
             device_actions, "\N{BLACK RIGHT-POINTING SMALL TRIANGLE}")
         connect_signal(menu, 'action', self._action, device)

--- a/subiquity/ui/views/filesystem/filesystem.py
+++ b/subiquity/ui/views/filesystem/filesystem.py
@@ -310,17 +310,29 @@ class DeviceList(WidgetWrap):
     _disk_PARTITION = _stretchy_shower(PartitionStretchy)
     _disk_FORMAT = _stretchy_shower(FormatEntireStretchy)
 
+    def _disk_REMOVE(self, disk):
+        cd = disk.constructed_device()
+        assert cd.type == "raid"
+        if disk in cd.devices:
+            cd.devices.remove(disk)
+        else:
+            cd.spare_devices.remove(disk)
+        disk._constructed_device = None
+        self.parent.refresh_model_inputs()
+
     def _disk_MAKE_BOOT(self, disk):
         self.parent.controller.make_boot_disk(disk)
         self.parent.refresh_model_inputs()
 
     _partition_EDIT = _stretchy_shower(
         lambda parent, part: PartitionStretchy(parent, part.device, part))
+    _partition_REMOVE = _disk_REMOVE
     _partition_DELETE = _stretchy_shower(ConfirmDeleteStretchy)
 
     _raid_EDIT = _stretchy_shower(RaidStretchy)
     _raid_PARTITION = _disk_PARTITION
     _raid_FORMAT = _disk_FORMAT
+    _raid_REMOVE = _disk_REMOVE
     _raid_DELETE = _partition_DELETE
 
     def _action(self, sender, value, device):

--- a/subiquity/ui/views/filesystem/raid.py
+++ b/subiquity/ui/views/filesystem/raid.py
@@ -305,15 +305,6 @@ class RaidStretchy(Stretchy):
 
         rows = form.as_rows()
 
-        if existing is not None:
-            rows[0:0] = [
-                Text("You cannot save edit to RAIDs just yet."),
-                Text(""),
-                ]
-            self.form.validated = lambda *args: setattr(
-                self.form.done_btn, 'enabled', False)
-            self.form.validated()
-
         super().__init__(
             title,
             [Pile(rows), Text(""), self.form.buttons],


### PR DESCRIPTION
This removes all my clever "can you made this edit to the raid without making some dependent object" code in favour of forbidding edits to devices that are parts of RAIDs (or LVMs, eventually).

It also removes the format/mount options from the create RAID dialog and adds a context menu item to remove a device from a RAID.