### PR TITLE
agetty needs an explicit -i to not to display the /etc/issue file

### DIFF
--- a/debian/console-conf.console-conf@.service
+++ b/debian/console-conf.console-conf@.service
@@ -10,7 +10,7 @@ StartLimitInterval=0
 [Service]
 Environment=PYTHONPATH=/usr/share/subiquity
 ExecStartPre=/bin/systemctl stop getty@%I
-ExecStart=/sbin/agetty -n --noclear -l /usr/share/subiquity/console-conf-wrapper %I $TERM
+ExecStart=/sbin/agetty -i -n --noclear -l /usr/share/subiquity/console-conf-wrapper %I $TERM
 ExecStopPost=/bin/systemctl start getty@%I
 Type=idle
 Restart=always

--- a/debian/console-conf.serial-console-conf@.service
+++ b/debian/console-conf.serial-console-conf@.service
@@ -9,7 +9,7 @@ StartLimitInterval=0
 [Service]
 Environment=PYTHONPATH=/usr/share/subiquity
 ExecStartPre=/bin/systemctl stop serial-getty@%I
-ExecStart=/sbin/agetty -n --keep-baud -l /usr/share/subiquity/console-conf-wrapper --login-options "--serial" 115200,38400,9600 %I $TERM
+ExecStart=/sbin/agetty -i -n --keep-baud -l /usr/share/subiquity/console-conf-wrapper --login-options "--serial" 115200,38400,9600 %I $TERM
 ExecStopPost=/bin/systemctl start serial-getty@%I
 Type=idle
 Restart=always

--- a/debian/subiquity.serial-subiquity@.service
+++ b/debian/subiquity.serial-subiquity@.service
@@ -9,7 +9,7 @@ StartLimitInterval=0
 [Service]
 Environment=PYTHONPATH=/usr/share/subiquity
 ExecStartPre=/bin/systemctl stop serial-getty@%I
-ExecStart=/sbin/agetty -n --keep-baud -l /usr/share/subiquity/subiquity-tui --login-options "--serial" 115200,38400,9600 %I $TERM
+ExecStart=/sbin/agetty -i -n --keep-baud -l /usr/share/subiquity/subiquity-tui --login-options "--serial" 115200,38400,9600 %I $TERM
 ExecStopPost=/bin/systemctl start serial-getty@%I
 Type=idle
 Restart=always

--- a/debian/subiquity.subiquity-debug@.service
+++ b/debian/subiquity.subiquity-debug@.service
@@ -9,7 +9,7 @@ ConditionPathExists=!/run/subiquity/complete
 [Service]
 Environment=PYTHONPATH=/usr/share/subiquity
 ExecStartPre=/bin/systemctl stop getty@%I
-ExecStart=/sbin/agetty -n --noclear -l /usr/share/subiquity/subiquity-debug %I $TERM
+ExecStart=/sbin/agetty -i -n --noclear -l /usr/share/subiquity/subiquity-debug %I $TERM
 ExecStopPost=/bin/systemctl start getty@%I
 Type=idle
 Restart=always

--- a/debian/subiquity.subiquity.service
+++ b/debian/subiquity.subiquity.service
@@ -10,7 +10,7 @@ ConditionPathExists=!/run/subiquity/complete
 Environment=PYTHONPATH=/usr/share/subiquity
 ExecStartPre=/usr/share/subiquity/subiquity-loadkeys
 ExecStartPre=/bin/systemctl stop getty@tty1
-ExecStart=/sbin/agetty -n --noclear -l /usr/share/subiquity/subiquity-tui tty1 $TERM
+ExecStart=/sbin/agetty -i -n --noclear -l /usr/share/subiquity/subiquity-tui tty1 $TERM
 ExecStopPost=/bin/systemctl start getty@tty1
 Type=idle
 Restart=always


### PR DESCRIPTION
Otherwise we get duplicate information (or wrong information), as by principle console-conf and subiquity handle all login-prompt-related printing. This seemed to be the default in the past? Not sure what changed but being more explicit is always good.