### PR TITLE
remove footer, make header narrower

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -82,18 +82,9 @@ A subiquity screen consists of:
     2. a scrollable content area
     3. a stack of buttons, including "done"/"cancel" buttons for moving between
        screens
- 3. a footer
 
 The header has a summary line describing the current screen against an "ubuntu
 orange" background.
-
-The footer has a progress bar indicating how far through the install process
-the user was, a blank line and the summary area.  Currently the summary area
-contains static content for the first few screens, but there are vague plans to
-make it specific to the currently focused element. Once the install has started
-but before we get to the final screen, the summary area contains a summary of
-progress made by the installation.  Someday soon the summary area will also
-contain a button that allows you to drop to a shell at any point.
 
 The body area is where most of the action is. It follows a standard pattern
 described above, and the `subiquitycore.ui.utils.screen()` function makes it

--- a/console_conf/controllers/identity.py
+++ b/console_conf/controllers/identity.py
@@ -199,8 +199,6 @@ class IdentityController(BaseController):
         self.model = app.base_model.identity
 
     def start_ui(self):
-        footer = ""
-        self.ui.set_footer(footer)
         self.ui.set_body(IdentityView(self.model, self))
         device_owner = get_device_owner()
         if device_owner is not None:
@@ -221,11 +219,9 @@ class IdentityController(BaseController):
             self.model.add_user(result)
             login_details_path = '.subiquity/login-details.txt'
         else:
-            self.ui.set_footer("Contacting store...")
             self.loop.draw_screen()
             cp = run_command(
                 ["snap", "create-user", "--sudoer", "--json", email])
-            self.ui.set_footer("")
             if cp.returncode != 0:
                 self.ui.body.error.set_text(
                     "Creating user failed:\n" + cp.stderr)
@@ -254,9 +250,7 @@ class IdentityController(BaseController):
 
     def login(self):
         title = "Configuration Complete"
-        footer = "View configured user and device access methods"
         self.ui.set_header(title)
-        self.ui.set_footer(footer)
 
         net_model = self.app.controller_instances['Network'].model
         ifaces = net_model.get_all_netdevs()

