### PR TITLE
Fix alignment of narrow views.

### DIFF
--- a/subiquity/controllers/installpath.py
+++ b/subiquity/controllers/installpath.py
@@ -66,7 +66,7 @@ class InstallpathController(BaseController):
             "treat physical servers like virtual machines (instances) "
             "in the cloud. Rather than having to manage each server "
             "individually, MAAS turns your bare metal into an elastic "
-            "cloud-like resource. \n\n"
+            "cloud-like resource.\n"
             "For further details, see https://maas.io/."
             )
         self.ui.set_body(MAASView(self.model, self, title, excerpt))

--- a/subiquity/ui/views/installpath.py
+++ b/subiquity/ui/views/installpath.py
@@ -66,6 +66,7 @@ class InstallpathView(BaseView):
         back = back_btn(_("Back"), on_press=self.cancel)
         super().__init__(screen(
             self._build_choices(), [back],
+            narrow_rows=True,
             focus_buttons=False, excerpt=_(self.excerpt)))
 
     def _build_choices(self):

--- a/subiquitycore/ui/form.py
+++ b/subiquitycore/ui/form.py
@@ -391,10 +391,10 @@ class Form(object, metaclass=MetaForm):
             rows.append(t)
         return rows
 
-    def as_screen(self, focus_buttons=True, excerpt=None):
+    def as_screen(self, focus_buttons=True, excerpt=None, narrow_rows=True):
         return screen(
             self.as_rows(), self.buttons,
-            focus_buttons=focus_buttons, excerpt=excerpt)
+            focus_buttons=focus_buttons, excerpt=excerpt, narrow_rows=narrow_rows)
 
     def validated(self):
         in_error = False

--- a/subiquitycore/ui/utils.py
+++ b/subiquitycore/ui/utils.py
@@ -236,7 +236,7 @@ def screen(rows, buttons, focus_buttons=True, excerpt=None, narrow_rows=False):
     if isinstance(rows, list):
         rows = ListBox(rows)
     if narrow_rows:
-        rows = Padding.center_63(rows)
+        rows = Padding.center_76(rows)
     if buttons is None:
         focus_buttons = False
     elif isinstance(buttons, list):


### PR DESCRIPTION
This does a few things:
- make `narrow_rows` views to be the same width as the progress bar in the footer
- use `narrow_rows` views in more places, i.e. on simple pages generated from a form

This results in welcome, installpath, proxy, mirror screens all have Header/title text/footer have one alignment, and the form/buttons have a second alignment with the progress bar.

But I was not sure, if we actually want to make this fix. Instead maybe we want to ditch narrow-rows views and have everything left-aligned to the title header?

Before: https://asciinema.org/a/N4XwVYlY3H3k6aDGQZBco8ork
After: https://asciinema.org/a/hwSyQxu1PxktZWvQtNWbrPbSD

E.g. pay attention to the changes on the Welcome, Installpath, Mirror, Proxy.

Notice how before some of the screens/forms are either wider or shorter than the progress bar, but now a few of them are just as wide as the progress bar.