### PR TITLE
Finer network refreshes

### DIFF
--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -3,6 +3,7 @@ set -eux
 python3 -m unittest discover
 export SUBIQUITY_REPLAY_TIMESCALE=10
 for answers in examples/answers*.yaml; do
+    rm -f .subiquity/subiquity-curtin-install.conf
     # The --foreground is important to avoid subiquity getting SIGTTOU-ed.
     timeout --foreground 60 sh -c "LANG=C.UTF-8 python3 -m subiquity.cmd.tui --answers $answers --dry-run --machine-config examples/mwhudson.json"
     python3 scripts/validate-yaml.py .subiquity/subiquity-curtin-install.conf

--- a/subiquitycore/models/network.py
+++ b/subiquitycore/models/network.py
@@ -14,6 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import copy
+import enum
 import ipaddress
 import logging
 from socket import AF_INET, AF_INET6, if_indextoname
@@ -29,6 +30,15 @@ log = logging.getLogger('subiquitycore.models.network')
 
 def ip_version(ip):
     return ipaddress.ip_interface(ip).version
+
+
+class NetDevAction(enum.Enum):
+    INFO = _("Info")
+    EDIT_WLAN = _("Edit Wifi")
+    EDIT_IPV4 = _("Edit IPv4")
+    EDIT_IPV6 = _("Edit IPv6")
+    ADD_VLAN = _("Add a VLAN tag")
+    DELETE = _("Delete")
 
 
 class Networkdev:
@@ -56,6 +66,16 @@ class Networkdev:
             return {self.name: self._configuration}
         else:
             return {}
+
+    def supports_action(self, action):
+        return getattr(self, "_supports_" + action.name)
+
+    _supports_INFO = True
+    _supports_EDIT_WLAN = property(lambda self: self.type == "wlan")
+    _supports_EDIT_IPV4 = True
+    _supports_EDIT_IPV6 = True
+    _supports_ADD_VLAN = property(lambda self: self.type != "vlan")
+    _supports_DELETE = property(lambda self: self.is_virtual)
 
     @property
     def configured(self):

--- a/subiquitycore/models/network.py
+++ b/subiquitycore/models/network.py
@@ -374,6 +374,7 @@ class NetworkModel(object):
         netdev = Networkdev(link, config)
         self.devices[ifindex] = netdev
         self.devices_by_name[link.name] = netdev
+        return netdev
 
     def update_link(self, ifindex):
         # This is pretty edge-casey as the fact that we wait for the
@@ -387,13 +388,15 @@ class NetworkModel(object):
                 log.debug("link renamed %s -> %s", k, dev.name)
                 del self.devices_by_name[k]
                 self.devices_by_name[dev.name] = dev
-                return
+                break
+        return dev
 
     def del_link(self, ifindex):
         if ifindex in self.devices:
             dev = self.devices[ifindex]
             del self.devices_by_name[dev.name]
             del self.devices[ifindex]
+            return dev
 
     def get_all_netdevs(self):
         return [v for k, v in sorted(self.devices_by_name.items())]

--- a/subiquitycore/ui/table.py
+++ b/subiquitycore/ui/table.py
@@ -371,11 +371,13 @@ class TablePile(AbstractTable):
         return Pile([('pack', r) for r in rows])
 
     def insert_rows(self, index, new_rows):
+        self._last_size = None
         self.table_rows[index:index] = new_rows
         self._w.contents[index:index] = [
             (urwid.Padding(w), self._w.options('pack')) for w in new_rows]
 
     def remove_rows(self, start, end):
+        self._last_size = None
         refocus = self._w.focus_position >= (len(self._w.contents) - (end - start))
         del self.table_rows[start:end]
         del self._w.contents[start:end]

--- a/subiquitycore/ui/table.py
+++ b/subiquitycore/ui/table.py
@@ -378,12 +378,20 @@ class TablePile(AbstractTable):
 
     def remove_rows(self, start, end):
         self._last_size = None
