### PR TITLE
allow the application to have a widget in the bottom right

### DIFF
--- a/console_conf/cmd/tui.py
+++ b/console_conf/cmd/tui.py
@@ -21,7 +21,6 @@ from subiquitycore.log import setup_logger
 from subiquitycore import __version__ as VERSION
 from console_conf.core import ConsoleConf
 from subiquitycore.core import ApplicationError
-from subiquitycore.ui.frame import SubiquityUI
 from subiquitycore.utils import environment_check
 
 
@@ -88,10 +87,8 @@ def main():
               'Check {} for errors.'.format(LOGFILE))
         return 1
 
-    ui = SubiquityUI()
-
     try:
-        interface = ConsoleConf(ui, opts)
+        interface = ConsoleConf(opts)
     except ApplicationError as e:
         logger.exception('Failed to load ConsoleConf interface')
         print(e)

--- a/subiquity/cmd/tui.py
+++ b/subiquity/cmd/tui.py
@@ -23,7 +23,6 @@ import sys
 from subiquitycore.log import setup_logger
 from subiquitycore import __version__ as VERSION
 from subiquitycore.core import ApplicationError
-from subiquitycore.ui.frame import SubiquityUI
 from subiquitycore.utils import environment_check
 
 from subiquity.core import Subiquity
@@ -145,10 +144,8 @@ def main():
             opts.answers.close()
             opts.answers = None
 
-    ui = SubiquityUI()
-
     try:
-        subiquity_interface = Subiquity(ui, opts, block_log_dir)
+        subiquity_interface = Subiquity(opts, block_log_dir)
     except ApplicationError as e:
         logger.exception('Failed to load Subiquity interface')
         print(e)

--- a/subiquity/core.py
+++ b/subiquity/core.py
@@ -24,6 +24,7 @@ from subiquity.snapd import (
     FakeSnapdConnection,
     SnapdConnection,
     )
+from subiquity.ui.frame import SubiquityUI
 
 
 log = logging.getLogger('subiquity.core')
@@ -43,6 +44,9 @@ class Subiquity(Application):
             root = os.path.abspath('.subiquity')
         return SubiquityModel(root, self.opts.sources)
 
+    def make_ui(self):
+        return SubiquityUI(self)
+
     controllers = [
             "Welcome",
             "Refresh",
@@ -59,11 +63,11 @@ class Subiquity(Application):
             "InstallProgress",
     ]
 
-    def __init__(self, ui, opts, block_log_dir):
+    def __init__(self, opts, block_log_dir):
         if not opts.bootloader == 'none' and platform.machine() != 's390x':
             self.controllers.remove("Zdev")
 
-        super().__init__(ui, opts)
+        super().__init__(opts)
         self.ui.progress_completion += 1
         self.block_log_dir = block_log_dir
         if opts.snaps_from_examples:

--- a/subiquity/ui/frame.py
+++ b/subiquity/ui/frame.py
@@ -1,0 +1,27 @@
+# Copyright 2019 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+
+from subiquitycore.ui.frame import SubiquityCoreUI
+
+
+log = logging.getLogger('subiquity.ui.frame')
+
+
+class SubiquityUI(SubiquityCoreUI):
+
+    def __init__(self, app):
+        super().__init__()

--- a/subiquitycore/core.py
+++ b/subiquitycore/core.py
@@ -29,6 +29,7 @@ import yaml
 from subiquitycore.controller import RepeatedController
 from subiquitycore.signals import Signal
 from subiquitycore.prober import Prober, ProberException
+from subiquitycore.ui.frame import SubiquityCoreUI
 
 log = logging.getLogger('subiquitycore.core')
 
@@ -231,7 +232,9 @@ class Application:
     # controllers in order, calling the default method on the controller
     # instance.
 
-    def __init__(self, ui, opts):
+    make_ui = SubiquityCoreUI
+
+    def __init__(self, opts):
         try:
             prober = Prober(opts)
         except ProberException as e:
@@ -239,7 +242,7 @@ class Application:
             log.exception(err)
             raise ApplicationError(err)
 
-        self.ui = ui
+        self.ui = self.make_ui()
         self.opts = opts
         opts.project = self.project
 
@@ -274,7 +277,7 @@ class Application:
                                 if c in opts.screens]
         else:
             self.controllers = self.controllers[:]
-        ui.progress_completion = len(self.controllers)
+        self.ui.progress_completion = len(self.controllers)
         self.controller_instances = dict.fromkeys(self.controllers)
         self.controller_index = -1
 

--- a/subiquitycore/ui/frame.py
+++ b/subiquitycore/ui/frame.py
@@ -34,9 +34,11 @@ log = logging.getLogger('subiquitycore.ui.frame')
 
 class SubiquityCoreUI(WidgetWrap):
 
+    right_icon = Text("")
+
     def __init__(self):
         self.header = Header("")
-        self.footer = Footer("", 0, 1)
+        self.footer = Footer("", self.right_icon, 0, 1)
         self.progress_current = 0
         self.progress_completion = 0
         # After the install starts, we want to stop setting the footer
@@ -58,7 +60,9 @@ class SubiquityCoreUI(WidgetWrap):
     def set_footer(self, message):
         self._assign_contents(
             2,
-            Footer(message, self.progress_current, self.progress_completion))
+            Footer(
+                message, self.right_icon,
+                self.progress_current, self.progress_completion))
 
     @property
     def body(self):

--- a/subiquitycore/ui/frame.py
+++ b/subiquitycore/ui/frame.py
@@ -32,7 +32,7 @@ from subiquitycore.ui.utils import Color
 log = logging.getLogger('subiquitycore.ui.frame')
 
 
-class SubiquityUI(WidgetWrap):
+class SubiquityCoreUI(WidgetWrap):
 
     def __init__(self):
         self.header = Header("")


### PR DESCRIPTION
I want to add a key combination to subiquity to allow the user drop to shell at any time. That means we need a way to discover this key combination, which means we want a help button. That means we need an application (i.e. subiquity or console-conf) to be able to put a widget in the bottom right of the screen. That means this PR.

It doesn't actually add a non-trivial widget there yet.