### PR TITLE
filesystem: whitelist multipath devices.

### DIFF
--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -885,13 +885,18 @@ class FilesystemModel(object):
             if path in currently_mounted:
                 continue
             if data['DEVTYPE'] == 'disk':
-                if data["DEVPATH"].startswith('/devices/virtual'):
+                if (data["DEVPATH"].startswith('/devices/virtual') and
+                        "DM_WWN" not in data):
                     continue
                 if data["MAJOR"] in ("2", "11"):  # serial and cd devices
                     continue
                 if data['attrs'].get('ro') == "1":
                     continue
                 if "ID_CDROM" in data:
+                    continue
+                if "DM_MULTIPATH_DEVICE_PATH" in data:
+                    continue
+                if "DM_PART" in data:
                     continue
                 # log.debug('disk={}\n{}'.format(
                 #    path, json.dumps(data, indent=4, sort_keys=True)))


### PR DESCRIPTION
This does a few things

- blacklists individual paths which are part of a multipath device (i.e. `/dev/sd[a-c]` are neither available in guided or manual partitioning)
- blacklists partitions of a multipath device
- whitelists multipath device itself

https://github.com/CanonicalLtd/probert/pull/44/files sets a nice looking serial for multipath disk, i.e. `mpath-36005076306ffd6b60000000000002405` which is clearly a multipath device, and the long WWID is clearly identifyable as to which one, one is installing things onto.