### PR TITLE
configure curtin to avoid writing files to /target/etc/grub.d

### DIFF
--- a/subiquity/models/subiquity.py
+++ b/subiquity/models/subiquity.py
@@ -202,6 +202,11 @@ class SubiquityModel:
                     ],
                 },
 
+            'grub': {
+                'terminal': 'unmodified',
+                'probe_additional_os': True
+                },
+
             'install': {
                 'target': self.target,
                 'unmount': 'disabled',


### PR DESCRIPTION
This will not actually do with the version of curtin we currently build
but it will not hurt either.