### PR TITLE
fix race in refresh view that can lead to done being called twice

### DIFF
--- a/subiquity/controllers/refresh.py
+++ b/subiquity/controllers/refresh.py
@@ -278,7 +278,9 @@ class RefreshController(BaseController):
 
     def done(self, sender=None):
         log.debug("RefreshController.done next-screen")
+        self.view = None
         self.signal.emit_signal('next-screen')
 
     def cancel(self, sender=None):
+        self.view = None
         self.signal.emit_signal('prev-screen')


### PR DESCRIPTION
The symptom of this is that the post install steps don't get run.

If you get to the refresh screen before the check for a snap update is
completed, you are shown a screen that indicates this. If the check
completes and shows no update, you are moved onto the next screen. The
problem is, this happens even if the user has already clicked the
"Continue without updating" button! This means (if the timing works out)
that the SSH screen gets skipped without its done method being called
and the postinstall steps never start because they are endlessly waiting
for the ssh config to be decided on.

Fortunately the fix is much simpler than the diagnosis: don't hang on to
the view after we stop showing it, so that when the check completes we
don't call methods on the view that can call back into the controller's
done method.

This isn't a CI only race, it could happen to a user, especially if they
require a proxy to talk to the snap store :/