### PR TITLE
Makefile,console-conf-wrapper: run shellcheck and fix issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,10 @@ ui-view:
 ui-view-serial:
 	(TERM=att4424 PYTHONPATH=$(PYTHONPATH) bin/$(PYTHONSRC)-tui $(DRYRUN) --serial)
 
+shellcheck:
+	echo "Running shellcheck..."
+	shellcheck bin/console-conf-wrapper
+
 lint:
 	echo "Running flake8 lint tests..."
 	python3 /usr/bin/flake8 bin/$(PYTHONSRC)-tui --ignore=F403
@@ -54,7 +58,7 @@ unit:
 	echo "Running unit tests..."
 	nosetests3 $(PYTHONSRC)/tests
 
-check: lint unit
+check: shellcheck lint unit
 
 installer/$(INSTALLIMG): installer/geninstaller installer/runinstaller $(INSTALLER_RESOURCES) probert
 	(cd installer && TOPDIR=$(TOPDIR)/installer ./geninstaller -v -r $(RELEASE) -a $(ARCH) -s $(STREAM) -b $(BOOTLOADER)) 

--- a/bin/console-conf-wrapper
+++ b/bin/console-conf-wrapper
@@ -14,13 +14,13 @@ if [ "$(snap managed)" = "true" ]; then
     # check if we have extrausers that have no password set
     if grep -qE '^[-a-z0-9+.-_]+:x:' /var/lib/extrausers/passwd && ! grep -qE '^[-a-z0-9+.-_]+:\$[0-9]+\$.*:' /var/lib/extrausers/shadow; then
         tty=$(tty)
-        tty=$(echo ${tty#/dev/} | tr '/' '-')
+        tty=$(echo "${tty#/dev/}" | tr '/' '-')
         readargs=()
         filepath="/run/console-conf/login-details-${tty}.txt"
-        if [ ! -f ${filepath} ]; then
+        if [ ! -f "${filepath}" ]; then
             mkdir -p /run/console-conf
             set +e
-            /usr/share/subiquity/console-conf-write-login-details > ${filepath}.tmp
+            /usr/share/subiquity/console-conf-write-login-details > "${filepath}.tmp"
             rval=$?
             set -e
             # A exit code of 2 from console-conf-write-login-details
@@ -29,19 +29,19 @@ if [ "$(snap managed)" = "true" ]; then
             # until the device gets an IP address so we display that
             # but check every 5 seconds if an ip address has appeared.
             if [ $rval -eq 0 ]; then
-                mv ${filepath}.tmp ${filepath}
+                mv "${filepath}.tmp" "${filepath}"
             elif [ $rval -eq 2 ]; then
-                mv ${filepath}.tmp ${filepath}.noip
-                filepath=${filepath}.noip
+                mv "${filepath}.tmp" "${filepath}.noip"
+                filepath="${filepath}.noip"
                 readargs=(-t 5)
             else
                 exit $rval
             fi
         fi
-        cat $filepath
+        cat "$filepath"
         set +e
         while :; do
-            read "${readargs[@]}" REPLY
+            read -r "${readargs[@]}" REPLY
             if [ $? -le 128 ]; then
                 # If we didn't time out, re-display everything.
                 exit 0
@@ -59,5 +59,5 @@ if [ "$(snap managed)" = "true" ]; then
 fi
 
 cat /usr/share/subiquity/console-conf-wait
-read REPLY
+read -r REPLY
 exec console-conf "$@"

--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,8 @@ Build-Depends: bzr,
                python3,
                python3-setuptools,
                python3-yaml,
-               python3-attr
+               python3-attr,
+               shellcheck
 Standards-Version: 3.9.5
 Homepage: https://github.com/CanonicalLtd/subiquity
 X-Python3-Version: >= 3.3


### PR DESCRIPTION
Make shellcheck part of "make check" and ensure that
bin/console-conf-wrapper is shellcheck clean.