### PR TITLE
PReP partition must be wiped, and the _disk_ should not have grub_device flag

### DIFF
--- a/subiquity/controllers/filesystem.py
+++ b/subiquity/controllers/filesystem.py
@@ -207,8 +207,8 @@ class FilesystemController(BaseController):
         self.delete_mount(fs.mount())
         self.model.remove_filesystem(fs)
 
-    def create_partition(self, device, spec, flag=""):
-        part = self.model.add_partition(device, spec["size"], flag)
+    def create_partition(self, device, spec, wipe=None, flag=""):
+        part = self.model.add_partition(device, spec["size"], wipe, flag)
         self.create_filesystem(part, spec)
         return part
 
@@ -237,6 +237,7 @@ class FilesystemController(BaseController):
                     size=PREP_GRUB_SIZE_BYTES,
                     fstype=None,
                     mount=None),
+                wipe='zero',
                 flag='prep')
         else:
             log.debug('Adding grub_bios gpt partition first')
@@ -247,7 +248,9 @@ class FilesystemController(BaseController):
                     fstype=None,
                     mount=None),
                 flag='bios_grub')
-        disk.grub_device = True
+        # should _not_ specify grub defice for prep
+        if not self.is_prep():
+            disk.grub_device = True
         return part
 
     def create_raid(self, spec):

--- a/subiquity/controllers/filesystem.py
+++ b/subiquity/controllers/filesystem.py
@@ -207,8 +207,8 @@ class FilesystemController(BaseController):
         self.delete_mount(fs.mount())
         self.model.remove_filesystem(fs)
 
-    def create_partition(self, device, spec, wipe=None, flag=""):
-        part = self.model.add_partition(device, spec["size"], wipe, flag)
+    def create_partition(self, device, spec, flag="", wipe=None):
+        part = self.model.add_partition(device, spec["size"], flag, wipe)
         self.create_filesystem(part, spec)
         return part
 

--- a/subiquity/controllers/filesystem.py
+++ b/subiquity/controllers/filesystem.py
@@ -237,6 +237,7 @@ class FilesystemController(BaseController):
                     size=PREP_GRUB_SIZE_BYTES,
                     fstype=None,
                     mount=None),
+                # must be wiped or grub-install will fail
                 wipe='zero',
                 flag='prep')
         else:
@@ -248,7 +249,7 @@ class FilesystemController(BaseController):
                     fstype=None,
                     mount=None),
                 flag='bios_grub')
-        # should _not_ specify grub defice for prep
+        # should _not_ specify grub device for prep
         if not self.is_prep():
             disk.grub_device = True
         return part

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -954,7 +954,7 @@ class FilesystemModel(object):
     def all_devices(self):
         return self.all_disks() + self.all_raids() + self.all_volgroups()
 
-    def add_partition(self, disk, size, wipe=None, flag=""):
+    def add_partition(self, disk, size, flag="", wipe=None):
         if size > disk.free_for_partitions:
             raise Exception("%s > %s", size, disk.free_for_partitions)
         real_size = align_up(size)
@@ -963,7 +963,7 @@ class FilesystemModel(object):
             self._use_disk(disk)
         if disk._fs is not None:
             raise Exception("%s is already formatted" % (disk.label,))
-        p = Partition(device=disk, size=real_size, wipe=wipe, flag=flag)
+        p = Partition(device=disk, size=real_size, flag=flag, wipe=wipe)
         if flag in ("boot", "bios_grub", "prep"):
             disk._partitions.insert(0, p)
         else:

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -954,7 +954,7 @@ class FilesystemModel(object):
     def all_devices(self):
         return self.all_disks() + self.all_raids() + self.all_volgroups()
 
-    def add_partition(self, disk, size, flag=""):
+    def add_partition(self, disk, size, wipe=None, flag=""):
         if size > disk.free_for_partitions:
             raise Exception("%s > %s", size, disk.free_for_partitions)
         real_size = align_up(size)
@@ -963,7 +963,7 @@ class FilesystemModel(object):
             self._use_disk(disk)
         if disk._fs is not None:
             raise Exception("%s is already formatted" % (disk.label,))
-        p = Partition(device=disk, size=real_size, flag=flag)
+        p = Partition(device=disk, size=real_size, wipe=wipe, flag=flag)
         if flag in ("boot", "bios_grub", "prep"):
             disk._partitions.insert(0, p)
         else:


### PR DESCRIPTION
However, we use the grub_device flag on the disk for UX, but we should
either not have it at all for power, or set it on the partition
(rather than the disk), and I guess we need to make our 'can make
boot' smarter for ppc64le... as in check if the disk has any
partitions marked as prep already... not sure.