### PR TITLE
reorganize handling of bootloader partitions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ i18n:
 	$(PYTHON) setup.py build
 
 dryrun: probert i18n
-	$(MAKE) ui-view DRYRUN="--dry-run --uefi"
+	$(MAKE) ui-view DRYRUN="--dry-run --bootloader uefi"
 
 ui-view:
 	$(PYTHON) -m subiquity $(DRYRUN) $(MACHARGS)

--- a/subiquity/cmd/tui.py
+++ b/subiquity/cmd/tui.py
@@ -63,9 +63,9 @@ def parse_options(argv):
     parser.add_argument('--machine-config', metavar='CONFIG',
                         dest='machine_config',
                         help="Don't Probe. Use probe data file")
-    parser.add_argument('--uefi', action='store_true',
-                        dest='uefi',
-                        help='run in uefi support mode')
+    parser.add_argument('--bootloader',
+                        choices=['none', 'bios', 'prep', 'uefi'],
+                        help='Override style of bootloader to use')
     parser.add_argument('--screens', action='append', dest='screens',
                         default=[])
     parser.add_argument('--script', metavar="SCRIPT", action='append',

--- a/subiquity/controllers/filesystem.py
+++ b/subiquity/controllers/filesystem.py
@@ -58,8 +58,9 @@ class FilesystemController(BaseController):
     def __init__(self, common):
         super().__init__(common)
         self.model = self.base_model.filesystem
-        if self.opts.dry_run and self.opts.uefi:
-            self.model.bootloader = Bootloader.UEFI
+        if self.opts.dry_run and self.opts.bootloader:
+            name = self.opts.bootloader.upper()
+            self.model.bootloader = getattr(Bootloader, name)
         self.answers = self.all_answers.get("Filesystem", {})
         self.answers.setdefault('guided', False)
         self.answers.setdefault('guided-index', 0)

--- a/subiquity/controllers/filesystem.py
+++ b/subiquity/controllers/filesystem.py
@@ -15,8 +15,6 @@
 
 import enum
 import logging
-import os
-import platform
 
 from probert.storage import StorageInfo
 
@@ -24,6 +22,7 @@ from subiquitycore.controller import BaseController
 
 from subiquity.models.filesystem import (
     align_up,
+    Bootloader,
     DeviceAction,
     Partition,
     raidlevels_by_value,
@@ -59,6 +58,8 @@ class FilesystemController(BaseController):
     def __init__(self, common):
         super().__init__(common)
         self.model = self.base_model.filesystem
+        if self.opts.dry_run and self.opts.uefi:
+            self.model.bootloader = Bootloader.UEFI
         self.answers = self.all_answers.get("Filesystem", {})
         self.answers.setdefault('guided', False)
         self.answers.setdefault('guided-index', 0)
@@ -294,7 +295,8 @@ class FilesystemController(BaseController):
         self.model.remove_partition(part)
 
     def _create_boot_partition(self, disk):
-        if self.is_uefi():
+        bootloader = self.model.bootloader
+        if bootloader == Bootloader.UEFI:
             part_size = UEFI_GRUB_SIZE_BYTES
             if UEFI_GRUB_SIZE_BYTES*2 >= disk.size:
                 part_size = disk.size // 2
@@ -303,7 +305,7 @@ class FilesystemController(BaseController):
                 disk,
                 dict(size=part_size, fstype='fat32', mount='/boot/efi'),
                 flag="boot")
-        elif self.is_prep():
+        elif bootloader == Bootloader.PREP:
             log.debug('Adding PReP gpt partition first')
             part = self.create_partition(
                 disk,
@@ -311,14 +313,14 @@ class FilesystemController(BaseController):
                 # must be wiped or grub-install will fail
                 wipe='zero',
                 flag='prep')
-        else:
+        elif bootloader == Bootloader.BIOS:
             log.debug('Adding grub_bios gpt partition first')
             part = self.create_partition(
                 disk,
                 dict(size=BIOS_GRUB_SIZE_BYTES, fstype=None, mount=None),
                 flag='bios_grub')
         # should _not_ specify grub device for prep
-        if not self.is_prep():
+        if bootloader != Bootloader.PREP:
             disk.grub_device = True
         return part
 
@@ -481,12 +483,3 @@ class FilesystemController(BaseController):
                 largest_part.size -= (
                     boot_partition.size - new_boot_disk.free_for_partitions)
         self._create_boot_partition(new_boot_disk)
-
-    def is_uefi(self):
-        if self.opts.dry_run:
-            return self.opts.uefi
-
-        return os.path.exists('/sys/firmware/efi')
-
-    def is_prep(self):
-        return platform.machine().startswith("ppc64")

--- a/subiquity/controllers/filesystem.py
+++ b/subiquity/controllers/filesystem.py
@@ -313,15 +313,14 @@ class FilesystemController(BaseController):
                 # must be wiped or grub-install will fail
                 wipe='zero',
                 flag='prep')
