### PR TITLE
validate raid and vg/lv names

### DIFF
--- a/subiquity/ui/views/filesystem/raid.py
+++ b/subiquity/ui/views/filesystem/raid.py
@@ -65,8 +65,14 @@ class RaidnameEditor(StringEditor, WantsToKnowFormField):
         if len(ch) == 1 and ch == '/':
             self.bff.in_error = True
             self.bff.show_extra(("info_error",
-                                 _("The character / is not permitted"
-                                   " in this field")))
+                                 _("The character / is not permitted "
+                                   "in the name of a RAID device")))
+            return False
+        elif len(ch) == 1 and ch.isspace():
+            self.bff.in_error = True
+            self.bff.show_extra(("info_error",
+                                 _("Whitespace is not permitted in the "
+                                   "name of a RAID device")))
             return False
         else:
             return super().valid_char(ch)
@@ -97,6 +103,8 @@ class RaidForm(CompoundDiskForm):
         if self.name.value in self.raid_names:
             return _("There is already a RAID named '{}'").format(
                 self.name.value)
+        if self.name.value in ('/dev/md/.', '/dev/md/..'):
+            return _(". and .. are not valid names for RAID devices")
 
     def validate_devices(self):
         log.debug(

--- a/subiquity/ui/views/filesystem/raid.py
+++ b/subiquity/ui/views/filesystem/raid.py
@@ -28,7 +28,6 @@ from subiquitycore.ui.form import (
     ChoiceField,
     ReadOnlyField,
     simple_field,
-    StringField,
     WantsToKnowFormField,
     )
 from subiquitycore.ui.interactive import (
@@ -65,7 +64,7 @@ class RaidnameEditor(StringEditor, WantsToKnowFormField):
         if len(ch) == 1 and ch == '/':
             self.bff.in_error = True
             self.bff.show_extra(("info_error",
-                                 _("The character / is not permitted "
+                                 _("/ is not permitted "
                                    "in the name of a RAID device")))
             return False
         elif len(ch) == 1 and ch.isspace():


### PR DESCRIPTION
For https://bugs.launchpad.net/subiquity/+bug/1786556

Got a bit sidetracked by mdadm's hilarious failures when you try to include spaces in the name of the device...