### PR TITLE
rework network ui, allow offline progress

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -96,5 +96,5 @@ parts:
     stage-packages: [libc6, libnl-3-dev, libnl-genl-3-dev, libnl-route-3-dev]
     source: https://github.com/CanonicalLtd/probert.git
     source-type: git
-    source-commit: 8b56d73068ec1f293d3db3b0b44966ede9ed1c94
+    source-commit: d4276ab044f4cc8311fb66a9050f6674726cbbf2
     requirements: requirements.txt

--- a/subiquitycore/controllers/network.py
+++ b/subiquitycore/controllers/network.py
@@ -365,6 +365,8 @@ class NetworkController(BaseController):
                     if not silent:
                         dev.set_dhcp_state(v, "PENDING")
                         self.network_event_receiver.update_link(dev.ifindex)
+                    else:
+                        dev.set_dhcp_state(v, "RECONFIGURE")
                     dhcp_device_versions.append((dev, v))
             if dev.info is None:
                 continue

--- a/subiquitycore/controllers/network.py
+++ b/subiquitycore/controllers/network.py
@@ -52,10 +52,15 @@ class DownNetworkDevices(BackgroundTask):
         self.devs_to_delete = devs_to_delete
 
     def __repr__(self):
-        return 'DownNetworkDevices(%s)' % ([dev.name for dev in
-                                            self.devs_to_down],)
+        return 'DownNetworkDevices({}, {})'.format(
+            [dev.name for dev in self.devs_to_down],
+            [dev.name for dev in self.devs_to_delete],
+            )
 
     def start(self):
+        pass
+
+    def _bg_run(self):
         for dev in self.devs_to_down:
             try:
                 log.debug('downing %s', dev.name)
@@ -72,14 +77,8 @@ class DownNetworkDevices(BackgroundTask):
             except subprocess.CalledProcessError as cp:
                 log.info("deleting %s failed with %r", dev.name, cp.stderr)
 
-    def _bg_run(self):
-        return True
-
     def end(self, observer, fut):
-        if fut.result():
-            observer.task_succeeded()
-        else:
-            observer.task_failed()
+        observer.task_succeeded()
 
 
 class WaitForDefaultRouteTask(CancelableTask):

--- a/subiquitycore/controllers/network.py
+++ b/subiquitycore/controllers/network.py
@@ -308,7 +308,7 @@ class NetworkController(BaseController):
         # explanation.
         for dev in self.model.get_all_netdevs():
             has_global_address = False
-            if dev.info is None:
+            if dev.info is None or not dev.config:
                 continue
             for a in dev.info.addresses.values():
                 if a.scope == "global":

--- a/subiquitycore/models/network.py
+++ b/subiquitycore/models/network.py
@@ -111,6 +111,10 @@ class NetworkDev(object):
         self.config = {}
         self.info = None
         self.disabled_reason = None
+        self._dhcp_state = {
+            4: None,
+            6: None,
+            }
 
     def dhcp_addresses(self):
         r = {4: [], 6: []}
@@ -128,6 +132,14 @@ class NetworkDev(object):
 
     def dhcp_enabled(self, version):
         return self.config.get('dhcp{v}'.format(v=version), False)
+
+    def dhcp_state(self, version):
+        if not self.config.get('dhcp{v}'.format(v=version), False):
+            return None
+        return self._dhcp_state[version]
+
+    def set_dhcp_state(self, version, state):
+        self._dhcp_state[version] = state
 
     @property
     def name(self):

--- a/subiquitycore/models/network.py
+++ b/subiquitycore/models/network.py
@@ -131,7 +131,10 @@ class NetworkDev(object):
         return r
 
     def dhcp_enabled(self, version):
-        return self.config.get('dhcp{v}'.format(v=version), False)
+        if self.config is None:
+            return False
+        else:
+            return self.config.get('dhcp{v}'.format(v=version), False)
 
     def dhcp_state(self, version):
         if not self.config.get('dhcp{v}'.format(v=version), False):

--- a/subiquitycore/models/network.py
+++ b/subiquitycore/models/network.py
@@ -110,6 +110,7 @@ class NetworkDev(object):
         self.type = typ
         self.config = {}
         self.info = None
+        self.disabled_reason = None
 
     def dhcp_addresses(self):
         r = {4: [], 6: []}

--- a/subiquitycore/models/network.py
+++ b/subiquitycore/models/network.py
@@ -234,6 +234,7 @@ class NetworkModel(object):
     def __init__(self, support_wlan=True):
         self.support_wlan = support_wlan
         self.devices_by_name = {}  # Maps interface names to NetworkDev
+        self.has_network = False
 
     def parse_netplan_configs(self, netplan_root):
         self.config = netplan.Config()

--- a/subiquitycore/ui/views/network.py
+++ b/subiquitycore/ui/views/network.py
@@ -292,6 +292,10 @@ class NetworkView(BaseView):
         log.debug(
             "del_link %s %s %s",
             dev.name, dev.ifindex, (dev in self.cur_netdevs))
