### PR TITLE
Flags that do not indicate a bootloader partition are ok_for_raid

### DIFF
--- a/scripts/validate-yaml.py
+++ b/scripts/validate-yaml.py
@@ -16,7 +16,7 @@ class StorageChecker:
         assert 'size' in action
         assert action['device'] in self.actions
         assert 'ptable' in self.actions[action['device']]
-        if action['flag']:
+        if action['flag'] in ('boot', 'bios_grub', 'prep'):
             assert self.actions[action['device']]['type'] == 'disk'
 
     def _check_format(self, action):

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -594,7 +594,7 @@ class Partition(_Formattable):
 
     @property
     def ok_for_raid(self):
-        if self.flag:
+        if self.flag in ('boot', 'bios_grub', 'prep'):
             return False
         if self._fs is not None:
             return False


### PR DESCRIPTION
Existing partitions can turn up with flags like "linux" and these are
fine to put into a RAID. I also checked all the other places we inspect
flag to check they weren't being over strict and they seem fine.