### PR TITLE
Introduce the idea of filesystem action annotations

### DIFF
--- a/subiquity/ui/views/filesystem/filesystem.py
+++ b/subiquity/ui/views/filesystem/filesystem.py
@@ -407,10 +407,8 @@ class DeviceList(WidgetWrap):
         for device in devices:
             menu = self._action_menu_for_device(device)
             label = device.label
-            if device.type == "lvm_volgroup":
-                member = next(iter(device.devices))
-                if member.type == "dm_crypt":
-                    label += _(" (encrypted)")
+            if device.annotations:
+                label = "{} ({})".format(label, ", ".join(device.annotations))
             cells = [
                 Text("["),
                 Text(label),
@@ -437,9 +435,13 @@ class DeviceList(WidgetWrap):
                     part_size = "{:>9} ({}%)".format(
                         humanize_size(part.size),
                         int(100 * part.size / device.size))
+                    part_label = part.short_label
+                    if part.annotations:
+                        part_label = "{} ({})".format(
+                            part_label, ", ".join(part.annotations))
                     cells = [
                         Text("["),
-                        Text("  " + part.short_label),
+                        Text("  " + part_label),
                         (2, Text(part_size)),
                         menu,
                         Text("]"),
@@ -447,12 +449,10 @@ class DeviceList(WidgetWrap):
                     row = make_action_menu_row(cells, menu, cursor_x=4)
                     rows.append(row)
                     if part.flag in ["bios_grub", "prep"]:
-                        label = part.flag
-                    else:
-                        label = _usage_label(part)
+                        continue
                     rows.append(TableRow([
                         Text(""),
-                        (3, Text("    " + label)),
+                        (3, Text("    " + _usage_label(part))),
                         Text(""),
                         Text(""),
                     ]))

--- a/subiquity/ui/views/filesystem/tests/test_partition.py
+++ b/subiquity/ui/views/filesystem/tests/test_partition.py
@@ -1,6 +1,5 @@
 import unittest
 from unittest import mock
-from collections import namedtuple
 
 import urwid
 
@@ -10,22 +9,11 @@ from subiquitycore.view import BaseView
 from subiquity.controllers.filesystem import FilesystemController
 from subiquity.models.filesystem import (
     dehumanize_size,
-    FilesystemModel,
+    )
+from subiquity.models.tests.test_filesystem import (
+    make_model_and_disk,
     )
 from subiquity.ui.views.filesystem.partition import PartitionStretchy
-
-
-FakeStorageInfo = namedtuple(
-    'FakeStorageInfo', ['name', 'size', 'free', 'serial', 'model'])
-FakeStorageInfo.__new__.__defaults__ = (None,) * len(FakeStorageInfo._fields)
-
-
-def make_model_and_disk():
-    model = FilesystemModel()
-    model._disk_info.append(FakeStorageInfo(
-        name='disk-name', size=100*(2**30), free=50*(2**30)))
-    model.reset()
-    return model, model._actions[0]
 
 
 def make_view(model, disk, partition=None):


### PR DESCRIPTION
This generalizes the way we display if a VG is encrypted and the way we
display the bootloader partitions, and will be how new/existing is
displayed when reusing existing partitions happens.