### PR TITLE
only run filesystem actions from answers once

### DIFF
--- a/subiquity/controllers/filesystem.py
+++ b/subiquity/controllers/filesystem.py
@@ -227,6 +227,7 @@ class FilesystemController(BaseController):
             self.finish()
         if self.answers['manual']:
             self._run_iterator(self._run_actions(self.answers['manual']))
+            self.answers['manual'] = []
 
     def guided(self, method):
         v = GuidedDiskSelectionView(self.model, self, method)


### PR DESCRIPTION
This means you can use an answers file that leaves you on the filesystem
screen, click "back" to choose a different option and not have
everything fall over in a heap.