### PR TITLE
Lock answers file.

### DIFF
--- a/subiquity/cmd/tui.py
+++ b/subiquity/cmd/tui.py
@@ -132,7 +132,8 @@ def main():
         try:
             fcntl.flock(opts.answers, fcntl.LOCK_EX | fcntl.LOCK_NB)
         except OSError:
-            logger.exception('Failed to lock auto answers file, proceding without it.')
+            logger.exception(
+                'Failed to lock auto answers file, proceding without it.')
             opts.answers.close()
             opts.answers = None
 

--- a/subiquity/cmd/tui.py
+++ b/subiquity/cmd/tui.py
@@ -17,6 +17,7 @@
 import argparse
 import logging
 import os
+import fcntl
 import signal
 import sys
 
@@ -125,6 +126,15 @@ def main():
     if opts.answers is None and os.path.exists(AUTO_ANSWERS_FILE):
         logger.debug("Autoloading answers from %s", AUTO_ANSWERS_FILE)
         opts.answers = AUTO_ANSWERS_FILE
+
+    if opts.answers:
+        opts.answers = open(opts.answers)
+        try:
+            fcntl.flock(opts.answers, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            logger.exception('Failed to lock auto answers file, proceding without it.')
+            opts.answers.close()
+            opts.answers = None
 
     ui = SubiquityUI()
 

--- a/subiquitycore/core.py
+++ b/subiquitycore/core.py
@@ -263,7 +263,7 @@ class Application:
 
         answers = {}
         if opts.answers is not None:
-            answers = yaml.safe_load(open(opts.answers).read())
+            answers = yaml.safe_load(opts.answers.read())
             log.debug("Loaded answers %s", answers)
             if not opts.dry_run:
                 open('/run/casper-no-prompt', 'w').close()


### PR DESCRIPTION
On ppc64el we are observing that subiquity is running both on tty1 and hvc0 (serial console), in automatic mode.

I think we should still spawn subiquity in all the places we need to spawn it on, but we shall lock the answers file, such that only one instance of subiquity is actually installing things. As two subiquities installing things simultaneously is not good.