### PR TITLE
reorganize how network/proxy changes are handled

### DIFF
--- a/subiquity/core.py
+++ b/subiquity/core.py
@@ -67,7 +67,11 @@ class Subiquity(Application):
         signal = self.common['signal']
         signal.connect_signals([
             ('network-proxy-set', self._proxy_set),
+            ('network-change', self._network_change),
             ])
+
+    def _network_change(self):
+        self.common['signal'].emit_signal('snapd-network-change')
 
     def _proxy_set(self):
         proxy_model = self.common['base_model'].proxy

--- a/subiquity/snapd.py
+++ b/subiquity/snapd.py
@@ -29,6 +29,8 @@ import requests_unixsocket
 
 log = logging.getLogger('subiquity.snapd')
 
+# Every method in this module blocks. Do not call them from the main thread!
+
 
 class SnapdConnection:
     def __init__(self, root, sock):

--- a/subiquitycore/controller.py
+++ b/subiquitycore/controller.py
@@ -48,6 +48,9 @@ class BaseController(ABC):
             signals.append((sig, getattr(self, cb)))
         self.signal.connect_signals(signals)
 
+    def start(self):
+        pass
+
     @abstractmethod
     def cancel(self):
         pass

--- a/subiquitycore/controller.py
+++ b/subiquitycore/controller.py
@@ -16,7 +16,6 @@
 
 from abc import ABC, abstractmethod
 import logging
-import os
 
 log = logging.getLogger("subiquitycore.controller")
 
@@ -38,6 +37,7 @@ class BaseController(ABC):
         self.all_answers = common['answers']
         self.input_filter = common['input_filter']
         self.scale_factor = common['scale_factor']
+        self.run_in_bg = common['run_in_bg']
         if 'snapd_connection' in common:
             self.snapd_connection = common['snapd_connection']
 
@@ -47,24 +47,6 @@ class BaseController(ABC):
         for sig, cb in self.signals:
             signals.append((sig, getattr(self, cb)))
         self.signal.connect_signals(signals)
-
-    def run_in_bg(self, func, callback):
-        """Run func() in a thread and call callback on UI thread.
-
-        callback will be passed a concurrent.futures.Future containing
-        the result of func(). The result of callback is discarded. An
-        exception will crash the process so be careful!
-        """
-        fut = self.pool.submit(func)
-
-        def in_main_thread(ignored):
-            callback(fut)
-
-        pipe = self.loop.watch_pipe(in_main_thread)
-
-        def in_random_thread(ignored):
-            os.write(pipe, b'x')
-        fut.add_done_callback(in_random_thread)
 
     @abstractmethod
     def cancel(self):

--- a/subiquitycore/controllers/network.py
+++ b/subiquitycore/controllers/network.py
@@ -92,6 +92,7 @@ class WaitForDefaultRouteTask(CancelableTask):
         return 'WaitForDefaultRouteTask(%r)' % (self.timeout,)
 
     def got_route(self):
+        self.event_receiver.remove_default_route_waiter(self.got_route)
         os.write(self.success_w, b'x')
 
     def start(self):
@@ -124,7 +125,7 @@ class SubiquityNetworkEventReceiver(NetworkEventReceiver):
     def __init__(self, model):
         self.model = model
         self.view = None
-        self.default_route_waiter = None
+        self.default_route_waiters = []
         self.default_routes = set()
 
     def new_link(self, ifindex, link):
@@ -153,18 +154,20 @@ class SubiquityNetworkEventReceiver(NetworkEventReceiver):
         ifindex = data['ifindex']
         if action == "NEW" or action == "CHANGE":
             self.default_routes.add(ifindex)
-            if self.default_route_waiter:
-                self.default_route_waiter()
-                self.default_route_waiter = None
+            for waiter in self.default_route_waiters:
+                waiter()
         elif action == "DEL" and ifindex in self.default_routes:
             self.default_routes.remove(ifindex)
         log.debug('default routes %s', self.default_routes)
 
     def add_default_route_waiter(self, waiter):
+        self.default_route_waiters.append(waiter)
         if self.default_routes:
             waiter()
-        else:
-            self.default_route_waiter = waiter
+
+    def remove_default_route_waiter(self, waiter):
+        if waiter in self.default_route_waiters:
+            self.default_route_waiters.remove(waiter)
 
 
 default_netplan = '''
@@ -215,7 +218,11 @@ class NetworkController(BaseController, TaskWatcher):
         self.model.parse_netplan_configs(self.root)
 
         self.network_event_receiver = SubiquityNetworkEventReceiver(self.model)
+        self.network_event_receiver.add_default_route_waiter(self.got_route)
         self._done_by_action = False
+
+    def got_route(self):
+        self.signal.emit_signal('network-change')
 
     def start(self):
         self._observer_handles = []
@@ -435,6 +442,5 @@ class NetworkController(BaseController, TaskWatcher):
             self.network_finish(self.model.render())
 
     def tasks_finished(self):
-        self.signal.emit_signal('network-config-written', self.netplan_path)
         self.loop.set_alarm_in(
             0.0, lambda loop, ud: self.signal.emit_signal('next-screen'))

--- a/subiquitycore/controllers/network.py
+++ b/subiquitycore/controllers/network.py
@@ -215,11 +215,13 @@ class NetworkController(BaseController, TaskWatcher):
         self.model.parse_netplan_configs(self.root)
 
         self.network_event_receiver = SubiquityNetworkEventReceiver(self.model)
+        self._done_by_action = False
+
+    def start(self):
         self._observer_handles = []
         self.observer, self._observer_fds = (
             self.prober.probe_network(self.network_event_receiver))
         self.start_watching()
-        self._done_by_action = False
 
     def stop_watching(self):
         for handle in self._observer_handles:

--- a/subiquitycore/core.py
+++ b/subiquitycore/core.py
@@ -511,6 +511,10 @@ class Application:
             self.common['loop'].set_alarm_in(
                 0.05, select_initial_screen, initial_controller_index)
             self._connect_base_signals()
+
+            for k in self.controllers:
+                self.common['controllers'][k].start()
+
             self.common['loop'].run()
         except Exception:
             log.exception("Exception in controller.run():")


### PR DESCRIPTION
Before the snap refresh stuff, the only thing that talked to the network really was the snap list. I pulled the code to talk to snapd itself out into a separate module already but I didn't pull out the code that tried again when a proxy was configured or the network configuration was changed. So I did that. I also changed things slightly so that the snap list only starts talking to snapd when a default route is noticed -- including the common case where a default route is present at startup (this will make it easier I think to add geoip lookups to suggest a mirror, as well as the snap refresh checks).