### PR TITLE
subiquity self-refresh

### DIFF
--- a/examples/answers-bond.yaml
+++ b/examples/answers-bond.yaml
@@ -1,5 +1,7 @@
 Welcome:
   lang: en_US
+Refresh:
+  update: no
 Keyboard:
   layout: us
 Installpath:

--- a/examples/answers-guided-lvm.yaml
+++ b/examples/answers-guided-lvm.yaml
@@ -1,5 +1,7 @@
 Welcome:
   lang: en_US
+Refresh:
+  update: no
 Keyboard:
   layout: us
 Installpath:

--- a/examples/answers-lvm-dmcrypt.yaml
+++ b/examples/answers-lvm-dmcrypt.yaml
@@ -1,5 +1,7 @@
 Welcome:
   lang: en_US
+Refresh:
+  update: no
 Keyboard:
   layout: us
 Installpath:

--- a/examples/answers-lvm.yaml
+++ b/examples/answers-lvm.yaml
@@ -1,5 +1,7 @@
 Welcome:
   lang: en_US
+Refresh:
+  update: no
 Keyboard:
   layout: us
 Installpath:

--- a/examples/answers-raid-lvm.yaml
+++ b/examples/answers-raid-lvm.yaml
@@ -1,5 +1,7 @@
 Welcome:
   lang: en_US
+Refresh:
+  update: no
 Keyboard:
   layout: us
 Installpath:

--- a/examples/answers-raid.yaml
+++ b/examples/answers-raid.yaml
@@ -1,5 +1,7 @@
 Welcome:
   lang: en_US
+Refresh:
+  update: no
 Keyboard:
   layout: us
 Installpath:

--- a/examples/answers-swap.yaml
+++ b/examples/answers-swap.yaml
@@ -1,5 +1,7 @@
 Welcome:
   lang: en_US
+Refresh:
+  update: no
 Keyboard:
   layout: us
 Installpath:

--- a/examples/answers.yaml
+++ b/examples/answers.yaml
@@ -1,5 +1,7 @@
 Welcome:
   lang: en_US
+Refresh:
+  update: yes
 Keyboard:
   layout: us
 Installpath:

