### PR TITLE
take jsonschema from probert

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -29,7 +29,10 @@ parts:
     requirements: requirements.txt
     organize:
       'lib/python*/site-packages/usr/lib/curtin': 'usr/lib/'
-    stage: [ "*", "-lib/python*/site-packages/_yaml.*.so" ]
+    stage:
+     - "*"
+     - "-lib/python*/site-packages/_yaml.*.so"
+     - "-lib/python*/site-packages/jsonschema"
     stage-packages: [libc6]
   subiquity:
     plugin: python


### PR DESCRIPTION
probert has a requirements.txt that pins the version to the version
currently in the archive whereas curtin's is unversioned.