### PR TITLE
Add generic clear and delete methods to FilesystemController

### DIFF
--- a/subiquity/ui/views/filesystem/delete.py
+++ b/subiquity/ui/views/filesystem/delete.py
@@ -63,7 +63,7 @@ class ConfirmDeleteStretchy(Stretchy):
         super().__init__(title, widgets, 0, 2)
 
     def confirm(self, sender=None):
-        getattr(self.parent.controller, 'delete_' + self.obj.type)(self.obj)
+        self.parent.controller.delete(self.obj)
         self.parent.refresh_model_inputs()
         self.parent.remove_overlay()
 


### PR DESCRIPTION
The guided "use a whole disk" flow in reusing existing partitions is
going to need to be able to generically destroy the existing users of
a disk, something that subiquity does not currently let you do (you
can't delete a RAID if is part of another RAID, for example). So add
generic ways of clearing and deleting objects.