### PR TITLE
Use a single list on FilesystemModel to store all the actions

### DIFF
--- a/subiquity/controllers/filesystem.py
+++ b/subiquity/controllers/filesystem.py
@@ -160,7 +160,7 @@ class FilesystemController(BaseController):
         if self.answers['guided']:
             index = self.answers['guided-index']
             disk = self.model.all_disks()[index]
-            v.choose_disk(None, disk)
+            v.choose_disk(None, disk.path)
 
     def reset(self):
         log.info("Resetting Filesystem model")

--- a/subiquity/ui/views/filesystem/guided.py
+++ b/subiquity/ui/views/filesystem/guided.py
@@ -115,7 +115,7 @@ class GuidedDiskSelectionView(BaseView):
             if disk.size >= dehumanize_size("6G"):
                 disk_btn = ClickableIcon(disk.label)
                 connect_signal(
-                    disk_btn, 'click', self.choose_disk, disk)
+                    disk_btn, 'click', self.choose_disk, disk.path)
                 attr = Color.done_button
             else:
                 disk_btn = Text("  "+disk.label)
@@ -142,8 +142,9 @@ class GuidedDiskSelectionView(BaseView):
     def cancel(self, btn=None):
         self.controller.default()
 
-    def choose_disk(self, btn, disk):
+    def choose_disk(self, btn, disk_path):
         self.model.reset()
+        disk = self.model.disk_by_path(disk_path)
         if self.method == "direct":
             result = {
                 "size": disk.free_for_partitions,

--- a/subiquity/ui/views/filesystem/tests/test_partition.py
+++ b/subiquity/ui/views/filesystem/tests/test_partition.py
@@ -10,7 +10,6 @@ from subiquitycore.view import BaseView
 from subiquity.controllers.filesystem import FilesystemController
 from subiquity.models.filesystem import (
     dehumanize_size,
-    Disk,
     FilesystemModel,
     )
 from subiquity.ui.views.filesystem.partition import PartitionStretchy
@@ -23,10 +22,10 @@ FakeStorageInfo.__new__.__defaults__ = (None,) * len(FakeStorageInfo._fields)
 
 def make_model_and_disk():
     model = FilesystemModel(prober=None)
-    disk = Disk.from_info(FakeStorageInfo(
+    model._disk_info.append(FakeStorageInfo(
         name='disk-name', size=100*(2**30), free=50*(2**30)))
-    model._available_disks[disk.name] = disk
-    return model, disk
+    model.reset()
+    return model, model._actions[0]
 
 
 def make_view(model, disk, partition=None):


### PR DESCRIPTION
Another thing looking forward to reusing existing partitions/devices.

One user-visible change here: the devices list now lists constructed
devices, most recently created first, followed by the disks. This feels
better to me.