### PR TITLE
reorganize storage probing

### DIFF
--- a/subiquity/controllers/filesystem.py
+++ b/subiquity/controllers/filesystem.py
@@ -95,7 +95,8 @@ class FilesystemController(BaseController):
                 self._reprobe()
             else:
                 self._probe_state = ProbeState.FAILED
-                self.default()
+                if self.showing:
+                    self.default()
         else:
             self.model.load_probe_data(storage)
             self._probe_state = ProbeState.DONE

--- a/subiquity/controllers/filesystem.py
+++ b/subiquity/controllers/filesystem.py
@@ -85,7 +85,7 @@ class FilesystemController(BaseController):
             return
         try:
             storage = fut.result()
-        except Exception as e:
+        except Exception:
             log.exception("probing failed restricted=%s", restricted)
             if not restricted:
                 log.info("reprobing for blockdev only")

--- a/subiquity/controllers/filesystem.py
+++ b/subiquity/controllers/filesystem.py
@@ -17,6 +17,8 @@ import logging
 import os
 import platform
 
+from probert.storage import StorageInfo
+
 from subiquitycore.controller import BaseController
 
 from subiquity.models.filesystem import (
@@ -48,7 +50,13 @@ class FilesystemController(BaseController):
         self.answers.setdefault('guided', False)
         self.answers.setdefault('guided-index', 0)
         self.answers.setdefault('manual', [])
-        self.model.probe()  # probe before we complete
+
+    def start(self):
+        probed_data = self.prober.get_storage()["blockdev"]
+        storage = {}
+        for path, data in probed_data.items():
+            storage[path] = StorageInfo({path: data})
+        self.model.load_probe_data(storage)
 
     def default(self):
         self.ui.set_body(GuidedFilesystemView(self))

--- a/subiquity/models/subiquity.py
+++ b/subiquity/models/subiquity.py
@@ -74,7 +74,7 @@ class SubiquityModel:
             target=self.target,
             sources=common['opts'].sources)
         self.network = NetworkModel(support_wlan=False)
-        self.filesystem = FilesystemModel(common['prober'])
+        self.filesystem = FilesystemModel()
         self.identity = IdentityModel()
         self.proxy = ProxyModel()
         self.mirror = MirrorModel()

--- a/subiquity/ui/views/filesystem/probing.py
+++ b/subiquity/ui/views/filesystem/probing.py
@@ -48,14 +48,16 @@ class SlowProbing(BaseView):
             ]))
 
 
+fail_text = _(
+    "Unfortunately probing for devices to install to failed. Please report a "
+    "bug on Launchpad, and if possible include the contents of the "
+    "/var/log/installer directory.")
+
+
 class ProbingFailed(BaseView):
 
     title = _("Probing for devices to install to failed")
 
     def __init__(self, controller):
         self.controller = controller
-        super().__init__(screen(
-            [
-                Text(_("Unfortunately probing for devices to install to "
-                       "failed. Please report a bug on Launchpad.")),
-            ]))
+        super().__init__(screen([Text(_(fail_text))]))

--- a/subiquity/ui/views/filesystem/probing.py
+++ b/subiquity/ui/views/filesystem/probing.py
@@ -46,3 +46,16 @@ class SlowProbing(BaseView):
                 Text(""),
                 self.spinner,
             ]))
+
+
+class ProbingFailed(BaseView):
+
+    title = _("Probing for devices to install to failed")
+
+    def __init__(self, controller):
+        self.controller = controller
+        super().__init__(screen(
+            [
+                Text(_("Unfortunately probing for devices to install to "
+                       "failed. Please report a bug on Launchpad.")),
+            ]))

--- a/subiquity/ui/views/filesystem/probing.py
+++ b/subiquity/ui/views/filesystem/probing.py
@@ -1,0 +1,48 @@
+# Copyright 2019 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+
+from urwid import (
+    Text,
+    )
+
+from subiquitycore.ui.spinner import (
+    Spinner,
+    )
+from subiquitycore.ui.utils import (
+    screen,
+    )
+from subiquitycore.view import BaseView
+
+
+log = logging.getLogger("subiquity.ui.views.filesystem.slow")
+
+
+class SlowProbing(BaseView):
+
+    title = _("Waiting for storage probing to complete")
+
+    def __init__(self, controller):
+        self.controller = controller
+        self.spinner = Spinner(loop=controller.loop, style="dots")
+        self.spinner.start()
+        super().__init__(screen(
+            [
+                Text(_("The installer is probing for block devices to install "
+                       "to. Please wait until it completes.")),
+                Text(""),
+                self.spinner,
+            ]))

--- a/subiquity/ui/views/filesystem/tests/test_partition.py
+++ b/subiquity/ui/views/filesystem/tests/test_partition.py
@@ -21,7 +21,7 @@ FakeStorageInfo.__new__.__defaults__ = (None,) * len(FakeStorageInfo._fields)
 
 
 def make_model_and_disk():
-    model = FilesystemModel(prober=None)
+    model = FilesystemModel()
     model._disk_info.append(FakeStorageInfo(
         name='disk-name', size=100*(2**30), free=50*(2**30)))
     model.reset()

--- a/subiquitycore/prober.py
+++ b/subiquitycore/prober.py
@@ -17,8 +17,7 @@ import logging
 import yaml
 from probert.network import (StoredDataObserver,
                              UdevObserver)
-from probert.storage import (Storage,
-                             StorageInfo)
+from probert.storage import Storage
 
 log = logging.getLogger('subiquitycore.prober')
 
@@ -62,17 +61,12 @@ class Prober():
             observer = UdevObserver(receiver)
         return observer, observer.start()
 
-    def get_storage(self):
+    def get_storage(self, probe_types=None):
         ''' Load a StorageInfo class.  Probe if it's not present '''
         if 'storage' not in self.probe_data:
             log.debug('get_storage: no storage in probe_data, fetching')
             storage = Storage()
-            results = storage.probe()
+            results = storage.probe(probe_types=probe_types)
             self.probe_data['storage'] = results
 
         return self.probe_data['storage']
-
-    def get_storage_info(self, device):
-        ''' Load a StorageInfo class for specified device '''
-        return StorageInfo(
-            {device: self.get_storage()['blockdev'].get(device)})

--- a/subiquitycore/ui/utils.py
+++ b/subiquitycore/ui/utils.py
@@ -218,7 +218,8 @@ def button_pile(buttons):
         Pile(buttons), min_width=width, width=width, align='center')
 
 
-def screen(rows, buttons, focus_buttons=True, excerpt=None, narrow_rows=False):
+def screen(rows, buttons=None, focus_buttons=True, excerpt=None,
+           narrow_rows=False):
     """Helper to create a common screen layout.
 
     The commonest screen layout in subiquity is:


### PR DESCRIPTION
This changes storage probing in a few ways:

 * it runs in the background thread
 * if storage probing fails or takes more than 5 seconds, it probes again but just for block devices
 * if probing still fails, it displays an error rather than just crashing out

If we'd done this before disco release we'd be able to fix bugs like https://bugs.launchpad.net/subiquity/+bug/1825479 via a snap update. Oh well.