--- a/examples/snaps/v2-changes-7/0000.json
+++ b/examples/snaps/v2-changes-7/0000.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Do",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Do",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0001.json
+++ b/examples/snaps/v2-changes-7/0001.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0002.json
+++ b/examples/snaps/v2-changes-7/0002.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0003.json
+++ b/examples/snaps/v2-changes-7/0003.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0004.json
+++ b/examples/snaps/v2-changes-7/0004.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0005.json
+++ b/examples/snaps/v2-changes-7/0005.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0006.json
+++ b/examples/snaps/v2-changes-7/0006.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0007.json
+++ b/examples/snaps/v2-changes-7/0007.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0008.json
+++ b/examples/snaps/v2-changes-7/0008.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0009.json
+++ b/examples/snaps/v2-changes-7/0009.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0010.json
+++ b/examples/snaps/v2-changes-7/0010.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0011.json
+++ b/examples/snaps/v2-changes-7/0011.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0012.json
+++ b/examples/snaps/v2-changes-7/0012.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0013.json
+++ b/examples/snaps/v2-changes-7/0013.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0014.json
+++ b/examples/snaps/v2-changes-7/0014.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0015.json
+++ b/examples/snaps/v2-changes-7/0015.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0016.json
+++ b/examples/snaps/v2-changes-7/0016.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0017.json
+++ b/examples/snaps/v2-changes-7/0017.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0018.json
+++ b/examples/snaps/v2-changes-7/0018.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0019.json
+++ b/examples/snaps/v2-changes-7/0019.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0020.json
+++ b/examples/snaps/v2-changes-7/0020.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0021.json
+++ b/examples/snaps/v2-changes-7/0021.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0022.json
+++ b/examples/snaps/v2-changes-7/0022.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0023.json
+++ b/examples/snaps/v2-changes-7/0023.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0024.json
+++ b/examples/snaps/v2-changes-7/0024.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0025.json
+++ b/examples/snaps/v2-changes-7/0025.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0026.json
+++ b/examples/snaps/v2-changes-7/0026.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0027.json
+++ b/examples/snaps/v2-changes-7/0027.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0028.json
+++ b/examples/snaps/v2-changes-7/0028.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0029.json
+++ b/examples/snaps/v2-changes-7/0029.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0030.json
+++ b/examples/snaps/v2-changes-7/0030.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0031.json
+++ b/examples/snaps/v2-changes-7/0031.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0032.json
+++ b/examples/snaps/v2-changes-7/0032.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0033.json
+++ b/examples/snaps/v2-changes-7/0033.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0034.json
+++ b/examples/snaps/v2-changes-7/0034.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0035.json
+++ b/examples/snaps/v2-changes-7/0035.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0036.json
+++ b/examples/snaps/v2-changes-7/0036.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0037.json
+++ b/examples/snaps/v2-changes-7/0037.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0038.json
+++ b/examples/snaps/v2-changes-7/0038.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0039.json
+++ b/examples/snaps/v2-changes-7/0039.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0040.json
+++ b/examples/snaps/v2-changes-7/0040.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0041.json
+++ b/examples/snaps/v2-changes-7/0041.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0042.json
+++ b/examples/snaps/v2-changes-7/0042.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0043.json
+++ b/examples/snaps/v2-changes-7/0043.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0044.json
+++ b/examples/snaps/v2-changes-7/0044.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0045.json
+++ b/examples/snaps/v2-changes-7/0045.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0046.json
+++ b/examples/snaps/v2-changes-7/0046.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0047.json
+++ b/examples/snaps/v2-changes-7/0047.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0048.json
+++ b/examples/snaps/v2-changes-7/0048.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0049.json
+++ b/examples/snaps/v2-changes-7/0049.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0050.json
+++ b/examples/snaps/v2-changes-7/0050.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0051.json
+++ b/examples/snaps/v2-changes-7/0051.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0052.json
+++ b/examples/snaps/v2-changes-7/0052.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0053.json
+++ b/examples/snaps/v2-changes-7/0053.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0054.json
+++ b/examples/snaps/v2-changes-7/0054.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0055.json
+++ b/examples/snaps/v2-changes-7/0055.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0056.json
+++ b/examples/snaps/v2-changes-7/0056.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0057.json
+++ b/examples/snaps/v2-changes-7/0057.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0058.json
+++ b/examples/snaps/v2-changes-7/0058.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0059.json
+++ b/examples/snaps/v2-changes-7/0059.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0060.json
+++ b/examples/snaps/v2-changes-7/0060.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 16384,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0061.json
+++ b/examples/snaps/v2-changes-7/0061.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 131027,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0062.json
+++ b/examples/snaps/v2-changes-7/0062.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 131027,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0063.json
+++ b/examples/snaps/v2-changes-7/0063.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 327500,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0064.json
+++ b/examples/snaps/v2-changes-7/0064.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 327500,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0065.json
+++ b/examples/snaps/v2-changes-7/0065.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 690864,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0066.json
+++ b/examples/snaps/v2-changes-7/0066.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 690864,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0067.json
+++ b/examples/snaps/v2-changes-7/0067.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 1198498,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0068.json
+++ b/examples/snaps/v2-changes-7/0068.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 1198498,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0069.json
+++ b/examples/snaps/v2-changes-7/0069.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 1198498,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0070.json
+++ b/examples/snaps/v2-changes-7/0070.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 1198498,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0071.json
+++ b/examples/snaps/v2-changes-7/0071.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 1198498,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0072.json
+++ b/examples/snaps/v2-changes-7/0072.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 1198498,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0073.json
+++ b/examples/snaps/v2-changes-7/0073.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 1640596,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0074.json
+++ b/examples/snaps/v2-changes-7/0074.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 2243043,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0075.json
+++ b/examples/snaps/v2-changes-7/0075.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 3291034,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0076.json
+++ b/examples/snaps/v2-changes-7/0076.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 3958929,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0077.json
+++ b/examples/snaps/v2-changes-7/0077.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 5507400,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0078.json
+++ b/examples/snaps/v2-changes-7/0078.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 5507400,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0079.json
+++ b/examples/snaps/v2-changes-7/0079.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 7530866,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0080.json
+++ b/examples/snaps/v2-changes-7/0080.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 8284215,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0081.json
+++ b/examples/snaps/v2-changes-7/0081.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 8595736,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0082.json
+++ b/examples/snaps/v2-changes-7/0082.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 8595736,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0083.json
+++ b/examples/snaps/v2-changes-7/0083.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 9529534,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0084.json
+++ b/examples/snaps/v2-changes-7/0084.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 11217176,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0085.json
+++ b/examples/snaps/v2-changes-7/0085.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 11889010,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0086.json
+++ b/examples/snaps/v2-changes-7/0086.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 11889010,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0087.json
+++ b/examples/snaps/v2-changes-7/0087.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 12642269,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0088.json
+++ b/examples/snaps/v2-changes-7/0088.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 13625669,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0089.json
+++ b/examples/snaps/v2-changes-7/0089.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 14657321,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0090.json
+++ b/examples/snaps/v2-changes-7/0090.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 15329425,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0091.json
+++ b/examples/snaps/v2-changes-7/0091.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 15460407,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0092.json
+++ b/examples/snaps/v2-changes-7/0092.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 17147734,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0093.json
+++ b/examples/snaps/v2-changes-7/0093.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 18229393,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0094.json
+++ b/examples/snaps/v2-changes-7/0094.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 18475018,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0095.json
+++ b/examples/snaps/v2-changes-7/0095.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 19572881,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0096.json
+++ b/examples/snaps/v2-changes-7/0096.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 19851229,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0097.json
+++ b/examples/snaps/v2-changes-7/0097.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 21014403,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0098.json
+++ b/examples/snaps/v2-changes-7/0098.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 21702486,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0099.json
+++ b/examples/snaps/v2-changes-7/0099.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 22522226,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0100.json
+++ b/examples/snaps/v2-changes-7/0100.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 23127804,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0101.json
+++ b/examples/snaps/v2-changes-7/0101.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 23931160,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0102.json
+++ b/examples/snaps/v2-changes-7/0102.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 24701073,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0103.json
+++ b/examples/snaps/v2-changes-7/0103.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 25372862,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0104.json
+++ b/examples/snaps/v2-changes-7/0104.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 26536216,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0105.json
+++ b/examples/snaps/v2-changes-7/0105.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 26814564,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0106.json
+++ b/examples/snaps/v2-changes-7/0106.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 27977918,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0107.json
+++ b/examples/snaps/v2-changes-7/0107.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 28289034,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0108.json
+++ b/examples/snaps/v2-changes-7/0108.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 29534218,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0109.json
+++ b/examples/snaps/v2-changes-7/0109.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 29976586,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0110.json
+++ b/examples/snaps/v2-changes-7/0110.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 30271588,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0111.json
+++ b/examples/snaps/v2-changes-7/0111.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 30435338,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0112.json
+++ b/examples/snaps/v2-changes-7/0112.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 32351546,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0113.json
+++ b/examples/snaps/v2-changes-7/0113.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 33220708,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0114.json
+++ b/examples/snaps/v2-changes-7/0114.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 33400842,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0115.json
+++ b/examples/snaps/v2-changes-7/0115.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 34285533,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0116.json
+++ b/examples/snaps/v2-changes-7/0116.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 34482276,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0117.json
+++ b/examples/snaps/v2-changes-7/0117.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 35367237,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0118.json
+++ b/examples/snaps/v2-changes-7/0118.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 35759733,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0119.json
+++ b/examples/snaps/v2-changes-7/0119.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 36644109,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0120.json
+++ b/examples/snaps/v2-changes-7/0120.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 37316753,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0121.json
+++ b/examples/snaps/v2-changes-7/0121.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 37759391,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0122.json
+++ b/examples/snaps/v2-changes-7/0122.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 38675905,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0123.json
+++ b/examples/snaps/v2-changes-7/0123.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 38905821,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0124.json
+++ b/examples/snaps/v2-changes-7/0124.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 39839709,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0125.json
+++ b/examples/snaps/v2-changes-7/0125.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 40035957,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0126.json
+++ b/examples/snaps/v2-changes-7/0126.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 40986679,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0127.json
+++ b/examples/snaps/v2-changes-7/0127.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 41396459,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0128.json
+++ b/examples/snaps/v2-changes-7/0128.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 42198825,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0129.json
+++ b/examples/snaps/v2-changes-7/0129.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 42673691,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0130.json
+++ b/examples/snaps/v2-changes-7/0130.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 43526424,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0131.json
+++ b/examples/snaps/v2-changes-7/0131.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 44493215,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0132.json
+++ b/examples/snaps/v2-changes-7/0132.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 44706117,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0133.json
+++ b/examples/snaps/v2-changes-7/0133.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 45689022,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0134.json
+++ b/examples/snaps/v2-changes-7/0134.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 45918263,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0135.json
+++ b/examples/snaps/v2-changes-7/0135.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 46917147,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0136.json
+++ b/examples/snaps/v2-changes-7/0136.json
@@ -1,0 +1,256 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "download-snap",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 47359245,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Do",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0137.json
+++ b/examples/snaps/v2-changes-7/0137.json
@@ -1,0 +1,257 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Done",
+        "kind": "download-snap",
+        "ready-time": "2019-03-04T23:48:43.119713092Z",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 47489024,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0138.json
+++ b/examples/snaps/v2-changes-7/0138.json
@@ -1,0 +1,257 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Done",
+        "kind": "download-snap",
+        "ready-time": "2019-03-04T23:48:43.119713092Z",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 47489024,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0139.json
+++ b/examples/snaps/v2-changes-7/0139.json
@@ -1,0 +1,257 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Done",
+        "kind": "download-snap",
+        "ready-time": "2019-03-04T23:48:43.119713092Z",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 47489024,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0140.json
+++ b/examples/snaps/v2-changes-7/0140.json
@@ -1,0 +1,257 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Done",
+        "kind": "download-snap",
+        "ready-time": "2019-03-04T23:48:43.119713092Z",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 47489024,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0141.json
+++ b/examples/snaps/v2-changes-7/0141.json
@@ -1,0 +1,257 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Done",
+        "kind": "download-snap",
+        "ready-time": "2019-03-04T23:48:43.119713092Z",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 47489024,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0142.json
+++ b/examples/snaps/v2-changes-7/0142.json
@@ -1,0 +1,257 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Done",
+        "kind": "download-snap",
+        "ready-time": "2019-03-04T23:48:43.119713092Z",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 47489024,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0143.json
+++ b/examples/snaps/v2-changes-7/0143.json
@@ -1,0 +1,257 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Done",
+        "kind": "download-snap",
+        "ready-time": "2019-03-04T23:48:43.119713092Z",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 47489024,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0144.json
+++ b/examples/snaps/v2-changes-7/0144.json
@@ -1,0 +1,257 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Done",
+        "kind": "download-snap",
+        "ready-time": "2019-03-04T23:48:43.119713092Z",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 47489024,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0145.json
+++ b/examples/snaps/v2-changes-7/0145.json
@@ -1,0 +1,257 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Done",
+        "kind": "download-snap",
+        "ready-time": "2019-03-04T23:48:43.119713092Z",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 47489024,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "validate-snap",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Do",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0146.json
+++ b/examples/snaps/v2-changes-7/0146.json
@@ -1,0 +1,258 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Done",
+        "kind": "download-snap",
+        "ready-time": "2019-03-04T23:48:43.119713092Z",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 47489024,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Done",
+        "kind": "validate-snap",
+        "ready-time": "2019-03-04T23:48:44.334767875Z",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0147.json
+++ b/examples/snaps/v2-changes-7/0147.json
@@ -1,0 +1,258 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Done",
+        "kind": "download-snap",
+        "ready-time": "2019-03-04T23:48:43.119713092Z",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 47489024,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Done",
+        "kind": "validate-snap",
+        "ready-time": "2019-03-04T23:48:44.334767875Z",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0148.json
+++ b/examples/snaps/v2-changes-7/0148.json
@@ -1,0 +1,258 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Done",
+        "kind": "download-snap",
+        "ready-time": "2019-03-04T23:48:43.119713092Z",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 47489024,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Done",
+        "kind": "validate-snap",
+        "ready-time": "2019-03-04T23:48:44.334767875Z",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0149.json
+++ b/examples/snaps/v2-changes-7/0149.json
@@ -1,0 +1,258 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Done",
+        "kind": "download-snap",
+        "ready-time": "2019-03-04T23:48:43.119713092Z",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 47489024,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Done",
+        "kind": "validate-snap",
+        "ready-time": "2019-03-04T23:48:44.334767875Z",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0150.json
+++ b/examples/snaps/v2-changes-7/0150.json
@@ -1,0 +1,258 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Done",
+        "kind": "download-snap",
+        "ready-time": "2019-03-04T23:48:43.119713092Z",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 47489024,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Done",
+        "kind": "validate-snap",
+        "ready-time": "2019-03-04T23:48:44.334767875Z",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0151.json
+++ b/examples/snaps/v2-changes-7/0151.json
@@ -1,0 +1,258 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Done",
+        "kind": "download-snap",
+        "ready-time": "2019-03-04T23:48:43.119713092Z",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 47489024,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Done",
+        "kind": "validate-snap",
+        "ready-time": "2019-03-04T23:48:44.334767875Z",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0152.json
+++ b/examples/snaps/v2-changes-7/0152.json
@@ -1,0 +1,258 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Done",
+        "kind": "download-snap",
+        "ready-time": "2019-03-04T23:48:43.119713092Z",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 47489024,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Done",
+        "kind": "validate-snap",
+        "ready-time": "2019-03-04T23:48:44.334767875Z",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "mount-snap",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0153.json
+++ b/examples/snaps/v2-changes-7/0153.json
@@ -1,0 +1,260 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Do",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Done",
+        "kind": "download-snap",
+        "ready-time": "2019-03-04T23:48:43.119713092Z",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 47489024,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Done",
+        "kind": "validate-snap",
+        "ready-time": "2019-03-04T23:48:44.334767875Z",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Done",
+        "kind": "mount-snap",
+        "ready-time": "2019-03-04T23:48:45.113544006Z",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Done",
+        "kind": "run-hook",
+        "ready-time": "2019-03-04T23:48:45.203935751Z",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Do",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0154.json
+++ b/examples/snaps/v2-changes-7/0154.json
@@ -1,0 +1,260 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Done",
+        "kind": "download-snap",
+        "ready-time": "2019-03-04T23:48:43.119713092Z",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 47489024,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Done",
+        "kind": "validate-snap",
+        "ready-time": "2019-03-04T23:48:44.334767875Z",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Done",
+        "kind": "mount-snap",
+        "ready-time": "2019-03-04T23:48:45.113544006Z",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Done",
+        "kind": "run-hook",
+        "ready-time": "2019-03-04T23:48:45.203935751Z",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0155.json
+++ b/examples/snaps/v2-changes-7/0155.json
@@ -1,0 +1,260 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Doing",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Done",
+        "kind": "download-snap",
+        "ready-time": "2019-03-04T23:48:43.119713092Z",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 47489024,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Done",
+        "kind": "validate-snap",
+        "ready-time": "2019-03-04T23:48:44.334767875Z",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Done",
+        "kind": "mount-snap",
+        "ready-time": "2019-03-04T23:48:45.113544006Z",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Done",
+        "kind": "run-hook",
+        "ready-time": "2019-03-04T23:48:45.203935751Z",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Doing",
+        "kind": "stop-snap-services",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Do",
+        "kind": "remove-aliases",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Do",
+        "kind": "unlink-current-snap",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0156.json
+++ b/examples/snaps/v2-changes-7/0156.json
@@ -1,0 +1,263 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Do",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Done",
+        "kind": "download-snap",
+        "ready-time": "2019-03-04T23:48:43.119713092Z",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 47489024,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Done",
+        "kind": "validate-snap",
+        "ready-time": "2019-03-04T23:48:44.334767875Z",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Done",
+        "kind": "mount-snap",
+        "ready-time": "2019-03-04T23:48:45.113544006Z",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Done",
+        "kind": "run-hook",
+        "ready-time": "2019-03-04T23:48:45.203935751Z",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Done",
+        "kind": "stop-snap-services",
+        "ready-time": "2019-03-04T23:48:45.546141706Z",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Done",
+        "kind": "remove-aliases",
+        "ready-time": "2019-03-04T23:48:45.572056221Z",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Done",
+        "kind": "unlink-current-snap",
+        "ready-time": "2019-03-04T23:48:46.038223202Z",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Do",
+        "kind": "copy-snap-data",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-profiles",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Do",
+        "kind": "link-snap",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0157.json
+++ b/examples/snaps/v2-changes-7/0157.json
@@ -1,0 +1,266 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Do",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Done",
+        "kind": "download-snap",
+        "ready-time": "2019-03-04T23:48:43.119713092Z",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 47489024,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Done",
+        "kind": "validate-snap",
+        "ready-time": "2019-03-04T23:48:44.334767875Z",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Done",
+        "kind": "mount-snap",
+        "ready-time": "2019-03-04T23:48:45.113544006Z",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Done",
+        "kind": "run-hook",
+        "ready-time": "2019-03-04T23:48:45.203935751Z",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Done",
+        "kind": "stop-snap-services",
+        "ready-time": "2019-03-04T23:48:45.546141706Z",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Done",
+        "kind": "remove-aliases",
+        "ready-time": "2019-03-04T23:48:45.572056221Z",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Done",
+        "kind": "unlink-current-snap",
+        "ready-time": "2019-03-04T23:48:46.038223202Z",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Done",
+        "kind": "copy-snap-data",
+        "ready-time": "2019-03-04T23:48:46.067012395Z",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Done",
+        "kind": "setup-profiles",
+        "ready-time": "2019-03-04T23:48:46.106691336Z",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Done",
+        "kind": "link-snap",
+        "ready-time": "2019-03-04T23:48:46.403955046Z",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Do",
+        "kind": "auto-connect",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Do",
+        "kind": "set-auto-aliases",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Do",
+        "kind": "setup-aliases",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Do",
+        "kind": "start-snap-services",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Do",
+        "kind": "clear-snap",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Do",
+        "kind": "discard-snap",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0158.json
+++ b/examples/snaps/v2-changes-7/0158.json
@@ -1,0 +1,273 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Do",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Done",
+        "kind": "download-snap",
+        "ready-time": "2019-03-04T23:48:43.119713092Z",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 47489024,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Done",
+        "kind": "validate-snap",
+        "ready-time": "2019-03-04T23:48:44.334767875Z",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Done",
+        "kind": "mount-snap",
+        "ready-time": "2019-03-04T23:48:45.113544006Z",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Done",
+        "kind": "run-hook",
+        "ready-time": "2019-03-04T23:48:45.203935751Z",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Done",
+        "kind": "stop-snap-services",
+        "ready-time": "2019-03-04T23:48:45.546141706Z",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Done",
+        "kind": "remove-aliases",
+        "ready-time": "2019-03-04T23:48:45.572056221Z",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Done",
+        "kind": "unlink-current-snap",
+        "ready-time": "2019-03-04T23:48:46.038223202Z",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Done",
+        "kind": "copy-snap-data",
+        "ready-time": "2019-03-04T23:48:46.067012395Z",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Done",
+        "kind": "setup-profiles",
+        "ready-time": "2019-03-04T23:48:46.106691336Z",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Done",
+        "kind": "link-snap",
+        "ready-time": "2019-03-04T23:48:46.403955046Z",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Done",
+        "kind": "auto-connect",
+        "ready-time": "2019-03-04T23:48:46.423294318Z",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Done",
+        "kind": "set-auto-aliases",
+        "ready-time": "2019-03-04T23:48:46.43171202Z",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Done",
+        "kind": "setup-aliases",
+        "ready-time": "2019-03-04T23:48:46.440409067Z",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Done",
+        "kind": "run-hook",
+        "ready-time": "2019-03-04T23:48:46.444988601Z",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Done",
+        "kind": "start-snap-services",
+        "ready-time": "2019-03-04T23:48:46.469742744Z",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Done",
+        "kind": "clear-snap",
+        "ready-time": "2019-03-04T23:48:46.477695298Z",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Done",
+        "kind": "discard-snap",
+        "ready-time": "2019-03-04T23:48:47.278748343Z",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Do",
+        "kind": "cleanup",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Do",
+        "kind": "run-hook",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 0,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": false,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-changes-7/0159.json
+++ b/examples/snaps/v2-changes-7/0159.json
@@ -1,0 +1,276 @@
+{
+  "status": "OK",
+  "type": "sync",
+  "result": {
+    "status": "Done",
+    "kind": "refresh-snap",
+    "tasks": [
+      {
+        "status": "Done",
+        "kind": "prerequisites",
+        "ready-time": "2019-03-04T23:48:27.944156996Z",
+        "summary": "Ensure prerequisites for \"subiquity\" are available",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "85",
+        "spawn-time": "2019-03-04T23:48:27.925891923Z"
+      },
+      {
+        "status": "Done",
+        "kind": "download-snap",
+        "ready-time": "2019-03-04T23:48:43.119713092Z",
+        "summary": "Download snap \"subiquity\" (639) from channel \"edge/test-branch\"",
+        "progress": {
+          "total": 47489024,
+          "done": 47489024,
+          "label": "subiquity"
+        },
+        "id": "86",
+        "spawn-time": "2019-03-04T23:48:27.92593791Z"
+      },
+      {
+        "status": "Done",
+        "kind": "validate-snap",
+        "ready-time": "2019-03-04T23:48:44.334767875Z",
+        "summary": "Fetch and check assertions for snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "87",
+        "spawn-time": "2019-03-04T23:48:27.92600422Z"
+      },
+      {
+        "status": "Done",
+        "kind": "mount-snap",
+        "ready-time": "2019-03-04T23:48:45.113544006Z",
+        "summary": "Mount snap \"subiquity\" (639)",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "88",
+        "spawn-time": "2019-03-04T23:48:27.926012439Z"
+      },
+      {
+        "status": "Done",
+        "kind": "run-hook",
+        "ready-time": "2019-03-04T23:48:45.203935751Z",
+        "summary": "Run pre-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "89",
+        "spawn-time": "2019-03-04T23:48:27.926025004Z"
+      },
+      {
+        "status": "Done",
+        "kind": "stop-snap-services",
+        "ready-time": "2019-03-04T23:48:45.546141706Z",
+        "summary": "Stop snap \"subiquity\" services",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "90",
+        "spawn-time": "2019-03-04T23:48:27.926039626Z"
+      },
+      {
+        "status": "Done",
+        "kind": "remove-aliases",
+        "ready-time": "2019-03-04T23:48:45.572056221Z",
+        "summary": "Remove aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "91",
+        "spawn-time": "2019-03-04T23:48:27.926045589Z"
+      },
+      {
+        "status": "Done",
+        "kind": "unlink-current-snap",
+        "ready-time": "2019-03-04T23:48:46.038223202Z",
+        "summary": "Make current revision for snap \"subiquity\" unavailable",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "92",
+        "spawn-time": "2019-03-04T23:48:27.926088091Z"
+      },
+      {
+        "status": "Done",
+        "kind": "copy-snap-data",
+        "ready-time": "2019-03-04T23:48:46.067012395Z",
+        "summary": "Copy snap \"subiquity\" data",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "93",
+        "spawn-time": "2019-03-04T23:48:27.926094562Z"
+      },
+      {
+        "status": "Done",
+        "kind": "setup-profiles",
+        "ready-time": "2019-03-04T23:48:46.106691336Z",
+        "summary": "Setup snap \"subiquity\" (639) security profiles",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "94",
+        "spawn-time": "2019-03-04T23:48:27.926100431Z"
+      },
+      {
+        "status": "Done",
+        "kind": "link-snap",
+        "ready-time": "2019-03-04T23:48:46.403955046Z",
+        "summary": "Make snap \"subiquity\" (639) available to the system",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "95",
+        "spawn-time": "2019-03-04T23:48:27.926105559Z"
+      },
+      {
+        "status": "Done",
+        "kind": "auto-connect",
+        "ready-time": "2019-03-04T23:48:46.423294318Z",
+        "summary": "Automatically connect eligible plugs and slots of snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "96",
+        "spawn-time": "2019-03-04T23:48:27.926109802Z"
+      },
+      {
+        "status": "Done",
+        "kind": "set-auto-aliases",
+        "ready-time": "2019-03-04T23:48:46.43171202Z",
+        "summary": "Set automatic aliases for snap \"subiquity\"",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "97",
+        "spawn-time": "2019-03-04T23:48:27.926113655Z"
+      },
+      {
+        "status": "Done",
+        "kind": "setup-aliases",
+        "ready-time": "2019-03-04T23:48:46.440409067Z",
+        "summary": "Setup snap \"subiquity\" aliases",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "98",
+        "spawn-time": "2019-03-04T23:48:27.926117547Z"
+      },
+      {
+        "status": "Done",
+        "kind": "run-hook",
+        "ready-time": "2019-03-04T23:48:46.444988601Z",
+        "summary": "Run post-refresh hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "99",
+        "spawn-time": "2019-03-04T23:48:27.926123233Z"
+      },
+      {
+        "status": "Done",
+        "kind": "start-snap-services",
+        "ready-time": "2019-03-04T23:48:46.469742744Z",
+        "summary": "Start snap \"subiquity\" (639) services",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "100",
+        "spawn-time": "2019-03-04T23:48:27.926136115Z"
+      },
+      {
+        "status": "Done",
+        "kind": "clear-snap",
+        "ready-time": "2019-03-04T23:48:46.477695298Z",
+        "summary": "Remove data for snap \"subiquity\" (705)",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "101",
+        "spawn-time": "2019-03-04T23:48:27.928834185Z"
+      },
+      {
+        "status": "Done",
+        "kind": "discard-snap",
+        "ready-time": "2019-03-04T23:48:47.278748343Z",
+        "summary": "Remove snap \"subiquity\" (705) from the system",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "102",
+        "spawn-time": "2019-03-04T23:48:27.928862386Z"
+      },
+      {
+        "status": "Done",
+        "kind": "cleanup",
+        "ready-time": "2019-03-04T23:48:47.310781536Z",
+        "summary": "Clean up \"subiquity\" (639) install",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "103",
+        "spawn-time": "2019-03-04T23:48:27.92891587Z"
+      },
+      {
+        "status": "Done",
+        "kind": "run-hook",
+        "ready-time": "2019-03-04T23:48:47.333649878Z",
+        "summary": "Run configure hook of \"subiquity\" snap if present",
+        "progress": {
+          "total": 1,
+          "done": 1,
+          "label": ""
+        },
+        "id": "104",
+        "spawn-time": "2019-03-04T23:48:27.928936157Z"
+      }
+    ],
+    "ready-time": "2019-03-04T23:48:47.33365513Z",
+    "summary": "Refresh \"subiquity\" snap",
+    "ready": true,
+    "id": "7",
+    "spawn-time": "2019-03-04T23:48:27.929018798Z"
+  },
+  "status-code": 200
+}

