### PR TITLE
Add help menu

### DIFF
--- a/subiquity/core.py
+++ b/subiquity/core.py
@@ -94,3 +94,10 @@ class Subiquity(Application):
             lambda fut: (
                 fut.result(), self.signal.emit_signal('snapd-network-change')),
             )
+
+    def unhandled_input(self, key):
+        if key == 'f1':
+            if not self.showing_help:
+                self.ui.right_icon.open_pop_up()
+        else:
+            super().unhandled_input(key)

--- a/subiquity/core.py
+++ b/subiquity/core.py
@@ -33,6 +33,7 @@ log = logging.getLogger('subiquity.core')
 class Subiquity(Application):
 
     snapd_socket_path = '/run/snapd.socket'
+    showing_help = False
 
     from subiquity.palette import COLORS, STYLES, STYLES_MONO
 

--- a/subiquity/core.py
+++ b/subiquity/core.py
@@ -33,7 +33,6 @@ log = logging.getLogger('subiquity.core')
 class Subiquity(Application):
 
     snapd_socket_path = '/run/snapd.socket'
-    showing_help = False
 
     from subiquity.palette import COLORS, STYLES, STYLES_MONO
 

--- a/subiquity/palette.py
+++ b/subiquity/palette.py
@@ -50,6 +50,9 @@ STYLES = [
     ('menu_button',         'fg',      'bg'),
     ('menu_button focus',   'fg',      'gray'),
 
+    ('frame_button',        'fg',      'orange'),
+    ('frame_button focus',  'orange',  'fg'),
+
     ('info_primary',        'fg',      'bg'),
     ('info_minor',          'gray',    'bg'),
     ('info_minor header',   'gray',    'orange'),

--- a/subiquity/ui/views/help.py
+++ b/subiquity/ui/views/help.py
@@ -14,6 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
+import os
 
 from urwid import (
     connect_signal,
@@ -62,14 +63,33 @@ def close_btn(parent):
 ABOUT_INSTALLER = _("""
 Welcome to the Ubuntu Server Installer!
 
-The most popular server Linux in the cloud and data centre, you can
-rely on Ubuntu Server and its five years of guaranteed free upgrades.
+The most popular server Linux in the cloud and data centre, this
+release of Ubuntu will receive updates for 9 months from release.
 
 The installer will guide you through installing Ubuntu Server
 {release}.
 
 The installer only requires the up and down arrow keys, space (or
-return) and the occasional bit of typing.""")
+return) and the occasional bit of typing.
+
+This is version {snap_version} of the installer.
+""")
+
+
+ABOUT_INSTALLER_LTS = _("""
+Welcome to the Ubuntu Server Installer!
+
+The most popular server Linux in the cloud and data centre, you can
+rely on Ubuntu Server and its five years of guaranteed free upgrades.
+
+The installer will guide you through installing Ubuntu Server
+{release} LTS.
+
+The installer only requires the up and down arrow keys, space (or
+return) and the occasional bit of typing.
+
+This is version {snap_version} of the installer.
+""")
 
 
 def rewrap(text):
@@ -221,11 +241,20 @@ class HelpMenu(WidgetWrap):
         ui.body.show_stretchy_overlay(stretchy)
 
     def _about(self, sender=None):
+        info = lsb_release()
+        if 'LTS' in info['description']:
+            template = _(ABOUT_INSTALLER_LTS)
+        else:
+            template = _(ABOUT_INSTALLER)
+        info.update({
+            'snap_version': os.environ.get("SNAP_VERSION", "SNAP_VERSION"),
+            'snap_revision': os.environ.get("SNAP_REVISION", "SNAP_REVISION"),
+            })
         self._show_overlay(
             SimpleTextStretchy(
                 self.parent.app.ui.body,
                 _("About the installer"),
-                _(ABOUT_INSTALLER).format(**lsb_release())))
+                template.format(**info)))
 
     def _shortcuts(self, sender):
         self._show_overlay(

--- a/subiquity/ui/views/help.py
+++ b/subiquity/ui/views/help.py
@@ -16,19 +16,116 @@
 import logging
 
 from urwid import (
+    connect_signal,
+    Divider,
     PopUpLauncher,
+    SolidFill,
+    Text,
     )
 
 from subiquitycore.ui.buttons import (
     header_btn,
     )
+from subiquitycore.ui.container import (
+    Columns,
+    ListBox,
+    Pile,
+    WidgetWrap,
+    )
+from subiquitycore.ui.utils import (
+    ClickableIcon,
+    Color,
+    )
+from subiquitycore.ui.width import (
+    widget_width,
+    )
 
 
 log = logging.getLogger('subiquity.ui.help')
+
+tlcorner = '┌'
+tline = '─'
+lline = '│'
+trcorner = '┐'
+blcorner = '└'
+rline = '│'
+bline = '─'
+brcorner = '┘'
+
+
+def menu_item(text):
+    return Color.frame_button(ClickableIcon(_(text), 0))
+
+
+class HelpMenu(WidgetWrap):
+
+    def __init__(self, parent):
+        self.parent = parent
+        close = header_btn(_("Help"))
+        top = Columns([
+            ('fixed', 1, Text(tlcorner)),
+            Divider(tline),
+            (widget_width(close), close),
+            ('fixed', 1, Text(trcorner)),
+            ])
+        about = menu_item(_("About the installer"))
+        local = menu_item(_("Help on this screen"))
+        keys = menu_item(_("Help on keyboard shortcuts"))
+        entries = [
+            about,
+            local,
+            Divider(tline),
+            keys,
+            ]
+        buttons = [
+            close,
+            about,
+            local,
+            keys,
+            ]
+        for button in buttons:
+            connect_signal(button.base_widget, 'click', self._close)
+        middle = Columns([
+            ('fixed', 1, SolidFill(lline)),
+            ListBox(entries),
+            ('fixed', 1, SolidFill(rline)),
+            ])
+        bottom = Columns([
+            (1, Text(blcorner)),
+            Divider(bline),
+            (1, Text(brcorner)),
+            ])
+        self.width = max([widget_width(b) for b in buttons]) + 2
+        self.height = len(entries) + 2
+        super().__init__(Color.frame_header(Pile([
+            ('pack', top),
+            middle,
+            ('pack', bottom),
+            ])))
+
+    def _close(self, sender):
+        self.parent.close_pop_up()
 
 
 class HelpButton(PopUpLauncher):
 
     def __init__(self, app):
         self.app = app
-        super().__init__(header_btn(_("Help")))
+        self.btn = header_btn(_("Help"), on_press=self._open)
+        super().__init__(self.btn)
+
+    def _open(self, sender):
+        log.debug("open help menu")
+        self.open_pop_up()
+
+    def create_pop_up(self):
+        self._menu = HelpMenu(self)
+        return self._menu
+
+    def get_pop_up_parameters(self):
+        return {
+            'left': widget_width(self.btn) - self._menu.width + 1,
+            'top': 0,
+            'overlay_width': self._menu.width,
+            'overlay_height': self._menu.height,
+            }

--- a/subiquity/ui/views/help.py
+++ b/subiquity/ui/views/help.py
@@ -232,20 +232,20 @@ class HelpMenu(WidgetWrap):
         self.parent.close_pop_up()
 
     def _show_overlay(self, stretchy):
-        app = self.parent.app
-        ui = app.ui
-        fp = ui.pile.focus_position
-        ui.pile.focus_position = 1
-        btn_label = self.parent.btn.base_widget._label
-        btn_label._selectable = False
-        app.showing_help = True
+        ui = self.parent.app.ui
 
-        def restore_focus():
-            app.showing_help = False
+        # We don't let help dialogs pile up: if one is already
+        # showing, remove it before showing the new one.
+        if self.parent.showing_something:
+            ui.body.remove_overlay()
+        self.parent.showing_something = True
+        fp, ui.pile.focus_position = ui.pile.focus_position, 1
+
+        def on_close():
+            self.parent.showing_something = False
             ui.pile.focus_position = fp
-            btn_label._selectable = True
 
-        connect_signal(stretchy, 'closed', restore_focus)
+        connect_signal(stretchy, 'closed', on_close)
 
         ui.body.show_stretchy_overlay(stretchy)
 
@@ -287,6 +287,7 @@ class HelpButton(PopUpLauncher):
     def __init__(self, app):
         self.app = app
         self.btn = header_btn(_("Help"), on_press=self._open)
+        self.showing_something = False
         super().__init__(self.btn)
 
     def _open(self, sender):

--- a/subiquity/ui/views/help.py
+++ b/subiquity/ui/views/help.py
@@ -15,16 +15,20 @@
 
 import logging
 
-from subiquitycore.ui.frame import SubiquityCoreUI
+from urwid import (
+    PopUpLauncher,
+    )
 
-from subiquity.ui.views.help import HelpButton
+from subiquitycore.ui.buttons import (
+    header_btn,
+    )
 
 
-log = logging.getLogger('subiquity.ui.frame')
+log = logging.getLogger('subiquity.ui.help')
 
 
-class SubiquityUI(SubiquityCoreUI):
+class HelpButton(PopUpLauncher):
 
     def __init__(self, app):
-        self.right_icon = HelpButton(app)
-        super().__init__()
+        self.app = app
+        super().__init__(header_btn(_("Help")))

--- a/subiquity/ui/views/help.py
+++ b/subiquity/ui/views/help.py
@@ -103,6 +103,12 @@ class HelpMenu(WidgetWrap):
             ('pack', bottom),
             ])))
 
+    def keypress(self, size, key):
+        if key == 'esc':
+            self.parent.close_pop_up()
+        else:
+            return super().keypress(size, key)
+
     def _close(self, sender):
         self.parent.close_pop_up()
 

--- a/subiquity/ui/views/help.py
+++ b/subiquity/ui/views/help.py
@@ -167,19 +167,25 @@ class HelpMenu(WidgetWrap):
         self.parent = parent
         close = header_btn(_("Help"))
         about = menu_item(_("About the installer"), on_press=self._about)
-        local = menu_item(_("Help on this screen"))
         keys = menu_item(
             _("Help on keyboard shortcuts"), on_press=self._shortcuts)
+        buttons = [
+            close,
+            about,
+            keys,
+            ]
+        local_title, local_doc = parent.app.ui.body.local_help()
+        if local_title is not None:
+            local = menu_item(
+                _("Help on {}").format(local_title),
+                on_press=self._show_local(local_title, local_doc))
+            buttons.append(local)
+        else:
+            local = Text(('info_minor header', _("Help on this screen")))
         entries = [
             about,
             local,
             hline,
-            keys,
-            ]
-        buttons = [
-            close,
-            about,
-            local,
             keys,
             ]
         for button in buttons:
@@ -209,7 +215,10 @@ class HelpMenu(WidgetWrap):
                 hline,
                 (1, brcorner),
                 ]))
-        self.width = max([widget_width(b) for b in buttons]) + 2
+        self.width = max([
+            widget_width(b) for b in entries
+            if not isinstance(b, Divider)
+            ]) + 2
         self.height = len(entries) + 2
         super().__init__(Color.frame_header(Filler(Pile(rows))))
 
@@ -255,6 +264,16 @@ class HelpMenu(WidgetWrap):
                 self.parent.app.ui.body,
                 _("About the installer"),
                 template.format(**info)))
+
+    def _show_local(self, local_title, local_doc):
+
+        def cb(sender=None):
+            self._show_overlay(
+                SimpleTextStretchy(
+                    self.parent.app.ui.body,
+                    local_title,
+                    local_doc))
+        return cb
 
     def _shortcuts(self, sender):
         self._show_overlay(

--- a/subiquity/ui/views/welcome.py
+++ b/subiquity/ui/views/welcome.py
@@ -28,6 +28,12 @@ from subiquitycore.view import BaseView
 log = logging.getLogger("subiquity.views.welcome")
 
 
+HELP = _("""
+Select the language to use for the installer and to be configured in the
+installed system.
+""")
+
+
 class WelcomeView(BaseView):
     title = "Willkommen! Bienvenue! Welcome! Добро пожаловать! Welkom!"
 
@@ -57,3 +63,6 @@ class WelcomeView(BaseView):
     def confirm(self, sender, code):
         log.debug('WelcomeView %s', code)
         self.controller.done(code)
+
+    def local_help(self):
+        return _("Language Selection"), _(HELP)

--- a/subiquitycore/ui/buttons.py
+++ b/subiquitycore/ui/buttons.py
@@ -40,6 +40,7 @@ _forward_rhs = "\N{BLACK RIGHT-POINTING SMALL TRIANGLE} ]"
 menu_btn = _stylized_button("[", _forward_rhs, "menu")
 forward_btn = _stylized_button("[", _forward_rhs, "done")
 
+header_btn = action_button("frame")
 done_btn = action_button("done")
 danger_btn = action_button("danger")
 other_btn = action_button("other")

--- a/subiquitycore/ui/frame.py
+++ b/subiquitycore/ui/frame.py
@@ -42,6 +42,7 @@ class SubiquityCoreUI(WidgetWrap):
             ('pack', self.header),
             ListBox([Text("")]),
             ])
+        self.pile.focus_position = 1
         super().__init__(Color.body(self.pile))
 
     def _assign_contents(self, i, w):

--- a/subiquitycore/ui/utils.py
+++ b/subiquitycore/ui/utils.py
@@ -151,6 +151,8 @@ STYLE_NAMES = set([
     'danger_button',
     'done_button focus',
     'done_button',
+    'frame_button focus',
+    'frame_button',
     'frame_header',
     'frame_header_fringe',
     'info_error',

--- a/subiquitycore/ui/width.py
+++ b/subiquitycore/ui/width.py
@@ -18,6 +18,7 @@ import urwid
 
 size_neutral_decorations = (
     urwid.AttrMap,
+    urwid.PopUpLauncher,
     urwid.WidgetDisable,
     )
 

--- a/subiquitycore/view.py
+++ b/subiquitycore/view.py
@@ -35,6 +35,13 @@ from subiquitycore.ui.utils import disabled
 
 class BaseView(WidgetWrap):
 
+    def local_help(self):
+        """Help for what the user is currently looking at.
+
+        Returns title, documentation (or None, None).
+        """
+        return None, None
+
     def show_overlay(self, overlay_widget, **kw):
         args = dict(
             align='center',


### PR DESCRIPTION
This adds a help menu to the header, currently containing general about this installer, help on the current screen and help on global shortcut keys.

I'm pretty happy with how this looks (https://asciinema.org/a/AYUYgKvaWPq7kIIJrYKxgEuc6) and the code is OK enough. There are some things I would like opinions on though:

 * The wording for the "about" dialog (I currently have separate content for LTS/non-LTS, maybe I should add content for devel series too? Totally happy to do whatever someone else says here ;-p)
 * More content for help on the current screen (this does not have to be in this branch of course, but we should populate this a bit more before the next release)
 * The behaviour of the help menu when looking at help content. Currently the help menu is disabled/non-focusable when help content is showing. Is that appropriate? Maybe it should still be active, have the current option disabled and selecting a different option shows that instead?