### PR TITLE
Refactor how model configs are combined

### DIFF
--- a/console_conf/core.py
+++ b/console_conf/core.py
@@ -28,7 +28,7 @@ class ConsoleConf(Application):
 
     project = "console_conf"
 
-    model_class = ConsoleConfModel
+    make_model = ConsoleConfModel
 
     controllers = [
         "Welcome",

--- a/subiquity/core.py
+++ b/subiquity/core.py
@@ -36,7 +36,11 @@ class Subiquity(Application):
 
     project = "subiquity"
 
-    model_class = SubiquityModel
+    def make_model(self, common):
+        root = '/'
+        if common['opts'].dry_run:
+            root = os.path.abspath('.subiquity')
+        return SubiquityModel(root, common['opts'].sources)
 
     controllers = [
             "Welcome",

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -890,7 +890,7 @@ class FilesystemModel(object):
     def reset(self):
         self._actions = [Disk.from_info(info) for info in self._disk_info]
 
-    def render(self):
+    def _render_actions(self):
         # The curtin storage config has the constraint that an action must be
         # preceded by all the things that it depends on.  We handle this by
         # repeatedly iterating over all actions and checking if we can emit
@@ -943,6 +943,17 @@ class FilesystemModel(object):
             work = next_work
 
         return r
+
+    def render(self):
+        config = {
+            'storage': {
+                'version': 1,
+                'config': self._render_actions(),
+                },
+            }
+        if not self.add_swapfile():
+            config['swap'] = {'size': 0}
+        return config
 
     def _get_system_mounted_disks(self):
         # This assumes a fairly vanilla setup. It won't list as

--- a/subiquity/models/installpath.py
+++ b/subiquity/models/installpath.py
@@ -38,26 +38,30 @@ class InstallpathModel(object):
         if self.cmdline_sources:
             cmdline = [(_('Install from cli provided sources'), 'cmdline')]
         return cmdline + [
-            (_('Install Ubuntu'),                 'ubuntu'),
+            (_('Install Ubuntu'),                         'ubuntu'),
             (_('Install MAAS bare-metal cloud (region)'), 'maas_region'),
             (_('Install MAAS bare-metal cloud (rack)'),   'maas_rack'),
         ]
-
-    @property
-    def sources(self):
-        src_map = {
-            'ubuntu': ['cp:///media/filesystem'],
-            'maas_region': ['cp:///media/region'],
-            'maas_rack': ['cp:///media/rack'],
-            'cmdline': self.cmdline_sources}
-        return {self.path + "%02d" % n: u
-                for n, u in enumerate(src_map[self.path])}
 
     def update(self, results):
         self.results = results
 
     def render(self):
-        config = {}
+        src_map = {
+            'ubuntu': ['cp:///media/filesystem'],
+            'maas_region': ['cp:///media/region'],
+            'maas_rack': ['cp:///media/rack'],
+            'cmdline': self.cmdline_sources,
+            }
+        src_list = src_map[self.path]
+
+        sources = {}
+        for n, u in enumerate(src_list):
+            sources[self.path + "%02d" % n] = u
+
+        config = {
+            'sources': sources,
+            }
 
         def t(path):
             return os.path.join(self.target, path)

--- a/subiquity/models/keyboard.py
+++ b/subiquity/models/keyboard.py
@@ -211,3 +211,14 @@ class KeyboardModel:
             else:
                 scale = os.environ.get('SUBIQUITY_REPLAY_TIMESCALE', "1")
                 run_command(['sleep', str(1/float(scale))])
+
+    def render(self):
+        return {
+            'write_files': {
+                'etc_default_keyboard': {
+                    'path': 'etc/default/keyboard',
+                    'content': self.setting.render(),
+                    'permissions': 0o644,
+                    },
+                },
+            }

--- a/subiquity/models/locale.py
+++ b/subiquity/models/locale.py
@@ -15,8 +15,9 @@
 
 import gettext
 import logging
-import os
+
 from subiquitycore import i18n
+
 
 log = logging.getLogger('subiquity.models.locale')
 
@@ -48,15 +49,6 @@ class LocaleModel(object):
     ]
     selected_language = None
 
-    def __init__(self, signal):
-        self.signal = signal
-        lang = os.environ.get("LANG")
-        if lang.endswith(".UTF-8"):
-            lang = lang.rsplit('.', 1)[0]
-        for code, name in self.supported_languages:
-            if code == lang:
-                self.switch_language(code)
-
     def get_languages(self):
         languages = []
         for code, name in self.supported_languages:
@@ -70,7 +62,6 @@ class LocaleModel(object):
 
     def switch_language(self, code):
         self.selected_language = code
-        self.signal.emit_signal('l10n:language-selected', code)
         i18n.switch_language(code)
 
     def __repr__(self):

--- a/subiquity/models/mirror.py
+++ b/subiquity/models/mirror.py
@@ -35,3 +35,13 @@ class MirrorModel(object):
         parsed = parse.urlparse(DEFAULT_MIRROR)
         new = parsed._replace(netloc=cc + '.' + parsed.netloc)
         self.mirror = parse.urlunparse(new)
+
+    def render(self):
+        return {
+             'apt': {
+                 'primary': [{
+                     'arches': ["default"],
+                     'uri': self.mirror,
+                     }],
+                 }
+            }

--- a/subiquity/models/proxy.py
+++ b/subiquity/models/proxy.py
@@ -32,3 +32,26 @@ class ProxyModel(object):
 
     def proxy_systemd_dropin(self):
         return dropin_template.format(proxy=self.proxy)
+
+    def render(self):
+        if self.proxy:
+            return {
+                'apt': {
+                    'http_proxy': self.proxy,
+                    'https_proxy': self.proxy,
+                    },
+                'proxy': {
+                    'http_proxy': self.proxy,
+                    'https_proxy': self.proxy,
+                    },
+                'write_files': {
+                    'snapd_dropin': {
+                        'path': ('etc/systemd/system/'
+                                 'snapd.service.d/snap_proxy.conf'),
+                        'content': self.proxy.proxy_systemd_dropin(),
+                        'permissions': 0o644,
+                        },
+                    },
+                }
+        else:
+            return {}

--- a/subiquity/models/proxy.py
+++ b/subiquity/models/proxy.py
@@ -48,7 +48,7 @@ class ProxyModel(object):
                     'snapd_dropin': {
                         'path': ('etc/systemd/system/'
                                  'snapd.service.d/snap_proxy.conf'),
-                        'content': self.proxy.proxy_systemd_dropin(),
+                        'content': self.proxy_systemd_dropin(),
                         'permissions': 0o644,
                         },
                     },