--- a/examples/snaps/v2-find-select=refresh.json
+++ b/examples/snaps/v2-find-select=refresh.json
@@ -1,0 +1,31 @@
+{
+  "type": "sync",
+  "status-code": 200,
+  "status": "OK",
+  "result": [
+    {
+      "id": "subiquity-id",
+      "summary": "",
+      "description": "",
+      "download-size": 52232192,
+      "name": "subiquity",
+      "publisher": {
+        "id": "canonical",
+        "username": "canonical",
+        "display-name": ""
+      },
+      "developer": "canonical",
+      "status": "available",
+      "type": "app",
+      "version": "0+git.04f1ff0d",
+      "channel": "",
+      "ignore-validation": false,
+      "revision": "424242",
+      "confinement": "classic",
+      "private": false,
+      "devmode": false,
+      "jailmode": false,
+      "contact": ""
+    }
+  ]
+}

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -5,6 +5,7 @@ export SUBIQUITY_REPLAY_TIMESCALE=100
 for answers in examples/answers*.yaml; do
     rm -f .subiquity/subiquity-curtin-install.conf
     rm -f .subiquity/subiquity-debug.log
+    rm -f .subiquity/run/subiquity/updating
     # The --foreground is important to avoid subiquity getting SIGTTOU-ed.
     timeout --foreground 60 sh -c "LANG=C.UTF-8 python3 -m subiquity.cmd.tui --answers $answers --dry-run --snaps-from-examples --machine-config examples/mwhudson.json"
     python3 scripts/validate-yaml.py .subiquity/subiquity-curtin-install.conf