+        # If a virtual device disappears while we still have config
+        # for it, we assume it will be back soon.
+        if dev.is_virtual and dev.config is not None:
+            return
         if dev in self.cur_netdevs:
             netdev_i = self.cur_netdevs.index(dev)
             self._remove_row(netdev_i+1)

--- a/subiquitycore/ui/views/network.py
+++ b/subiquitycore/ui/views/network.py
@@ -224,7 +224,10 @@ class NetworkView(BaseView):
                 if dev2.type == "vlan" and dev.name == dev2.config.get('link'):
                     break
             else:
-                address_info.append((Text(_("disabled")), Text("")))
+                reason = dev.disabled_reason
+                if reason is None:
+                    reason = ""
+                address_info.append((Text(_("disabled")), Text(reason)))
         rows = []
         for label, value in address_info:
             rows.append(TableRow([Text(""), label, (2, value)]))

--- a/subiquitycore/ui/views/network.py
+++ b/subiquitycore/ui/views/network.py
@@ -209,6 +209,8 @@ class NetworkView(BaseView):
                     address_info.append((label, s))
                 elif dev.dhcp_state(v) == "TIMEDOUT":
                     address_info.append((label, Text(_("timed out"))))
+                elif dev.dhcp_state(v) == "RECONFIGURE":
+                    address_info.append((label, Text(_("-"))))
                 else:
                     address_info.append((
                         label,

--- a/subiquitycore/ui/views/network.py
+++ b/subiquitycore/ui/views/network.py
@@ -201,10 +201,17 @@ class NetworkView(BaseView):
                 if addrs:
                     address_info.extend(
                         [(label, Text(addr)) for addr in addrs])
+                elif dev.dhcp_state(v) == "PENDING":
+                    s = Spinner(self.controller.loop, align='left')
+                    s.rate = 0.3
+                    s.start()
+                    address_info.append((label, s))
+                elif dev.dhcp_state(v) == "TIMEDOUT":
+                    address_info.append((label, Text(_("timed out"))))
                 else:
                     address_info.append((
                         label,
-                        Text(_("no address")),
+                        Text(_("unknown state {}".format(dev.dhcp_state(v))))
                         ))
             else:
                 addrs = []

--- a/subiquitycore/ui/views/network.py
+++ b/subiquitycore/ui/views/network.py
@@ -258,6 +258,8 @@ class NetworkView(BaseView):
         log.debug(
             "update_link %s %s %s",
             dev.name, dev.ifindex, (dev in self.cur_netdevs))
+        if dev not in self.cur_netdevs:
+            return
         # Update the display of dev to represent the current state.
         #
         # The easiest way of doing this would be to just create a new table

--- a/subiquitycore/ui/views/network_configure_manual_interface.py
+++ b/subiquitycore/ui/views/network_configure_manual_interface.py
@@ -247,6 +247,7 @@ class EditNetworkStretchy(Stretchy):
             self.device.config['dhcp{v}'.format(v=self.ip_version)] = True
         else:
             pass
+        self.parent.controller.apply_config()
         self.parent.update_link(self.device)
         self.parent.remove_overlay()
 
@@ -300,6 +301,7 @@ class AddVlanStretchy(Stretchy):
         dev = self.parent.controller.add_vlan(
             self.device, self.form.vlan.value)
         self.parent.new_link(dev)
+        self.parent.controller.apply_config()
 
     def cancel(self, sender=None):
         self.parent.remove_overlay()
@@ -479,6 +481,7 @@ class BondStretchy(Stretchy):
         for dev in touched_devices:
             self.parent.update_link(dev)
         self.parent.remove_overlay()
+        self.parent.controller.apply_config()
 
     def cancel(self, sender=None):
         self.parent.remove_overlay()

--- a/subiquitycore/ui/views/tests/test_network_configure_manual_interface.py
+++ b/subiquitycore/ui/views/tests/test_network_configure_manual_interface.py
@@ -3,6 +3,7 @@ from unittest import mock
 
 import urwid
 
+from subiquitycore.controllers.network import NetworkController
 from subiquitycore.models.network import NetworkDev
 from subiquitycore.testing import view_helpers
 from subiquitycore.ui.views.network_configure_manual_interface import (
@@ -28,6 +29,7 @@ class TestNetworkConfigureIPv4InterfaceView(unittest.TestCase):
         device.config = {}
         base_view = BaseView(urwid.Text(""))
         base_view.update_link = lambda device: None
+        base_view.controller = mock.create_autospec(spec=NetworkController)
         stretchy = EditNetworkStretchy(base_view, device, 4)
         base_view.show_stretchy_overlay(stretchy)
         stretchy.method_form.method.value = "manual"


### PR DESCRIPTION
This changes how the network UI works to:

 1. apply changes on every edit
 2. mark interfaces that do not autoconfigure as disabled
 3. allow progress past the network screen even if there is no network

Demo at https://asciinema.org/a/LIC8SLjYyZRdsl8lp2vukUh94