### PR TITLE
put the terminal into raw mode

### DIFF
--- a/console_conf/cmd/tui.py
+++ b/console_conf/cmd/tui.py
@@ -17,7 +17,6 @@
 import argparse
 import sys
 import logging
-import signal
 from subiquitycore.log import setup_logger
 from subiquitycore import __version__ as VERSION
 from console_conf.core import ConsoleConf
@@ -82,9 +81,6 @@ def main():
     logger = logging.getLogger('console_conf')
     logger.info("Starting console-conf v{}".format(VERSION))
     logger.info("Arguments passed: {}".format(sys.argv))
-
-    signal.signal(signal.SIGINT, signal.SIG_IGN)
-    signal.signal(signal.SIGQUIT, signal.SIG_IGN)
 
     env_ok = environment_check(ENVIRONMENT)
     if env_ok is False and not opts.dry_run:

--- a/subiquity/cmd/tui.py
+++ b/subiquity/cmd/tui.py
@@ -18,7 +18,6 @@ import argparse
 import logging
 import os
 import fcntl
-import signal
 import sys
 
 from subiquitycore.log import setup_logger
@@ -125,9 +124,6 @@ def main():
     handler.addFilter(lambda rec: rec.name != 'probert.network')
     logging.getLogger('curtin').addHandler(handler)
     logging.getLogger('block-discover').addHandler(handler)
-
-    signal.signal(signal.SIGINT, signal.SIG_IGN)
-    signal.signal(signal.SIGQUIT, signal.SIG_IGN)
 
     env_ok = environment_check(ENVIRONMENT)
     if env_ok is False and not opts.dry_run:


### PR DESCRIPTION
For whatever reason, urwid puts the terminal into cbreak mode during
initialization. If we put the terminal into raw mode instead, then we
don't have to ignore SIGINT and SIGQUIT, which is good, because when we
support dropping to a subshell we don't want to run that subshell with
those signals ignored, because that is extremely confusing.

This also lets me dump the code that puts the terminal into raw mode
during keyboard detection.