### PR TITLE
the probe_types argument of probert.storage.Storage.probe takes a set, not a list

### DIFF
--- a/subiquity/controllers/filesystem.py
+++ b/subiquity/controllers/filesystem.py
@@ -123,7 +123,7 @@ class FilesystemController(BaseController):
     def _reprobe(self):
         self._probe_state = ProbeState.REPROBING
         self.run_in_bg(
-            lambda: self._bg_probe(["blockdev"]),
+            lambda: self._bg_probe({"blockdev"}),
             lambda fut: self._probed(fut, True),
             )
 


### PR DESCRIPTION
This means my careful code to do rich probing of block devices and fall
back to simple probing doesn't work! Oh well, at least the fix is
trivial.

Seen in the logs from this bug report:

    https://bugs.launchpad.net/ubuntu/+source/subiquity/+bug/1839529