-        refocus = self._w.focus_position >= (len(self._w.contents) - (end - start))
+        # MonitoredFocusList clamps the focus position to the new
+        # length of the list when you remove elements but it doesn't
+        # check that that the element it moves the focus to is
+        # selectable...
+        new_length = len(self._w.contents) - (end - start)
+        refocus = self._w.focus_position >= new_length
         del self.table_rows[start:end]
         del self._w.contents[start:end]
         log.debug("%s", (self._w.focus_position, len(self._w.contents)))
         if refocus:
             self._select_last_selectable()
+        else:
+            while not self._w.focus.selectable():
+                self._w.focus_position += 1
 
     def set_contents(self, rows):
         """Update the list of rows. """

--- a/subiquitycore/ui/table.py
+++ b/subiquitycore/ui/table.py
@@ -370,6 +370,19 @@ class TablePile(AbstractTable):
     def _make(self, rows):
         return Pile([('pack', r) for r in rows])
 
+    def insert_rows(self, index, new_rows):
+        self.table_rows[index:index] = new_rows
+        self._w.contents[index:index] = [
+            (urwid.Padding(w), self._w.options('pack')) for w in new_rows]
+
+    def remove_rows(self, start, end):
+        refocus = self._w.focus_position >= (len(self._w.contents) - (end - start))
+        del self.table_rows[start:end]
+        del self._w.contents[start:end]
+        log.debug("%s", (self._w.focus_position, len(self._w.contents)))
+        if refocus:
+            self._select_last_selectable()
+
     def set_contents(self, rows):
         """Update the list of rows. """
         self._last_size = None

--- a/subiquitycore/ui/views/network.py
+++ b/subiquitycore/ui/views/network.py
@@ -241,7 +241,11 @@ class NetworkView(BaseView):
         self.dev_to_row[dev] = row.base_widget
         self.cur_netdevs[netdev_i:netdev_i] = [dev]
         rows.append(row)
-        info = " / ".join([dev.hwaddr, dev.vendor, dev.model])
+        if dev.type == "vlan":
+            info = _("VLAN {id} on interface {link}").format(
+                **dev._configuration)
+        else:
+            info = " / ".join([dev.hwaddr, dev.vendor, dev.model])
         rows.append(Color.info_minor(TableRow([
             Text(""),
             (4, Text(info)),

--- a/subiquitycore/ui/views/network_configure_manual_interface.py
+++ b/subiquitycore/ui/views/network_configure_manual_interface.py
@@ -233,7 +233,7 @@ class EditNetworkStretchy(Stretchy):
             self.device.set_dhcp_for_version(self.ip_version, True)
         else:
             pass
-        self.parent.refresh_model_inputs()
+        self.parent.update_link(self.device)
         self.parent.remove_overlay()
 
     def cancel(self, sender=None):

--- a/subiquitycore/ui/views/tests/test_network_configure_manual_interface.py
+++ b/subiquitycore/ui/views/tests/test_network_configure_manual_interface.py
@@ -3,8 +3,7 @@ from unittest import mock
 
 import urwid
 
-from subiquitycore.controllers.network import NetworkController
-from subiquitycore.models.network import Networkdev, NetworkModel
+from subiquitycore.models.network import Networkdev
 from subiquitycore.testing import view_helpers
 from subiquitycore.ui.views.network_configure_manual_interface import (
     EditNetworkStretchy,
@@ -24,15 +23,10 @@ valid_data = {
 class TestNetworkConfigureIPv4InterfaceView(unittest.TestCase):
 
     def make_view(self):
-        model = mock.create_autospec(spec=NetworkModel)
-        controller = mock.create_autospec(spec=NetworkController)
-
         device = mock.create_autospec(spec=Networkdev)
         device.configured_ip_addresses_for_version = lambda v: []
         base_view = BaseView(urwid.Text(""))
-        base_view.model = model
-        base_view.controller = controller
-        base_view.refresh_model_inputs = lambda: None
+        base_view.update_link = lambda device: None
         stretchy = EditNetworkStretchy(base_view, device, 4)
         base_view.show_stretchy_overlay(stretchy)
         stretchy.method_form.method.value = "manual"


### PR DESCRIPTION
The main change in this is that instead of rebuilding the entire view when a netlink change comes in, make a much smaller change to just update the details of the link that has changed. This has the advantage that e.g. if you have a menu open for a nic when DHCP completes, the menu isn't closed.

There is also a certain amount of random cleaning up and refactoring.