### PR TITLE
do not crash when the ssh keys are downloaded after curtin fails

### DIFF
--- a/subiquity/controllers/ssh.py
+++ b/subiquity/controllers/ssh.py
@@ -89,6 +89,10 @@ class SSHController(BaseController):
         return user_spec, ssh_import_id, key_material, fingerprints
 
     def _fetched_ssh_keys(self, fut):
+        if not isinstance(self.ui.frame.body, SSHView):
+            # This can happen if curtin failed while the keys where being
+            # fetched and we jump to the log view.
+            return
         try:
             result = fut.result()
         except FetchSSHKeysFailure as e:


### PR DESCRIPTION
https://bugs.launchpad.net/subiquity/+bug/1824404