### PR TITLE
 allow /boot to be on any kind of device

### DIFF
--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -1210,20 +1210,9 @@ class FilesystemModel(object):
     def is_root_mounted(self):
         return self._mount_for_path('/') is not None
 
-    def is_slash_boot_on_local_disk(self):
-        for path in '/boot', '/':
-            mount = self._mount_for_path(path)
-            if mount is not None:
-                dev = mount.device.volume
-                return (
-                    isinstance(dev, Partition)
-                    and isinstance(dev.device, Disk))
-        return False
-
     def can_install(self):
         return (self.is_root_mounted()
-                and not self.needs_bootloader_partition()
-                and self.is_slash_boot_on_local_disk())
+                and not self.needs_bootloader_partition())
 
     def _should_add_swapfile(self):
         mount = self._mount_for_path('/')

--- a/subiquity/ui/mount.py
+++ b/subiquity/ui/mount.py
@@ -46,13 +46,11 @@ LEAVE_UNMOUNTED = object()
 
 
 class MountSelector(WidgetWrap):
-    def __init__(self, mountpoints, ok_for_slash_boot):
+    def __init__(self, mountpoints):
         opts = []
         first_opt = None
         for i, mnt in enumerate(common_mountpoints):
-            if not ok_for_slash_boot and mnt == "/boot":
-                opts.append((mnt, False))
-            elif mnt not in mountpoints:
+            if mnt not in mountpoints:
                 if first_opt is None:
                     first_opt = i
                 opts.append((mnt, True, mnt))
@@ -117,4 +115,4 @@ class MountField(FormField):
     takes_default_style = False
 
     def _make_widget(self, form):
-        return MountSelector(form.mountpoints, form.ok_for_slash_boot)
+        return MountSelector(form.mountpoints)

--- a/subiquity/ui/views/filesystem/filesystem.py
+++ b/subiquity/ui/views/filesystem/filesystem.py
@@ -576,10 +576,6 @@ class FilesystemView(BaseView):
             elif not self.model.is_root_mounted():
                 self.controller.ui.set_footer(
                     _("You need to mount a device at / to continue."))
-            elif not self.model.is_slash_boot_on_local_disk():
-                self.controller.ui.set_footer(
-                    _("You must mount a partition of a local disk at /boot to "
-                      "continue."))
 
     def create_raid(self, button=None):
         self.show_stretchy_overlay(RaidStretchy(self))

--- a/subiquity/ui/views/filesystem/partition.py
+++ b/subiquity/ui/views/filesystem/partition.py
@@ -128,14 +128,12 @@ LVNameField = simple_field(LVNameEditor)
 
 class PartitionForm(Form):
 
-    def __init__(self, model, max_size, initial, ok_for_slash_boot,
-                 lvm_names):
+    def __init__(self, model, max_size, initial, lvm_names):
         self.model = model
         initial_path = initial.get('mount')
         self.mountpoints = {
             m.path: m.device.volume for m in self.model.all_mounts()
             if m.path != initial_path}
-        self.ok_for_slash_boot = ok_for_slash_boot
         self.max_size = max_size
         if max_size is not None:
             self.size_str = humanize_size(max_size)
@@ -203,8 +201,6 @@ class PartitionForm(Form):
         if dev is not None:
             return _("{} is already mounted at {}.").format(
                 dev.label.title(), mount)
-        if mount == "/boot" and not self.ok_for_slash_boot:
-            return _("/boot must be on a partition of a local disk.")
 
 
 bios_grub_partition_description = _(
@@ -279,8 +275,7 @@ class PartitionStretchy(Stretchy):
                     x += 1
                 initial['name'] = name
 
-        self.form = PartitionForm(
-            self.model, max_size, initial, isinstance(disk, Disk), lvm_names)
+        self.form = PartitionForm(self.model, max_size, initial, lvm_names)
 
         if not isinstance(disk, LVM_VolGroup):
             self.form.remove_field('name')
@@ -385,7 +380,7 @@ class FormatEntireStretchy(Stretchy):
                     initial['mount'] = mount.path
         elif not isinstance(device, Disk):
             initial['fstype'] = 'ext4'
-        self.form = PartitionForm(self.model, 0, initial, False, None)
+        self.form = PartitionForm(self.model, 0, initial, None)
         self.form.remove_field('size')
         self.form.remove_field('name')
 


### PR DESCRIPTION
This includes a workaround for the issue causing RAID installs to fail (which will make LVM installs fail), so should not be landed as is.

I also had got the impression that when /boot was on RAID, grub would always show its menu. That didn't happen in my test.