### PR TITLE
Use the names mdadm uses for the raid levels in mdadm --detail --export

### DIFF
--- a/subiquity/controllers/filesystem.py
+++ b/subiquity/controllers/filesystem.py
@@ -173,6 +173,8 @@ class FilesystemController(BaseController):
         return {self._action_get(d): 'active' for d in devices}
 
     def _action_clean_level(self, level):
+        if isinstance(level, int):
+            level = "raid" + str(level)
         return raidlevels_by_value[level]
 
     def _answers_action(self, action):

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -88,11 +88,11 @@ class RaidLevel:
 
 
 raidlevels = [
-    RaidLevel(_("0 (striped)"),  0,  2, False),
-    RaidLevel(_("1 (mirrored)"), 1,  2),
-    RaidLevel(_("5"),            5,  3),
-    RaidLevel(_("6"),            6,  4),
-    RaidLevel(_("10"),           10, 4),
+    RaidLevel(_("0 (striped)"),  "raid0",  2, False),
+    RaidLevel(_("1 (mirrored)"), "raid1",  2),
+    RaidLevel(_("5"),            "raid5",  3),
+    RaidLevel(_("6"),            "raid6",  4),
+    RaidLevel(_("10"),           "raid10", 4),
     ]
 raidlevels_by_value = {l.value: l for l in raidlevels}
 
@@ -163,15 +163,15 @@ def get_raid_size(level, devices):
     min_size = min(dev.size for dev in devices) - RAID_OVERHEAD
     if min_size <= 0:
         return 0
-    if level == 0:
+    if level == "raid0":
         return min_size * len(devices)
-    elif level == 1:
+    elif level == "raid1":
         return min_size
-    elif level == 5:
+    elif level == "raid5":
         return (min_size - RAID_OVERHEAD) * (len(devices) - 1)
-    elif level == 6:
+    elif level == "raid6":
         return (min_size - RAID_OVERHEAD) * (len(devices) - 2)
-    elif level == 10:
+    elif level == "raid10":
         return min_size * (len(devices) // 2)
     else:
         raise ValueError("unknown raid level %s" % level)
@@ -611,7 +611,7 @@ class Raid(_Device):
     type = const("raid")
     preserve = attr.ib(default=False)
     name = attr.ib(default=None)
-    raidlevel = attr.ib(default=None)  # 0, 1, 5, 6, 10
+    raidlevel = attr.ib(default=None)  # raid0, raid1, raid5, raid6, raid10
     devices = reflist(backlink="_constructed_device")  # set([_Formattable])
     spare_devices = reflist(backlink="_constructed_device")  # ditto
     ptable = attr.ib(default=None)
@@ -632,7 +632,7 @@ class Raid(_Device):
         return self.name
 
     def desc(self):
-        return _("software RAID {}").format(self.raidlevel)
+        return _("software RAID {}").format(self.raidlevel[4:])
 
     supported_actions = [
         DeviceAction.EDIT,

--- a/subiquity/ui/views/filesystem/raid.py
+++ b/subiquity/ui/views/filesystem/raid.py
@@ -135,7 +135,7 @@ class RaidStretchy(Stretchy):
             initial = {
                 'devices': {},
                 'name': name,
-                'level': raidlevels_by_value[1],
+                'level': raidlevels_by_value["raid1"],
                 'size': '-',
                 }
         else:

--- a/subiquity/ui/views/filesystem/tests/test_raid.py
+++ b/subiquity/ui/views/filesystem/tests/test_raid.py
@@ -38,13 +38,12 @@ class RaidViewTests(unittest.TestCase):
         form_data = {
             'name': 'md0',
             'devices': {part1: 'active', part2: 'active', part3: 'spare'},
-            'level': raidlevels_by_value[1],
             }
         expected_data = {
             'name': 'md0',
             'devices': {part1, part2},
             'spare_devices': {part3},
-            'level': raidlevels_by_value[1],
+            'level': raidlevels_by_value["raid1"],
             }
         view_helpers.enter_data(stretchy.form, form_data)
         view_helpers.click(stretchy.form.done_btn.base_widget)
@@ -55,17 +54,17 @@ class RaidViewTests(unittest.TestCase):
         model, disk = make_model_and_disk()
         part1 = model.add_partition(disk, 10*(2**30))
         part2 = model.add_partition(disk, 10*(2**30))
-        raid = model.add_raid("md0", 1, {part1, part2}, set())
+        raid = model.add_raid("md0", "raid1", {part1, part2}, set())
         view, stretchy = make_view(model, raid)
         form_data = {
             'name': 'md1',
-            'level': raidlevels_by_value[0],
+            'level': raidlevels_by_value["raid0"],
             }
         expected_data = {
             'name': 'md1',
             'devices': {part1, part2},
             'spare_devices': set(),
-            'level': raidlevels_by_value[0],
+            'level': raidlevels_by_value["raid0"],
             }
         view_helpers.enter_data(stretchy.form, form_data)
         view_helpers.click(stretchy.form.done_btn.base_widget)


### PR DESCRIPTION
These names are what end up in udev as MD_LEVEL and so in the probert
output and so will end up in the regenerated curtin config for a system
with an existing RAID. It makes life a little bit easier for subiquity
to use the same names too.