### PR TITLE
Fix Disk._can_MAKE_BOOT on a UEFI system

### DIFF
--- a/subiquity/controllers/tests/test_filesystem.py
+++ b/subiquity/controllers/tests/test_filesystem.py
@@ -22,6 +22,9 @@ from subiquity.controllers.filesystem import (
 from subiquity.models.tests.test_filesystem import (
     make_model_and_disk,
     )
+from subiquity.models.filesystem import (
+    Bootloader,
+    )
 
 
 class Thing:
@@ -57,3 +60,17 @@ class TestFilesystemController(unittest.TestCase):
         dm_crypts = [
             a for a in controller.model._actions if a.type == 'dm_crypt']
         self.assertEqual(dm_crypts, [])
+
+    def test_can_only_make_boot_once(self):
+        # This is really testing model code but it's much easier to test with a
+        # controller around.
+        for bl in Bootloader:
+            if bl == Bootloader.NONE:
+                continue
+            controller, disk = make_controller_and_disk()
+            controller.model.bootloader = bl
+            controller.make_boot_disk(disk)
+            self.assertFalse(
+                disk._can_MAKE_BOOT,
+                "make_boot_disk(disk) did not make _can_MAKE_BOOT false with "
+                "bootloader {}".format(bl))

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -593,12 +593,17 @@ class Disk(_Device):
 
     @property
     def _can_MAKE_BOOT(self):
-        install_dev = self._m.grub_install_device
-        if install_dev:
-            # For the PReP case, the install_device is the prep partition.
-            if install_dev.type == "partition":
-                install_dev = install_dev.device
-            if install_dev is self:
+        bl = self._m.bootloader
+        if bl == Bootloader.BIOS:
+            if self._m.grub_install_device is self:
+                return False
+        elif bl == Bootloader.UEFI:
+            m = self._m._mount_for_path('/boot/efi')
+            if m and m.device.volume.device is self:
+                return False
+        elif bl == Bootloader.PREP:
+            install_dev = self._m.grub_install_device
+            if install_dev.device is self:
                 return False
         return self._fs is None and self._constructed_device is None
 


### PR DESCRIPTION
A recent refactoring left MAKE_BOOT action always enabled for the UEFI
bootloader mode. Fix + test.