### PR TITLE
Remove the Joliet option to support symlinks

### DIFF
--- a/scripts/inject-subiquity-snap.sh
+++ b/scripts/inject-subiquity-snap.sh
@@ -119,7 +119,7 @@ mksquashfs new_installer new_iso/casper/installer.squashfs
 xorriso -as mkisofs -r -checksum_algorithm_iso md5,sha1 \
 	-V Ubuntu\ custom\ amd64 \
 	-o "${NEW_ISO}" \
-	-cache-inodes -J -l \
+	-cache-inodes -l \
 	-b isolinux/isolinux.bin -c isolinux/boot.cat -no-emul-boot \
 	-boot-load-size 4 -boot-info-table \
 	-eltorito-alt-boot -e boot/grub/efi.img -no-emul-boot \


### PR DESCRIPTION
This allows the generated ISO to be used as a cdrom source for apt and quashes the following warnings:

```
libisofs: WARNING : Cannot add /dists/stable to Joliet tree. Symlinks can only be added to a Rock Ridge tree.
libisofs: WARNING : Cannot add /dists/unstable to Joliet tree. Symlinks can only be added to a Rock Ridge tree.
libisofs: WARNING : Cannot add /ubuntu to Joliet tree. Symlinks can only be added to a Rock Ridge tree.
```