--- a/subiquity/models/subiquity.py
+++ b/subiquity/models/subiquity.py
@@ -183,6 +183,10 @@ class SubiquityModel:
         else:
             return "media-info"
 
+    def _machine_id(self):
+        with open('/etc/machine-id') as fp:
+            return fp.read()
+
     def render(self, syslog_identifier):
         config = {
             'apt': {
@@ -229,7 +233,7 @@ class SubiquityModel:
             'write_files': {
                 'etc_machine_id': {
                     'path': 'etc/machine-id',
-                    'content': open('/etc/machine-id').read(),
+                    'content': self._machine_id(),
                     'permissions': 0o444,
                     },
                 'media_info': {

--- a/subiquity/models/subiquity.py
+++ b/subiquity/models/subiquity.py
@@ -68,18 +68,16 @@ class SubiquityModel:
 
     target = '/target'
 
-    def __init__(self, common):
-        self.root = '/'
-        self.opts = common['opts']
-        if self.opts.dry_run:
-            self.root = os.path.abspath(".subiquity")
-            self.target = self.root
+    def __init__(self, root, sources=()):
+        self.root = root
+        if root != '/':
+            self.target = root
 
-        self.locale = LocaleModel(common['signal'])
+        self.locale = LocaleModel()
         self.keyboard = KeyboardModel(self.root)
         self.installpath = InstallpathModel(
             target=self.target,
-            sources=common['opts'].sources)
+            sources=sources)
         self.network = NetworkModel(support_wlan=False)
         self.proxy = ProxyModel()
         self.mirror = MirrorModel()
@@ -101,7 +99,7 @@ class SubiquityModel:
 
     def get_target_groups(self):
         command = ['chroot', self.target, 'getent', 'group']
-        if self.opts.dry_run:
+        if self.root != '/':
             del command[:2]
         cp = run_command(command, check=True)
         groups = set()

--- a/subiquity/models/tests/test_subiquity.py
+++ b/subiquity/models/tests/test_subiquity.py
@@ -1,0 +1,137 @@
+# Copyright 2019 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import fnmatch
+import unittest
+
+from subiquity.models.subiquity import SubiquityModel
+
+
+class TestSubiquityModel(unittest.TestCase):
+
+    def writtenFiles(self, config):
+        for k, v in config.get('write_files', {}).items():
+            yield v
+
+    def assertConfigWritesFile(self, config, path):
+        self.assertIn(path, [s['path'] for s in self.writtenFiles(config)])
+
+    def writtenFilesMatching(self, config, pattern):
+        files = list(self.writtenFiles(config))
+        matching = []
+        for spec in files:
+            if fnmatch.fnmatch(spec['path'], pattern):
+                matching.append(spec)
+        return matching
+
+    def writtenFilesMatchingContaining(self, config, pattern, content):
+        matching = []
+        for spec in self.writtenFilesMatching(config, pattern):
+            if content in spec['content']:
+                matching.append(content)
+        return matching
+
+    def configVal(self, config, path):
+        cur = config
+        for component in path.split('.'):
+            if not isinstance(cur, dict):
+                self.fail(
+                    "extracting {} reached non-dict {} too early".format(
+                        path, cur))
+            if component not in cur:
+                self.fail("no value found for {}".format(path))
+            cur = cur[component]
+        return cur
+
+    def assertConfigHasVal(self, config, path, val):
+        self.assertEqual(self.configVal(config, path), val)
+
+    def assertConfigDoesNotHaveVal(self, config, path):
+        cur = config
+        for component in path.split('.'):
+            if not isinstance(cur, dict):
+                self.fail(
+                    "extracting {} reached non-dict {} too early".format(
+                        path, cur))
+            if component not in cur:
+                return
+            cur = cur[component]
+        self.fail("config has value {} for {}".format(cur, path))
+
+    def test_proxy_set(self):
+        model = SubiquityModel('test')
+        proxy_val = 'http://my-proxy'
+        model.proxy.proxy = proxy_val
+        config = model.render('ident')
+        self.assertConfigHasVal(config, 'proxy.http_proxy', proxy_val)
+        self.assertConfigHasVal(config, 'proxy.https_proxy', proxy_val)
+        self.assertConfigHasVal(config, 'apt.http_proxy', proxy_val)
+        self.assertConfigHasVal(config, 'apt.https_proxy', proxy_val)
+        confs = self.writtenFilesMatchingContaining(
+            config,
+            'etc/systemd/system/snapd.service.d/*.conf',
+            'HTTP_PROXY=' + proxy_val)
+        self.assertTrue(len(confs) > 0)
+
+    def test_proxy_notset(self):
+        model = SubiquityModel('test')
+        config = model.render('ident')
+        self.assertConfigDoesNotHaveVal(config, 'proxy.http_proxy')
+        self.assertConfigDoesNotHaveVal(config, 'proxy.https_proxy')
+        self.assertConfigDoesNotHaveVal(config, 'apt.http_proxy')
+        self.assertConfigDoesNotHaveVal(config, 'apt.https_proxy')
+        confs = self.writtenFilesMatchingContaining(
+            config,
+            'etc/systemd/system/snapd.service.d/*.conf',
+            'HTTP_PROXY=')
+        self.assertTrue(len(confs) == 0)
+
+    def test_keyboard(self):
+        model = SubiquityModel('test')
+        config = model.render('ident')
+        self.assertConfigWritesFile(config, 'etc/default/keyboard')
+
+    def test_writes_machine_id_media_info(self):
+        model_no_proxy = SubiquityModel('test')
+        model_proxy = SubiquityModel('test')
+        model_proxy.proxy = 'http://something'
+        for model in model_no_proxy, model_proxy:
+            config = model.render('ident')
+            self.assertConfigWritesFile(config, 'etc/machine-id')
+            self.assertConfigWritesFile(config, 'var/log/installer/media-info')
+
+    def test_storage_version(self):
+        model = SubiquityModel('test')
+        config = model.render('ident')
+        self.assertConfigHasVal(config, 'storage.version', 1)
+
+    def test_network_version(self):
+        model = SubiquityModel('test')
+        config = model.render('ident')
+        self.assertConfigHasVal(config, 'network.version', 2)
+
+    def test_has_sources(self):
+        model = SubiquityModel('test')
+        config = model.render('ident')
+        self.assertIn('sources', config)
+
+    def test_mirror(self):
+        model = SubiquityModel('test')
+        mirror_val = model.mirror.mirror = 'http://my-mirror'
+        config = model.render('ident')
+        val = self.configVal(config, 'apt.primary')
+        self.assertEqual(len(val), 1)
+        val = val[0]
+        self.assertEqual(val['uri'], mirror_val)

--- a/subiquity/ui/views/tests/test_welcome.py
+++ b/subiquity/ui/views/tests/test_welcome.py
@@ -24,8 +24,7 @@ class WelcomeViewTests(unittest.TestCase):
         view = self.make_view_with_languages([('code', 'native')])
         but = view_helpers.find_button_matching(view, "^native$")
         view_helpers.click(but)
-        view.model.switch_language.assert_called_once_with("code")
-        view.controller.done.assert_called_once_with()
+        view.controller.done.assert_called_once_with('code')
 
     def test_initial_focus(self):
         # The initial focus for the view is the button for the first

--- a/subiquity/ui/views/welcome.py
+++ b/subiquity/ui/views/welcome.py
@@ -56,6 +56,5 @@ class WelcomeView(BaseView):
         return lb
 
     def confirm(self, sender, code):
-        self.model.switch_language(code)
-        log.debug('calling installpath')
-        self.controller.done()
+        log.debug('WelcomeController %s', code)
+        self.controller.done(code)

--- a/subiquitycore/core.py
+++ b/subiquitycore/core.py
@@ -477,7 +477,7 @@ class Application:
 
             log.debug("Running event loop: {}".format(
                 self.common['loop'].event_loop))
-            self.common['base_model'] = self.model_class(self.common)
+            self.common['base_model'] = self.make_model(self.common)
         try:
             if self.common['opts'].scripts:
                 self.run_scripts(self.common['opts'].scripts)

--- a/subiquitycore/i18n.py
+++ b/subiquitycore/i18n.py
@@ -29,6 +29,7 @@ syslog.syslog('Final localedir is ' + localedir)
 
 
 def switch_language(code='en_US'):
+    syslog.syslog('switch_language ' + code)
     fake_trans = os.environ.get("FAKE_TRANSLATE", "0")
     if code != 'en_US' and fake_trans == "mangle":
         def my_gettext(message):


### PR DESCRIPTION
Basically each model now produces a fragment of a complete curtin config
and they are combined using curtin's merge_config function rather than
SubiquityModel.render knowing the shape of the config produced by each
model.

I've been meaning to do this for a while. It would be easy to mess things up here so please review with a bit of care.