### PR TITLE
Make a unified launcher

### DIFF
--- a/bin/subiquity-service
+++ b/bin/subiquity-service
@@ -1,6 +1,14 @@
 #!/bin/sh
+port=tty1
+if [ -n "$1" ]; then
+   port=$1
+fi
 /bin/dmesg -n 1
 export PATH=$SNAP/bin:$SNAP/usr/bin:$PATH
-$SNAP/usr/bin/subiquity-loadkeys
-setfont $SNAP/subiquity.psf
-/sbin/agetty -n --noclear -l $SNAP/usr/bin/python3 -o $SNAP/usr/bin/subiquity tty1 $TERM
+if [ "$port" = "tty1" ]; then
+	$SNAP/usr/bin/subiquity-loadkeys
+	setfont $SNAP/subiquity.psf
+	exec /sbin/agetty -n --noclear -l $SNAP/usr/bin/python3 -o $SNAP/usr/bin/subiquity $port $TERM
+else
+	exec /sbin/agetty -n --keep-baud -l $SNAP/usr/bin/python3 -o "$SNAP/usr/bin/subiquity --serial" $port 115200,38400,9600 $TERM
+fi


### PR DESCRIPTION
Currently tty1 subiquity is launched via snap run subiquity-service, which setups up expected PATH, and does a keys&font setup.

At the moment serial subiquity does nto go via the subiquity-service, and results in a different environment. Also serial subiquity does not block on seeding snaps, and does a weird loop of trying to start up like 3 times. Since it's not blocking on snapd via "/usr/bin/snap run subiquity.subiquity-service"

Let's try to make subiquity-service script, a unified entry point into subiquity. And make serial-subiquity@.service to use that.

This merge can go in, anytime. Whilst livecd-rootfs change will need to go in, after this commit is promoted to stable. As otherwise the arguments passed to the script will not be processed in serial-subiquity@ case.