--- a/console_conf/palette.py
+++ b/console_conf/palette.py
@@ -28,7 +28,6 @@ COLORS = [
 
 STYLES = [
     ('frame_header',        'fg',      'orange'),
-    ('frame_footer',        'fg',      'brand'),
     ('body',                'fg',      'bg'),
 
     ('done_button',         'fg',      'bg'),
@@ -56,7 +55,6 @@ STYLES = [
 
 STYLES_MONO = [
     ('frame_header',        'white',   'black'),
-    ('frame_footer',        'white',   'black'),
     ('body',                'white',   'black'),
 
     ('done_button',         'white',   'black'),

--- a/subiquity/core.py
+++ b/subiquity/core.py
@@ -68,7 +68,6 @@ class Subiquity(Application):
             self.controllers.remove("Zdev")
 
         super().__init__(opts)
-        self.ui.progress_completion += 1
         self.block_log_dir = block_log_dir
         if opts.snaps_from_examples:
             connection = FakeSnapdConnection(

--- a/subiquity/palette.py
+++ b/subiquity/palette.py
@@ -36,6 +36,7 @@ COLORS = [
 ]
 
 STYLES = [
+    ('frame_header_fringe', 'orange',  'bg'),
     ('frame_header',        'fg',      'orange'),
     ('frame_footer',        'fg',      'brand'),
     ('body',                'fg',      'bg'),

--- a/subiquity/palette.py
+++ b/subiquity/palette.py
@@ -38,7 +38,6 @@ COLORS = [
 STYLES = [
     ('frame_header_fringe', 'orange',  'bg'),
     ('frame_header',        'fg',      'orange'),
-    ('frame_footer',        'fg',      'brand'),
     ('body',                'fg',      'bg'),
 
     ('done_button',         'fg',      'bg'),
@@ -71,8 +70,8 @@ STYLES = [
 
 
 STYLES_MONO = [
+    ('frame_header_fringe', 'black',   'white'),
     ('frame_header',        'white',   'black'),
-    ('frame_footer',        'white',   'black'),
     ('body',                'white',   'black'),
 
     ('done_button',         'white',   'black'),

--- a/subiquity/ui/views/filesystem/filesystem.py
+++ b/subiquity/ui/views/filesystem/filesystem.py
@@ -433,7 +433,6 @@ class DeviceList(WidgetWrap):
 
 class FilesystemView(BaseView):
     title = _("Filesystem setup")
-    footer = _("Select available disks to format and mount")
 
     def __init__(self, model, controller):
         self.model = model

--- a/subiquity/ui/views/filesystem/filesystem.py
+++ b/subiquity/ui/views/filesystem/filesystem.py
@@ -490,7 +490,6 @@ class FilesystemView(BaseView):
         if not todos:
             return None
         rows = [
-            TableRow([Text("")]),
             TableRow([
                 Text("To continue you need to:"),
                 Text(todos[0]),
@@ -498,6 +497,7 @@ class FilesystemView(BaseView):
             ]
         for todo in todos[1:]:
             rows.append(TableRow([Text(""), Text(todo)]))
+        rows.append(TableRow([Text("")]))
         return TablePile(rows)
 
     def _build_buttons(self):

--- a/subiquity/ui/views/filesystem/filesystem.py
+++ b/subiquity/ui/views/filesystem/filesystem.py
@@ -474,11 +474,31 @@ class FilesystemView(BaseView):
 
         self.lb = ListBox(body)
         self.lb.base_widget.offset_rows = 2
-        frame = screen(
+        super().__init__(screen(
             self.lb, self._build_buttons(),
-            focus_buttons=self.model.can_install())
-        super().__init__(frame)
+            focus_buttons=self.model.can_install()))
+        self.frame = self._w.base_widget
+        self.showing_guidance = False
         self.refresh_model_inputs()
+
+    def _guidance(self):
+        todos = []
+        if not self.model.is_root_mounted():
+            todos.append(_("Mount a filesystem at /"))
+        if self.model.needs_bootloader_partition():
+            todos.append(_("Select a boot disk"))
+        if not todos:
+            return None
+        rows = [
+            TableRow([Text("")]),
+            TableRow([
+                Text("To continue you need to:"),
+                Text(todos[0]),
+                ]),
+            ]
+        for todo in todos[1:]:
+            rows.append(TableRow([Text(""), Text(todo)]))
+        return TablePile(rows)
 
     def _build_buttons(self):
         self.done = Toggleable(done_btn(_("Done"), on_press=self.done))
@@ -511,15 +531,15 @@ class FilesystemView(BaseView):
         self.lb.base_widget._select_first_selectable()
         can_install = self.model.can_install()
         self.done.enabled = can_install
-        if can_install:
-            self.controller.ui.set_footer(
-                _("Select Done to begin the installation."))
+        if self.showing_guidance:
+            del self.frame.contents[0]
+        guidance = self._guidance()
+        if guidance:
+            self.frame.contents.insert(
+                0, (guidance, self.frame.options('pack')))
+            self.showing_guidance = True
         else:
-            if self.model.needs_bootloader_partition():
-                self.controller.ui.set_footer(self.footer)
-            elif not self.model.is_root_mounted():
-                self.controller.ui.set_footer(
-                    _("You need to mount a device at / to continue."))
+            self.showing_guidance = False
 
     def create_raid(self, button=None):
         self.show_stretchy_overlay(RaidStretchy(self))

--- a/subiquity/ui/views/filesystem/guided.py
+++ b/subiquity/ui/views/filesystem/guided.py
@@ -59,7 +59,6 @@ review and modify the results.""")
 class GuidedFilesystemView(BaseView):
 
     title = _("Filesystem setup")
-    footer = _("Choose guided or manual partitioning")
 
     def __init__(self, controller):
         self.controller = controller
@@ -111,7 +110,6 @@ def _wrap_button_row(row):
 class GuidedDiskSelectionView(BaseView):
 
     title = _("Filesystem setup")
-    footer = (_("Choose the installation target"))
 
     def __init__(self, model, controller, method):
         self.model = model

--- a/subiquity/ui/views/installprogress.py
+++ b/subiquity/ui/views/installprogress.py
@@ -54,7 +54,6 @@ class ProgressView(BaseView):
         self.event_linebox = MyLineBox(self.event_listbox)
         self.event_buttons = button_pile([self.view_log_btn])
         event_body = [
-            ('pack', Text("")),
             ('weight', 1, Padding.center_79(self.event_linebox, min_width=76)),
             ('pack', Text("")),
             ('pack', self.event_buttons),
@@ -125,7 +124,7 @@ class ProgressView(BaseView):
             btns = [self.view_log_btn, self.reboot_btn]
         self._set_buttons(btns)
         self.event_buttons.base_widget.focus_position = 1
-        self.event_pile.base_widget.focus_position = 3
+        self.event_pile.base_widget.focus_position = 2
 
     def reboot(self, btn):
         self.reboot_btn.base_widget.set_label(_("Rebooting..."))

--- a/subiquity/ui/views/keyboard.py
+++ b/subiquity/ui/views/keyboard.py
@@ -385,7 +385,6 @@ class KeyboardForm(Form):
 class KeyboardView(BaseView):
 
     title = _("Keyboard configuration")
-    footer = _("Use UP, DOWN and ENTER keys to select your keyboard.")
 
     def __init__(self, model, controller, opts):
         self.model = model

--- a/subiquity/ui/views/snaplist.py
+++ b/subiquity/ui/views/snaplist.py
@@ -172,16 +172,18 @@ class SnapInfoView(WidgetWrap):
         info_table.bind(self.lb_channels)
         self.info_padding = Padding.pull_1(info_table)
 
-        publisher = [('info_minor header', "by: "), snap.publisher]
+        publisher = [('info_minor', "by: "), snap.publisher]
         if snap.verified:
-            publisher.append(('verified header', ' \N{check mark}'))
+            publisher.append(('verified', ' \N{check mark}'))
 
-        self.title = Columns([
+        title = Columns([
             Text(snap.name),
             ('pack', Text(publisher, align='right')),
             ], dividechars=1)
 
         contents = [
+            ('pack',      title),
+            ('pack',      Text("")),
             ('pack',      Text(snap.summary)),
             ('pack',      Text("")),
             self.lb_description,  # overwritten in render()
@@ -328,7 +330,6 @@ class SnapCheckBox(CheckBox):
                 if self.snap.name in self.parent.to_install:
                     cur_chan = self.parent.to_install[self.snap.name].channel
                 siv = SnapInfoView(self.parent, self.snap, cur_chan)
-                self.parent.controller.ui.set_header(siv.title)
                 self.parent.show_screen(screen(
                     siv,
                     [other_btn(
@@ -402,7 +403,6 @@ class SnapListView(BaseView):
             ])
 
     def show_main_screen(self, sender=None):
-        self.controller.ui.set_header(_(self.title))
         self._w = self._main_screen
 
     def show_screen(self, screen):

--- a/subiquity/ui/views/welcome.py
+++ b/subiquity/ui/views/welcome.py
@@ -30,7 +30,6 @@ log = logging.getLogger("subiquity.views.welcome")
 
 class WelcomeView(BaseView):
     title = "Willkommen! Bienvenue! Welcome! Добро пожаловать! Welkom!"
-    footer = _("Use UP, DOWN and ENTER keys to select your language.")
 
     def __init__(self, model, controller):
         self.model = model
@@ -39,7 +38,7 @@ class WelcomeView(BaseView):
             self._build_model_inputs(),
             buttons=None,
             narrow_rows=True,
-            excerpt=_("Please choose your preferred language.")))
+            excerpt=_("Use UP, DOWN and ENTER keys to select your language.")))
 
     def _build_model_inputs(self):
         btns = []

--- a/subiquity/ui/views/zdev.py
+++ b/subiquity/ui/views/zdev.py
@@ -127,7 +127,6 @@ class ZdevList(WidgetWrap):
 
 class ZdevView(BaseView):
     title = _("Zdev setup")
-    footer = _("Activate and configure Z devices")
 
     def __init__(self, controller):
         log.debug('FileSystemView init start()')

--- a/subiquitycore/ui/anchors.py
+++ b/subiquitycore/ui/anchors.py
@@ -16,8 +16,9 @@
 import logging
 
 from urwid import (
+    int_scale,
+    SolidFill,
     Text,
-    ProgressBar,
     )
 
 from subiquitycore.ui.container import (
@@ -25,83 +26,54 @@ from subiquitycore.ui.container import (
     Pile,
     WidgetWrap,
     )
-from subiquitycore.ui.utils import Padding, Color
+from subiquitycore.ui.utils import Color
 from subiquitycore.ui.width import widget_width
 
 log = logging.getLogger('subiquitycore.ui.anchors')
 
 
-class Header(WidgetWrap):
-    """ Header Widget
-
-    This widget uses the style key `frame_header`
-
-    :param str title: Title of Header
-    :returns: Header()
-    """
-
-    def __init__(self, title):
-        if isinstance(title, str):
-            title = Text(title)
-        title = Padding.center_79(title, min_width=76)
-        super().__init__(Color.frame_header(
-                Pile(
-                    [Text(""), title, Text("")])))
-
-
-class StepsProgressBar(ProgressBar):
-
-    def get_text(self):
-        return "{} / {}".format(self.current, self.done)
-
-
-class MyColumns(Columns):
+class HeaderColumns(Columns):
     # The idea is to render output like this:
     #
-    #                  message                [ help  ]
-    # [ lpad        ][ middle        ][ rpad ][ right ]
+    # [ pad ][ message       ][ btn ][ pad ]
     #
     # The constraints are:
     #
-    # 1. lpad + rpad + right + message = maxcol
+    # 1. pad + message + btn + pad = maxcol
     #
-    # 2. lpad and rpad are at least 1
+    # 2. pad is at least 1
     #
-    # 3. right is fixed
+    # 3. btn is fixed
     #
-    # 4. if possible, lpad = rpad + right and middle is 79% of maxcol
-    #    or 76, whichever is greater.
+    # 4. message + btn is 79% of maxcol or 76, whichever is greater.
 
     def column_widths(self, size, focus=False):
         maxcol = size[0]
-        right = widget_width(self.contents[3][0])
+        btn = widget_width(self.contents[2][0])
 
-        center = max(79*maxcol//100, 76)
-        lpad = (maxcol - center)//2
-        rpad = lpad - right
-        if rpad < 1:
-            rpad = 1
-        middle = maxcol - (lpad + rpad + right)
-        return [lpad, middle, rpad, right]
+        center = max(int_scale(79, 101, maxcol + 1), 76)
+        message = center - btn
+        pad = (maxcol - center)//2
+        return [pad, message, btn, pad]
 
 
-class Footer(WidgetWrap):
-    """ Footer widget
+class Header(WidgetWrap):
+    """ Header Widget """
 
-    Style key: `frame_footer`
-
-    """
-
-    def __init__(self, message, right_icon, current, complete):
-        if isinstance(message, str):
-            message = Text(message)
-        progress_bar = Padding.center_60(
-            StepsProgressBar(normal='progress_incomplete',
-                             complete='progress_complete',
-                             current=current, done=complete))
-        status = [
-            progress_bar,
-            Padding.line_break(""),
-            MyColumns([Text(""), message, Text(""), right_icon]),
-        ]
-        super().__init__(Color.frame_footer(Pile(status)))
+    def __init__(self, title, right_icon):
+        if isinstance(title, str):
+            title = Text(title)
+        title = HeaderColumns([
+            Text(""),
+            title,
+            right_icon,
+            Text(""),
+            ])
+        super().__init__(
+                Pile([
+                    (1, Color.frame_header_fringe(
+                        SolidFill("\N{lower half block}"))),
+                    Color.frame_header(title),
+                    (1, Color.frame_header_fringe(
+                        SolidFill("\N{upper half block}"))),
+                    ]))

--- a/subiquitycore/ui/frame.py
+++ b/subiquitycore/ui/frame.py
@@ -50,9 +50,6 @@ class SubiquityCoreUI(WidgetWrap):
     def set_header(self, title=None):
         self._assign_contents(0, Header(title, self.right_icon))
 
-    def set_footer(self, message):
-        pass
-
     @property
     def body(self):
         return self.pile.contents[1][0]

--- a/subiquitycore/ui/frame.py
+++ b/subiquitycore/ui/frame.py
@@ -37,7 +37,7 @@ class SubiquityCoreUI(WidgetWrap):
     right_icon = Text("")
 
     def __init__(self):
-        self.header = Header("")
+        self.header = Header("", self.right_icon)
         self.pile = Pile([
             ('pack', self.header),
             ListBox([Text("")]),
@@ -48,7 +48,7 @@ class SubiquityCoreUI(WidgetWrap):
         self.pile.contents[i] = (w, self.pile.contents[i][1])
 
     def set_header(self, title=None):
-        self._assign_contents(0, Header(title))
+        self._assign_contents(0, Header(title, self.right_icon))
 
     def set_footer(self, message):
         pass

--- a/subiquitycore/ui/frame.py
+++ b/subiquitycore/ui/frame.py
@@ -20,7 +20,7 @@ import logging
 from urwid import (
     Text,
     )
-from subiquitycore.ui.anchors import Header, Footer
+from subiquitycore.ui.anchors import Header
 from subiquitycore.ui.container import (
     ListBox,
     Pile,
@@ -38,16 +38,9 @@ class SubiquityCoreUI(WidgetWrap):
 
     def __init__(self):
         self.header = Header("")
-        self.footer = Footer("", self.right_icon, 0, 1)
-        self.progress_current = 0
-        self.progress_completion = 0
-        # After the install starts, we want to stop setting the footer
-        # from the body view.
-        self.auto_footer = True
         self.pile = Pile([
             ('pack', self.header),
             ListBox([Text("")]),
-            ('pack', self.footer),
             ])
         super().__init__(Color.body(self.pile))
 
@@ -58,11 +51,7 @@ class SubiquityCoreUI(WidgetWrap):
         self._assign_contents(0, Header(title))
 
     def set_footer(self, message):
-        self._assign_contents(
-            2,
-            Footer(
-                message, self.right_icon,
-                self.progress_current, self.progress_completion))
+        pass
 
     @property
     def body(self):
@@ -71,5 +60,3 @@ class SubiquityCoreUI(WidgetWrap):
     def set_body(self, widget):
         self.set_header(_(widget.title))
         self._assign_contents(1, widget)
-        if self.auto_footer:
-            self.set_footer(_(widget.footer))

--- a/subiquitycore/ui/utils.py
+++ b/subiquitycore/ui/utils.py
@@ -151,7 +151,6 @@ STYLE_NAMES = set([
     'danger_button',
     'done_button focus',
     'done_button',
-    'frame_footer',
     'frame_header',
     'frame_header_fringe',
     'info_error',

--- a/subiquitycore/ui/utils.py
+++ b/subiquitycore/ui/utils.py
@@ -153,6 +153,7 @@ STYLE_NAMES = set([
     'done_button',
     'frame_footer',
     'frame_header',
+    'frame_header_fringe',
     'info_error',
     'info_minor',
     'info_primary',
@@ -245,11 +246,10 @@ def screen(rows, buttons=None, focus_buttons=True, excerpt=None,
     excerpt_rows = []
     if excerpt is not None:
         excerpt_rows = [
-            ('pack', Text("")),
             ('pack', Text(excerpt)),
+            ('pack', Text("")),
             ]
     body = [
-        ('pack', Text("")),
         rows,
         ('pack', Text("")),
     ]
@@ -260,7 +260,7 @@ def screen(rows, buttons=None, focus_buttons=True, excerpt=None,
         ])
     pile = Pile(excerpt_rows + body)
     if focus_buttons:
-        pile.focus_position = len(excerpt_rows) + 3
+        pile.focus_position = len(excerpt_rows) + 2
     return Padding.center_79(pile, min_width=76)
 
 

--- a/subiquitycore/ui/views/network.py
+++ b/subiquitycore/ui/views/network.py
@@ -75,8 +75,6 @@ class NetworkView(BaseView):
     excerpt = _("Configure at least one interface this server can use to talk "
                 "to other machines, and which preferably provides sufficient "
                 "access for updates.")
-    footer = _("Select an interface to configure it or select Done to "
-               "continue")
 
     def __init__(self, model, controller):
         self.model = model

--- a/subiquitycore/view.py
+++ b/subiquitycore/view.py
@@ -35,8 +35,6 @@ from subiquitycore.ui.utils import disabled
 
 class BaseView(WidgetWrap):
 
-    footer = ""
-
     def show_overlay(self, overlay_widget, **kw):
         args = dict(
             align='center',


### PR DESCRIPTION
In Paris mpt asked if we could use unicode half-blocks (▄ / ▀) to make the header a bit narrower. As, coincidentally, I'd added these characters to the console font subiquity bundles the week before, this was very easy, and looked good. This also allows us to remove the ever present blank line beneath the header, which gets us another line of usable vertical space, something that is at a bit of a premium in subiquity's smallest target screen of 80x24.

The only problem was that it now looked out of balance with the footer. The footer has been a bit of a sore point for a while: mpt has previously complained that progress bars in installers have been observed to cause confusion in users, and the messages we displayed in the footer were largely a waste of space. So, let's delete the footer entirely! The only useful messaging in the footer was on the filesystem screen, where we provided clues on what had to be done to proceed. So this branch does that more explicitly.

Video at: https://asciinema.org/a/I5av0jfAPxCkmOkwW1YupARm5