+            self.model.grub_install_device = part
         elif bootloader == Bootloader.BIOS:
             log.debug('Adding grub_bios gpt partition first')
             part = self.create_partition(
                 disk,
                 dict(size=BIOS_GRUB_SIZE_BYTES, fstype=None, mount=None),
                 flag='bios_grub')
-        # should _not_ specify grub device for prep
-        if bootloader != Bootloader.PREP:
-            disk.grub_device = True
+            self.model.grub_install_device = disk
         return part
 
     def create_raid(self, spec):
@@ -472,7 +471,6 @@ class FilesystemController(BaseController):
             boot_disk = boot_partition.device
             full = boot_disk.free_for_partitions == 0
             self.delete_partition(boot_partition)
-            boot_disk.grub_device = False
             if full:
                 largest_part = max(
                     boot_disk.partitions(), key=lambda p: p.size)

--- a/subiquity/controllers/tests/test_filesystem.py
+++ b/subiquity/controllers/tests/test_filesystem.py
@@ -24,16 +24,21 @@ from subiquity.models.tests.test_filesystem import (
     )
 
 
-class FakeBaseModel:
+class Thing:
+    # Just something to hang attributes off
     pass
 
 
 def make_controller_and_disk():
     common = defaultdict(type(None))
-    bm = FakeBaseModel()
+    bm = Thing()
     bm.filesystem, disk = make_model_and_disk()
     common['base_model'] = bm
     common['answers'] = {}
+    opts = Thing()
+    opts.dry_run = True
+    opts.uefi = True
+    common['opts'] = opts
     controller = FilesystemController(common)
     return controller, disk
 

--- a/subiquity/controllers/tests/test_filesystem.py
+++ b/subiquity/controllers/tests/test_filesystem.py
@@ -37,7 +37,7 @@ def make_controller_and_disk():
     common['answers'] = {}
     opts = Thing()
     opts.dry_run = True
-    opts.uefi = True
+    opts.bootloader = "UEFI"
     common['opts'] = opts
     controller = FilesystemController(common)
     return controller, disk

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -70,6 +70,7 @@ def _remove_backlinks(obj):
 
 def fsobj(c):
     c.__attrs_post_init__ = _set_backlinks
+    c._m = attr.ib(default=None)
     return attr.s(cmp=False)(c)
 
 
@@ -484,8 +485,8 @@ class Disk(_Device):
     _info = attr.ib(default=None)
 
     @classmethod
-    def from_info(self, info):
-        d = Disk(info=info)
+    def from_info(self, model, info):
+        d = Disk(m=model, info=info)
         d.serial = info.serial
         d.path = info.name
         d.model = info.model
@@ -915,7 +916,8 @@ class FilesystemModel(object):
         self.reset()
 
     def reset(self):
-        self._actions = [Disk.from_info(info) for info in self._disk_info]
+        self._actions = [
+            Disk.from_info(self, info) for info in self._disk_info]
 
     def _render_actions(self):
         # The curtin storage config has the constraint that an action must be
@@ -1020,7 +1022,7 @@ class FilesystemModel(object):
                 if info.size < self.lower_size_limit:
                     continue
                 self._disk_info.append(info)
-                self._actions.append(Disk.from_info(info))
+                self._actions.append(Disk.from_info(self, info))
 
     def disk_by_path(self, path):
         for a in self._actions:
@@ -1070,7 +1072,8 @@ class FilesystemModel(object):
         log.debug("add_partition: rounded size from %s to %s", size, real_size)
         if disk._fs is not None:
             raise Exception("%s is already formatted" % (disk.label,))
-        p = Partition(device=disk, size=real_size, flag=flag, wipe=wipe)
+        p = Partition(
+            m=self, device=disk, size=real_size, flag=flag, wipe=wipe)
         if flag in ("boot", "bios_grub", "prep"):
             disk._partitions.insert(0, disk._partitions.pop())
         disk.ptable = 'gpt'