--- a/subiquity/controllers/__init__.py
+++ b/subiquity/controllers/__init__.py
@@ -21,6 +21,7 @@ from .keyboard import KeyboardController
 from .proxy import ProxyController
 from .mirror import MirrorController
 from subiquitycore.controllers.network import NetworkController
+from .refresh import RefreshController
 from .snaplist import SnapListController
 from .ssh import SSHController
 from .welcome import WelcomeController
@@ -33,6 +34,7 @@ __all__ = [
     'ProxyController',
     'MirrorController',
     'NetworkController',
+    'RefreshController',
     'SnapListController',
     'SSHController',
     'WelcomeController',

--- a/subiquity/controllers/refresh.py
+++ b/subiquity/controllers/refresh.py
@@ -74,16 +74,17 @@ class RefreshController(BaseController):
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
             log.exception("checking for update")
+            self.check_error = e
             self.check_state = CheckState.FAILED
-            return
-        result = response.json()
-        log.debug("_check_result %s", result)
-        for snap in result["result"]:
-            if snap["name"] == self.snap_name:
-                self.check_state = CheckState.AVAILABLE
-                break
         else:
-            self.check_state = CheckState.UNAVAILABLE
+            result = response.json()
+            log.debug("_check_result %s", result)
+            for snap in result["result"]:
+                if snap["name"] == self.snap_name:
+                    self.check_state = CheckState.AVAILABLE
+                    break
+            else:
+                self.check_state = CheckState.UNAVAILABLE
         if self.view:
             self.view.update_check_state()
 

--- a/subiquity/controllers/refresh.py
+++ b/subiquity/controllers/refresh.py
@@ -49,6 +49,7 @@ class RefreshController(BaseController):
         self.check_state = CheckState.NOT_STARTED
         self.view = None
         self.offered_first_time = False
+        self.answers = self.all_answers.get("Refresh", {})
 
     def snapd_network_changed(self):
         # If we restarted into this version, don't check for a new version.
@@ -151,6 +152,11 @@ class RefreshController(BaseController):
         if show:
             self.view = RefreshView(self)
             self.ui.set_body(self.view)
+            if 'update' in self.answers:
+                if self.answers['update']:
+                    self.view.update()
+                else:
+                    self.done()
         else:
             raise Skip()
 

--- a/subiquity/controllers/refresh.py
+++ b/subiquity/controllers/refresh.py
@@ -13,7 +13,11 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import enum
 import logging
+import os
+
+import requests.exceptions
 
 from subiquitycore.controller import BaseController
 from subiquitycore.core import Skip
@@ -21,10 +25,92 @@ from subiquitycore.core import Skip
 log = logging.getLogger('subiquity.controllers.refresh')
 
 
+class CheckState(enum.IntEnum):
+    NOT_STARTED = enum.auto()
+    CHECKING = enum.auto()
+    FAILED = enum.auto()
+
+    AVAILABLE = enum.auto()
+    UNAVAILABLE = enum.auto()
+
+    def is_definite(self):
+        return self in [self.AVAILABLE, self.UNAVAILABLE]
+
+
 class RefreshController(BaseController):
 
-    def default(self, index=1):
-        raise Skip()
+    signals = [
+        ('snapd-network-change', 'snapd_network_changed'),
+    ]
 
-    def cancel(self):
+    def __init__(self, common):
+        super().__init__(common)
+        self.snap_name = os.environ.get("SNAP_NAME", "subiquity")
+        self.check_state = CheckState.NOT_STARTED
+        self.view = None
+        self.offered_first_time = False
+
+    def snapd_network_changed(self):
+        # If we restarted into this version, don't check for a new version.
+        if self.updated:
+            return
+        # If we got an answer, don't check again.
+        if self.check_state.is_definite():
+            return
+        self.check_state = CheckState.CHECKING
+        self.run_in_bg(self._bg_check_for_update, self._check_result)
+
+    def _bg_check_for_update(self):
+        return self.snapd_connection.get('v2/find', select='refresh')
+
+    def _check_result(self, fut):
+        # If we managed to send concurrent requests and one has
+        # already provided an answer, just forget all about the other
+        # one!
+        if self.check_state.is_definite():
+            return
+        try:
+            response = fut.result()
+            response.raise_for_status()
+        except requests.exceptions.RequestException as e:
+            log.exception("checking for update")
+            self.check_state = CheckState.FAILED
+            return
+        result = response.json()
+        log.debug("_check_result %s", result)
+        for snap in result["result"]:
+            if snap["name"] == self.snap_name:
+                self.check_state = CheckState.AVAILABLE
+                break
+        else:
+            self.check_state = CheckState.UNAVAILABLE
+        if self.view:
+            self.view.update_check_state()
+
+    def default(self, index=1):
+        from subiquity.ui.views.refresh import RefreshView
+        if self.updated:
+            raise Skip()
+        show = False
+        if index == 1:
+            if self.check_state == CheckState.AVAILABLE:
+                show = True
+                self.offered_first_time = True
+        elif index == 2:
+            if not self.offered_first_time:
+                if self.check_state in [CheckState.AVAILABLE,
+                                        CheckState.CHECKING]:
+                    show = True
+        else:
+            raise AssertionError("unexpected index {}".format(index))
+        if show:
+            self.view = RefreshView(self)
+            self.ui.set_body(self.view)
+        else:
+            raise Skip()
+
+    def done(self, sender=None):
+        self.signal.emit_signal('next-screen')
+
+    def cancel(self, sender=None):
         self.signal.emit_signal('prev-screen')

--- a/subiquity/controllers/refresh.py
+++ b/subiquity/controllers/refresh.py
@@ -1,0 +1,30 @@
+# Copyright 2019 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+
+from subiquitycore.controller import BaseController
+from subiquitycore.core import Skip
+
+log = logging.getLogger('subiquity.controllers.refresh')
+
+
+class RefreshController(BaseController):
+
+    def default(self, index=1):
+        raise Skip()
+
+    def cancel(self):
+        self.signal.emit_signal('prev-screen')

--- a/subiquity/core.py
+++ b/subiquity/core.py
@@ -40,11 +40,13 @@ class Subiquity(Application):
 
     controllers = [
             "Welcome",
+            "Refresh",
             "Keyboard",
             "Installpath",
             "Network",
             "Proxy",
             "Mirror",
+            "Refresh",
             "Filesystem",
             "Identity",
             "SSH",

--- a/subiquity/snapd.py
+++ b/subiquity/snapd.py
@@ -83,6 +83,7 @@ class FakeSnapdConnection:
         time.sleep(2)
 
     def get(self, path, **args):
+        log.debug("snapd get %s %s", path, args)
         filename = path.replace('/', '-')
         if args:
             filename += '-' + urlencode(sorted(args.items()))

--- a/subiquity/ui/spinner.py
+++ b/subiquity/ui/spinner.py
@@ -32,7 +32,7 @@ styles = {
 
 
 class Spinner(Text):
-    def __init__(self, loop, style='spin', align='center'):
+    def __init__(self, loop=None, style='spin', align='center'):
         self.loop = loop
         self.spin_index = 0
         self.spin_text = styles[style]['texts']
@@ -40,9 +40,12 @@ class Spinner(Text):
         super().__init__('', align=align)
         self.handle = None
 
-    def _advance(self, sender=None, user_data=None):
+    def spin(self):
         self.spin_index = (self.spin_index + 1) % len(self.spin_text)
         self.set_text(self.spin_text[self.spin_index])
+
+    def _advance(self, sender=None, user_data=None):
+        self.spin()
         self.handle = self.loop.set_alarm_in(self.rate, self._advance)
 
     def start(self):

--- a/subiquity/ui/views/refresh.py
+++ b/subiquity/ui/views/refresh.py
@@ -1,0 +1,152 @@
+# Copyright 2019 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+
+from urwid import (
+    Text,
+    )
+
+from subiquitycore.view import BaseView
+from subiquitycore.ui.buttons import done_btn, other_btn
+from subiquitycore.ui.utils import button_pile, screen
+
+from subiquity.controllers.refresh import CheckState
+from subiquity.ui.spinner import Spinner
+
+log = logging.getLogger('subiquity.ui.views.refresh')
+
+
+class RefreshView(BaseView):
+
+    checking_title = _("Checking for installer update...")
+    checking_excerpt = _(
+        "Contacting the snap store to check if a new version of the "
+        "installer is available."
+        )
+
+    failed_title = _("Contacting the snap store failed")
+    failed_excerpt = _(
+        "Contacting the snap store failed:"
+        )
+
+    available_title = _("Installer update available")
+    available_excerpt = _(
+        "A new version of the installer is available."
+        )
+
+    progress_title = _("Downloading update...")
+    progress_excerpt = _(
+        "Please wait while the updated installer is being downloaded. The "
+        "installer will restart automatically when the download is complete."
+        )
+
+    def __init__(self, controller):
+        self.controller = controller
+        self.spinner = Spinner(self.controller.loop, style="dots")
+
+        if self.controller.check_state == CheckState.CHECKING:
+            self.check_state_checking()
+        elif self.controller.check_state == CheckState.AVAILABLE:
+            self.check_state_available()
+        else:
+            raise AssertionError(
+                "instantiating the view with check_state {}".format(
+                    self.controller.check_state))
+
+        super().__init__(self._w)
+
+    def update_check_state(self):
+        if self.controller.check_state == CheckState.UNAVAILABLE:
+            self.done()
+        elif self.controller.check_state == CheckState.FAILED:
+            self.check_state_failed()
+        elif self.controller.check_state == CheckState.AVAILABLE:
+            self.check_state_available()
+        else:
+            raise AssertionError(
+                "update_check_state with check_state {}".format(
+                    self.controller.check_state))
+
+    def check_state_checking(self):
+        self.spinner.start()
+
+        rows = [self.spinner]
+
+        buttons = [
+            done_btn(_("Continue without updating"), on_press=self.done),
+            other_btn(_("Back"), on_press=self.cancel),
+            ]
+
+        self.title = self.checking_title
+        self.controller.ui.set_header(self.title)
+        self._w = screen(rows, buttons, excerpt=_(self.checking_excerpt))
+
+    def check_state_available(self, sender=None):
+        self.spinner.stop()
+
+        rows = [
+            Text(
+                _("If you choose to update, the update will be downloaded "
+                  "and the installation will continue from here."),
+                )
+            ]
+
+        buttons = button_pile([
+            done_btn(_("Update to the new installer"), on_press=self.update),
+            done_btn(_("Continue without updating"), on_press=self.done),
+            other_btn(_("Back"), on_press=self.cancel),
+            ])
+        buttons.base_widget.focus_position = 1
+
+        self.title = self.available_title
+        self.controller.ui.set_header(self.available_title)
+        self._w = screen(rows, buttons, excerpt=_(self.available_excerpt))
+
+    def check_state_failed(self):
+        self.spinner.stop()
+
+        rows = [Text("<explanation goes here>")]
+
+        buttons = button_pile([
+            done_btn(_("Try again"), on_press=self.still_checking),
+            done_btn(_("Continue without updating"), on_press=self.done),
+            other_btn(_("Back"), on_press=self.cancel),
+            ])
+        buttons.base_widget.focus_position = 1
+
+        self.title = self.failed_title
+        self._w = screen(rows, buttons, excerpt=_(self.failed_excerpt))
+
+    def update(self, sender=None):
+        self.spinner.stop()
+
+        rows = [Text("not yet")]
+
+        buttons = [
+            other_btn(_("Cancel update"), on_press=self.check_state_available),
+            ]
+
+        self.controller.ui.set_header("Downloading update...")
+        self._w = screen(rows, buttons, excerpt=_(self.progress_excerpt))
+        # self.controller.start_update(self.update_started)
+
+    def done(self, result=None):
+        self.spinner.stop()
+        self.controller.done()
+
+    def cancel(self, result=None):
+        self.spinner.stop()
+        self.controller.cancel()

--- a/subiquitycore/controller.py
+++ b/subiquitycore/controller.py
@@ -38,6 +38,8 @@ class BaseController(ABC):
         self.input_filter = common['input_filter']
         self.scale_factor = common['scale_factor']
         self.run_in_bg = common['run_in_bg']
+        self.updated = common['updated']
+        self.application = common['application']
         if 'snapd_connection' in common:
             self.snapd_connection = common['snapd_connection']
 

--- a/subiquitycore/controller.py
+++ b/subiquitycore/controller.py
@@ -105,3 +105,19 @@ class BaseController(ABC):
         self.loop.set_alarm_in(
             delay,
             lambda *args: self._run_iterator(it, delay/1.1))
+
+
+class RepeatedController(BaseController):
+
+    def __init__(self, orig, index):
+        self.orig = orig
+        self.index = index
+
+    def register_signals(self):
+        pass
+
+    def default(self):
+        self.orig.default(self.index)
+
+    def cancel(self):
+        self.orig.cancel()

--- a/subiquitycore/core.py
+++ b/subiquitycore/core.py
@@ -284,7 +284,7 @@ class Application:
             "signal": Signal(),
             "prober": prober,
             "loop": None,
-            "pool": futures.ThreadPoolExecutor(4),
+            "pool": futures.ThreadPoolExecutor(10),
             "answers": answers,
             "input_filter": input_filter,
             "scale_factor": scale,

--- a/subiquitycore/core.py
+++ b/subiquitycore/core.py
@@ -277,6 +277,7 @@ class Application:
         scale = float(os.environ.get('SUBIQUITY_REPLAY_TIMESCALE', "1"))
         updated = os.path.exists(os.path.join(self.state_dir, 'updating'))
         self.common = {
+            "application": self,
             "updated": updated,
             "ui": ui,
             "opts": opts,

--- a/subiquitycore/signals.py
+++ b/subiquitycore/signals.py
@@ -54,8 +54,8 @@ class Signal:
             raise SignalException(
                 "Passed something other than a required list.")
         for sig, cb in signal_callback:
-            if sig not in self.known_signals:
-                self.register_signals(sig)
+            # if sig not in self.known_signals:
+            self.register_signals(sig)
             self.connect_signal(sig, cb)
 
     def __repr__(self):

--- a/subiquitycore/signals.py
+++ b/subiquitycore/signals.py
@@ -34,7 +34,7 @@ class Signal:
             self.known_signals.extend(signals)
         else:
             self.known_signals.append(signals)
-        urwid.register_signal(Signal, signals)
+        urwid.register_signal(Signal, self.known_signals)
 
     def emit_signal(self, name, *args, **kwargs):
         urwid.emit_signal(self, name, *args, **kwargs)
@@ -54,8 +54,8 @@ class Signal:
             raise SignalException(
                 "Passed something other than a required list.")
         for sig, cb in signal_callback:
-            # if sig not in self.known_signals:
-            self.register_signals(sig)
+            if sig not in self.known_signals:
+                self.register_signals(sig)
             self.connect_signal(sig, cb)
 
     def __repr__(self):


### PR DESCRIPTION
Allow the user to update to a newer version of the installer, if available.

Offer the upgrade after language selection, and again after mirror selection (i.e. after network/proxy have been configured).

This does not implement showing release notes of the new version to the user; not yet sure how to do that.