### PR TITLE
services: run console-conf after core18.start-snapd.service

### DIFF
--- a/debian/console-conf.console-conf@.service
+++ b/debian/console-conf.console-conf@.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Ubuntu Core Firstboot Configuration %I
 After=systemd-user-sessions.service plymouth-quit-wait.service
-After=rc-local.service
+After=rc-local.service core18.start-snapd.service
 IgnoreOnIsolate=yes
 ConditionPathExists=/dev/tty0
 ConditionPathExists=!/var/lib/console-conf/complete

--- a/debian/console-conf.serial-console-conf@.service
+++ b/debian/console-conf.serial-console-conf@.service
@@ -2,7 +2,7 @@
 Description=Ubuntu Core Firstboot Configuration %I
 BindsTo=dev-%i.device
 After=dev-%i.device systemd-user-sessions.service plymouth-quit-wait.service
-After=rc-local.service
+After=rc-local.service core18.start-snapd.service
 ConditionPathExists=!/var/lib/console-conf/complete
 StartLimitInterval=0
 


### PR DESCRIPTION
On core18 the firstboot seeding happens via the core18.start-snapd
service. This service will do the initial start of snapd when the
system is unseeded. This service will wait until the system is
fully seeded.

We cannot run console-conf before that because it uses the "snap"
command which will not be available before the system is seeded.

Once that has landed https://github.com/snapcore/core18/pull/74
can be reverted (in fact the hooks/200-console-conf-after.chroot
file can be removed entirely).