@@ -1087,6 +1090,7 @@ class FilesystemModel(object):
 
     def add_raid(self, name, raidlevel, devices, spare_devices):
         r = Raid(
+            m=self,
             name=name,
             raidlevel=raidlevel,
             devices=devices,
@@ -1101,7 +1105,7 @@ class FilesystemModel(object):
         self._actions.remove(raid)
 
     def add_volgroup(self, name, devices):
-        vg = LVM_VolGroup(name=name, devices=devices)
+        vg = LVM_VolGroup(m=self, name=name, devices=devices)
         self._actions.append(vg)
         return vg
 
@@ -1112,7 +1116,7 @@ class FilesystemModel(object):
         self._actions.remove(vg)
 
     def add_logical_volume(self, vg, name, size):
-        lv = LVM_LogicalVolume(volgroup=vg, name=name, size=size)
+        lv = LVM_LogicalVolume(m=self, volgroup=vg, name=name, size=size)
         self._actions.append(lv)
         return lv
 
@@ -1142,7 +1146,7 @@ class FilesystemModel(object):
                     raise Exception("{} is not available".format(volume))
         if volume._fs is not None:
             raise Exception("%s is already formatted")
-        fs = Filesystem(volume=volume, fstype=fstype)
+        fs = Filesystem(m=self, volume=volume, fstype=fstype)
         self._actions.append(fs)
         return fs
 
@@ -1155,7 +1159,7 @@ class FilesystemModel(object):
     def add_mount(self, fs, path):
         if fs._mount is not None:
             raise Exception("%s is already mounted")
-        m = Mount(device=fs, path=path)
+        m = Mount(m=self, device=fs, path=path)
         self._actions.append(m)
         return m
 

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -541,14 +541,18 @@ class Disk(_Device):
             return self.serial
         return self.path
 
-    supported_actions = [
-        DeviceAction.INFO,
-        DeviceAction.PARTITION,
-        DeviceAction.FORMAT,
-        DeviceAction.REMOVE,
-        ]
-    if platform.machine() != 's390x':
-        supported_actions.append(DeviceAction.MAKE_BOOT)
+    @property
+    def supported_actions(self):
+        actions = [
+            DeviceAction.INFO,
+            DeviceAction.PARTITION,
+            DeviceAction.FORMAT,
+            DeviceAction.REMOVE,
+            ]
+        if self._m.bootloader != Bootloader.NONE:
+            actions.append(DeviceAction.MAKE_BOOT)
+        return actions
+
     _can_INFO = True
     _can_PARTITION = property(lambda self: self.free_for_partitions > 0)
     _can_FORMAT = property(

--- a/subiquity/ui/views/filesystem/tests/test_filesystem.py
+++ b/subiquity/ui/views/filesystem/tests/test_filesystem.py
@@ -21,21 +21,21 @@ FakeStorageInfo.__new__.__defaults__ = (None,) * len(FakeStorageInfo._fields)
 
 class FilesystemViewTests(unittest.TestCase):
 
-    def make_view(self, devices=[]):
+    def make_view(self, model, devices=[]):
         controller = mock.create_autospec(spec=FilesystemController)
         controller.ui = mock.Mock()
-        model = mock.create_autospec(spec=FilesystemModel)
         model.all_devices.return_value = devices
         return FilesystemView(model, controller)
 
     def test_simple(self):
-        self.make_view()
+        self.make_view(mock.create_autospec(spec=FilesystemModel))
 
     def test_one_disk(self):
-        disk = Disk.from_info(FakeStorageInfo(
+        model = mock.create_autospec(spec=FilesystemModel)
+        disk = Disk.from_info(model, FakeStorageInfo(
             name='disk-name', size=100*(2**20), free=50*(2**20),
             serial="DISK-SERIAL"))
-        view = self.make_view([disk])
+        view = self.make_view(model, [disk])
         w = view_helpers.find_with_pred(
             view,
             lambda w: isinstance(w, urwid.Text) and "DISK-SERIAL" in w.text)

--- a/subiquity/ui/views/filesystem/tests/test_filesystem.py
+++ b/subiquity/ui/views/filesystem/tests/test_filesystem.py
@@ -25,6 +25,7 @@ class FilesystemViewTests(unittest.TestCase):
         controller = mock.create_autospec(spec=FilesystemController)
         controller.ui = mock.Mock()
         model.all_devices.return_value = devices
+        model.grub_install_device = None
         return FilesystemView(model, controller)
 
     def test_simple(self):

--- a/subiquity/ui/views/filesystem/tests/test_filesystem.py
+++ b/subiquity/ui/views/filesystem/tests/test_filesystem.py
@@ -8,6 +8,7 @@ from subiquitycore.testing import view_helpers
 
 from subiquity.controllers.filesystem import FilesystemController
 from subiquity.models.filesystem import (
+    Bootloader,
     Disk,
     FilesystemModel,
     )
@@ -24,6 +25,7 @@ class FilesystemViewTests(unittest.TestCase):
     def make_view(self, model, devices=[]):
         controller = mock.create_autospec(spec=FilesystemController)
         controller.ui = mock.Mock()
+        model.bootloader = Bootloader.NONE
         model.all_devices.return_value = devices
         model.grub_install_device = None
         return FilesystemView(model, controller)


### PR DESCRIPTION
This includes #477 so go review that first.

The upshot is that we no longer set grub_device on any disks but rather track the boot device as grub_install_device on the FilesystemModel object if necessary -- it's not needed for s390x or UEFI boots. This should be easier to make work with existing partitions.