### PR TITLE
Lots of new things.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,8 @@
-subiquity (0.0.30) UNRELEASED; urgency=medium
+subiquity (19.06.1) eoan; urgency=medium
 
-  * Losts of new things.
+  * Lots of new things.
 
- -- Michael Hudson-Doyle <mwhudson@debian.org>  Fri, 16 Mar 2018 14:54:48 +1300
+ -- Dimitri John Ledkov <xnox@ubuntu.com>  Tue, 25 Jun 2019 10:14:53 +0100
 
 subiquity (0.0.29) zesty; urgency=medium
 

--- a/debian/control
+++ b/debian/control
@@ -1,10 +1,9 @@
 Source: subiquity
 Section: admin
-Priority: extra
+Priority: optional
 Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
-Build-Depends: debhelper (>= 9),
+Build-Depends: debhelper (>= 9.20160709),
                dh-python,
-               dh-systemd,
                git,
                iso-codes,
                python3,
@@ -12,11 +11,11 @@ Build-Depends: debhelper (>= 9),
                python3-distutils-extra,
                python3-setuptools,
                python3-yaml
-Standards-Version: 3.9.5
+Standards-Version: 4.3.0
 Homepage: https://github.com/CanonicalLtd/subiquity
-X-Python3-Version: >= 3.3
 Vcs-Browser: https://github.com/CanonicalLtd/subiquity
 Vcs-Git: https://github.com/CanonicalLtd/subiquity.git
+XS-Ubuntu-Use-Langpack: yes
 
 Package: subiquity
 Architecture: all

--- a/debian/rules
+++ b/debian/rules
@@ -18,21 +18,22 @@ override_dh_auto_clean:
 
 override_dh_install:
 	rm -rf $(PYBUILD_DESTDIR)usr/share/subiquity/subiquity-0.0.5.egg-info
-	dh_install --fail-missing
+	dh_install
+	dh_missing --fail-missing
 
 override_dh_python3:
 	dh_python3 --ignore-shebangs
 
 override_dh_installinit:
-	dh_installinit --no-start --name=console-conf@
-	dh_installinit --no-start --name=serial-console-conf@
+	dh_installsystemd --no-start --name=console-conf@
+	dh_installsystemd --no-start --name=serial-console-conf@
 	mkdir $(CURDIR)/debian/console-conf/lib/systemd/system/getty@.service.d/
 	install -m 0644 $(CURDIR)/debian/console-conf.conf $(CURDIR)/debian/console-conf/lib/systemd/system/getty@.service.d/
 	mkdir $(CURDIR)/debian/console-conf/lib/systemd/system/serial-getty@.service.d/
 	install -m 0644 $(CURDIR)/debian/console-conf-serial.conf $(CURDIR)/debian/console-conf/lib/systemd/system/serial-getty@.service.d/
-	dh_installinit --no-start --name=subiquity
-	dh_installinit --no-start --name=serial-subiquity@
-	dh_installinit --no-start --name=subiquity-debug@
+	dh_installsystemd --no-start --name=subiquity
+	dh_installsystemd --no-start --name=serial-subiquity@
+	dh_installsystemd --no-start --name=subiquity-debug@
 	mkdir $(CURDIR)/debian/subiquity/lib/systemd/system/getty@tty1.service.d/
 	install -m 0644 $(CURDIR)/debian/subiquity-tty1.conf $(CURDIR)/debian/subiquity/lib/systemd/system/getty@tty1.service.d/
 	mkdir $(CURDIR)/debian/subiquity/lib/systemd/system/getty@.service.d/

--- a/debian/subiquity.install
+++ b/debian/subiquity.install
@@ -1,5 +1,2 @@
-debian/tmp/usr/bin/subiquity-debug      usr/share/subiquity
-debian/tmp/usr/bin/subiquity-loadkeys   usr/share/subiquity
-debian/tmp/usr/bin/subiquity-service    usr/share/subiquity
-debian/tmp/usr/bin/subiquity-tui        usr/share/subiquity
+debian/tmp/usr/bin/subiquity-*      usr/share/subiquity
 usr/share/subiquity/subiquity

--- a/examples/snaps/README.md~
+++ b/examples/snaps/README.md~
@@ -1,2 +1,0 @@
-## Sample snap data
-


### PR DESCRIPTION
Update debian packaging to be buildable.

Set magic langpack variable, such that translations are stripped into the ubuntu langpack. That would enable in-ubuntu translations of subiquity.