### PR TITLE
use more of the screen for content when the terminal is narrow

### DIFF
--- a/subiquity/ui/views/filesystem/filesystem.py
+++ b/subiquity/ui/views/filesystem/filesystem.py
@@ -518,7 +518,6 @@ class FilesystemView(BaseView):
         frame = screen(
             self.lb, self._build_buttons(),
             focus_buttons=self.model.can_install())
-        frame.width = ('relative', 95)
         super().__init__(frame)
         self.refresh_model_inputs()
         log.debug('FileSystemView init complete()')

--- a/subiquity/ui/views/filesystem/guided.py
+++ b/subiquity/ui/views/filesystem/guided.py
@@ -131,7 +131,7 @@ class GuidedDiskSelectionView(BaseView):
             TableListBox(rows, spacing=1, colspecs={
                 1: ColSpec(can_shrink=True, min_width=20, rpad=2),
                 2: ColSpec(min_width=9),
-                }),
+                }, align='center'),
             button_pile([cancel]),
             focus_buttons=False,
             excerpt=(

--- a/subiquity/ui/views/filesystem/guided.py
+++ b/subiquity/ui/views/filesystem/guided.py
@@ -25,7 +25,6 @@ from subiquitycore.ui.buttons import (
     cancel_btn,
     ok_btn,
     )
-from subiquitycore.ui.container import ListBox
 from subiquitycore.ui.table import (
     ColSpec,
     TableListBox,
@@ -35,7 +34,6 @@ from subiquitycore.ui.utils import (
     button_pile,
     ClickableIcon,
     Color,
-    Padding,
     screen,
     )
 from subiquitycore.view import BaseView
@@ -70,13 +68,11 @@ class GuidedFilesystemView(BaseView):
             user_arg="lvm")
         manual = ok_btn(_("Manual"), on_press=self.manual)
         back = back_btn(_("Back"), on_press=self.cancel)
-        lb = ListBox([
-            Padding.center_70(Text("")),
-            Padding.center_70(Text(_(text))),
-            Padding.center_70(Text("")),
-            button_pile([direct, lvm, manual, back]),
-            ])
-        super().__init__(lb)
+        super().__init__(screen(
+            rows=[button_pile([direct, lvm, manual, back]), Text("")],
+            buttons=None,
+            focus_buttons=False,
+            excerpt=text))
 
     def manual(self, btn):
         self.controller.manual()

--- a/subiquity/ui/views/installpath.py
+++ b/subiquity/ui/views/installpath.py
@@ -22,10 +22,10 @@ import binascii
 import logging
 import re
 
-from urwid import connect_signal
+from urwid import connect_signal, Text
 
 from subiquitycore.ui.buttons import back_btn, forward_btn
-from subiquitycore.ui.utils import screen
+from subiquitycore.ui.utils import button_pile, screen
 from subiquitycore.view import BaseView
 from subiquitycore.ui.interactive import (
     PasswordEditor,
@@ -65,7 +65,7 @@ class InstallpathView(BaseView):
         self.items = []
         back = back_btn(_("Back"), on_press=self.cancel)
         super().__init__(screen(
-            self._build_choices(), [back],
+            [button_pile(self._build_choices()), Text("")], [back],
             focus_buttons=False, excerpt=_(self.excerpt)))
 
     def _build_choices(self):

--- a/subiquity/ui/views/installprogress.py
+++ b/subiquity/ui/views/installprogress.py
@@ -48,7 +48,7 @@ class ProgressView(BaseView):
                                           on_press=self.view_log)])
         event_body = [
             ('pack', Text("")),
-            ('weight', 1, Padding.center_79(self.event_linebox)),
+            ('weight', 1, Padding.center_79(self.event_linebox, min_width=76)),
             ('pack', Text("")),
             ('pack', self.event_buttons),
             ('pack', Text("")),

--- a/subiquitycore/ui/anchors.py
+++ b/subiquitycore/ui/anchors.py
@@ -58,9 +58,8 @@ class Footer(WidgetWrap):
 
     def __init__(self, message, current, complete):
         if isinstance(message, str):
-            message_widget = Padding.center_79(Text(message))
-        else:
-            message_widget = Padding.center_79(message)
+            message_widget = Text(message)
+        message_widget = Padding.center_79(message_widget, min_width=76)
         progress_bar = Padding.center_60(
             StepsProgressBar(normal='progress_incomplete',
                              complete='progress_complete',

--- a/subiquitycore/ui/anchors.py
+++ b/subiquitycore/ui/anchors.py
@@ -58,8 +58,8 @@ class Footer(WidgetWrap):
 
     def __init__(self, message, current, complete):
         if isinstance(message, str):
-            message_widget = Text(message)
-        message_widget = Padding.center_79(message_widget, min_width=76)
+            message = Text(message)
+        message = Padding.center_79(message, min_width=76)
         progress_bar = Padding.center_60(
             StepsProgressBar(normal='progress_incomplete',
                              complete='progress_complete',
@@ -67,6 +67,6 @@ class Footer(WidgetWrap):
         status = [
             progress_bar,
             Padding.line_break(""),
-            message_widget,
+            message,
         ]
         super().__init__(Color.frame_footer(Pile(status)))

--- a/subiquitycore/ui/anchors.py
+++ b/subiquitycore/ui/anchors.py
@@ -38,7 +38,7 @@ class Header(WidgetWrap):
             Color.frame_header(
                 Pile([
                     Text(""),
-                    Padding.center_79(Text(title)),
+                    Padding.center_79(Text(title), min_width=76),
                     Text(""),
                 ])))
 

--- a/subiquitycore/ui/table.py
+++ b/subiquitycore/ui/table.py
@@ -305,14 +305,14 @@ def _compute_widths_for_size(maxcol, table_rows, colspecs, default_spacing):
 class AbstractTable(WidgetWrap):
     # See the module docstring for docs.
 
-    def __init__(self, rows, colspecs=None, spacing=1):
+    def __init__(self, rows, colspecs=None, spacing=1, align='left'):
         """Create a Table.
 
         `rows` - a list of possibly-decorated TableRows
         `colspecs` - a mapping {column-index:ColSpec}
         'spacing` - how much space to put between cells.
         """
-        self.table_rows = [urwid.Padding(row) for row in rows]
+        self.table_rows = [urwid.Padding(row, align=align) for row in rows]
         if colspecs is None:
             colspecs = {}
         self.colspecs = defaultdict(ColSpec, colspecs)

--- a/subiquitycore/ui/utils.py
+++ b/subiquitycore/ui/utils.py
@@ -260,7 +260,7 @@ def screen(rows, buttons, focus_buttons=True, excerpt=None, narrow_rows=False):
     pile = Pile(excerpt_rows + body)
     if focus_buttons:
         pile.focus_position = len(excerpt_rows) + 3
-    return Padding.center_79(pile)
+    return Padding.center_79(pile, min_width=76)
 
 
 class CursorOverride(WidgetDecoration):

--- a/subiquitycore/ui/views/network.py
+++ b/subiquitycore/ui/views/network.py
@@ -41,7 +41,6 @@ from subiquitycore.ui.buttons import (
     menu_btn,
     )
 from subiquitycore.ui.container import (
-    ListBox,
     Pile,
     WidgetWrap,
     )
@@ -51,7 +50,7 @@ from subiquitycore.ui.utils import (
     button_pile,
     Color,
     make_action_menu_row,
-    Padding,
+    screen,
     )
 from .network_configure_manual_interface import (
     AddVlanStretchy,
@@ -120,24 +119,26 @@ class NetworkView(BaseView):
         bp = button_pile([self._create_bond_btn])
         bp.align = 'left'
 
-        self.listbox = ListBox([self.device_table] + [
+        rows = [
+            self.device_table,
             bp,
-        ])
+        ]
+
+        buttons = button_pile([
+                    done_btn(_("Done"), on_press=self.done),
+                    back_btn(_("Back"), on_press=self.cancel),
+                    ])
         self.bottom = Pile([
-                Text(""),
-                self._build_buttons(),
-                Text(""),
-                ])
+            ('pack', buttons),
+        ])
+
         self.error_showing = False
 
-        self.frame = Pile([
-            ('pack', Text("")),
-            ('pack', Padding.center_79(Text(_(self.excerpt)))),
-            ('pack', Text("")),
-            Padding.center_90(self.listbox),
-            ('pack', self.bottom)])
-        self.frame.set_focus(self.bottom)
-        super().__init__(self.frame)
+        super().__init__(screen(
+            rows=rows,
+            buttons=self.bottom,
+            focus_buttons=True,
+            excerpt=self.excerpt))
 
     def _build_buttons(self):
         back = back_btn(_("Back"), on_press=self.cancel)
@@ -291,8 +292,8 @@ class NetworkView(BaseView):
     def show_network_error(self, action, info=None):
         self.error_showing = True
         self.bottom.contents[0:0] = [
-            (Text(""), self.bottom.options()),
             (Color.info_error(self.error), self.bottom.options()),
+            (Text(""), self.bottom.options()),
             ]
         if action == 'stop-networkd':
             exc = info[0]


### PR DESCRIPTION
I realized that "Padding.center_79(..., min_width=76)" does what I always wanted: it uses most of the available width when the terminal is 80 columns wide (all but two columns on either side) but only uses 80% of the width when the terminal is wider. I really wanted this for the network and filesystem views but I've changed all views to this because consistency is a nice thing.

Video at https://asciinema.org/a/JYQb2QEQ5oeonnOnXQHbVWwCN 
