### PR TITLE
display new/existing-ness of fs and volume in filesystem summary

### DIFF
--- a/subiquity/ui/views/filesystem/filesystem.py
+++ b/subiquity/ui/views/filesystem/filesystem.py
@@ -129,11 +129,20 @@ class MountInfo:
 
     @property
     def fstype(self):
-        return self.mount.device.fstype
+        fstype = self.mount.device.fstype
+        if self.mount.device.preserve:
+            fstype = "existing" + " " + fstype
+        else:
+            fstype = "new" + " " + fstype
+        return fstype
 
     @property
     def desc(self):
-        return self.mount.device.volume.desc()
+        annotations = self.mount.device.volume.annotations
+        desc = self.mount.device.volume.desc()
+        if annotations:
+            desc = annotations[0] + " " + desc
+        return desc
 
     def startswith(self, other):
         i = 0


### PR DESCRIPTION
for https://bugs.launchpad.net/subiquity/+bug/1837215

A bit simpler, this one.