### PR TITLE
Allow starting subiquity/console-conf without translations.

### DIFF
--- a/subiquitycore/i18n.py
+++ b/subiquitycore/i18n.py
@@ -39,7 +39,7 @@ def switch_language(code='en_US'):
             return message
     elif code:
         translation = gettext.translation('subiquity', localedir=localedir,
-                                          languages=[code])
+                                          languages=[code], fallback=True)
 
         def my_gettext(message):
             if not message:


### PR DESCRIPTION
Set fallback=True on gettext.translation() call such that it returns
NullTranslation object. This means subiquity/console-conf can start,
even if .mo files are not build in the tree, or are outright missing.