### PR TITLE
netplan.Config().config should initialize to a dict

### DIFF
--- a/subiquitycore/netplan.py
+++ b/subiquitycore/netplan.py
@@ -18,7 +18,7 @@ class Config:
 
     def __init__(self):
         self.devices = []
-        self.config = []
+        self.config = {}
 
     def parse_netplan_config(self, config):
         try:


### PR DESCRIPTION
Normally netplan.Config().config is a dict as produced by
yaml.safe_load(). However, on systems without any netplan configs that
is not true. The subiquity code that calls into this function expects
.config to be a dictionary. When it's not
subiquitycore/models/network.py produces traceback that "list does not
have get method" when trying to get 'network' key.