### PR TITLE
define a 'closed' signal on StretchyOverlay

### DIFF
--- a/subiquitycore/ui/stretchy.py
+++ b/subiquitycore/ui/stretchy.py
@@ -73,6 +73,8 @@ class StretchyOverlay(urwid.Widget):
     _selectable = True
     _sizing = frozenset([urwid.BOX])
 
+    signals = ['closed']
+
     def __init__(self, bottom_w, stretchy):
         self.bottom_w = bottom_w
         self.stretchy = stretchy

--- a/subiquitycore/view.py
+++ b/subiquitycore/view.py
@@ -61,8 +61,11 @@ class BaseView(WidgetWrap):
 
     def show_stretchy_overlay(self, stretchy):
         self._w = StretchyOverlay(disabled(self._w), stretchy)
+        return self._w
 
     def remove_overlay(self):
+        if isinstance(self._w, StretchyOverlay):
+            self._w._emit('closed')
         # disabled() wraps a widget in two decorations.
         self._w = self._w.bottom_w.original_widget.original_widget
 


### PR DESCRIPTION
And return the overlay from show_stretchy_overlay, so you can do things
when the overlay is closed.

Will be used by the help-showing stuff.