### PR TITLE
create one log file per invocation

### DIFF
--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -4,12 +4,12 @@ python3 -m unittest discover
 export SUBIQUITY_REPLAY_TIMESCALE=100
 for answers in examples/answers*.yaml; do
     rm -f .subiquity/subiquity-curtin-install.conf
-    rm -f .subiquity/subiquity-debug.log
+    rm -f .subiquity/subiquity-debug.log.*
     rm -f .subiquity/run/subiquity/updating
     # The --foreground is important to avoid subiquity getting SIGTTOU-ed.
     timeout --foreground 60 sh -c "LANG=C.UTF-8 python3 -m subiquity.cmd.tui --answers $answers --dry-run --snaps-from-examples --machine-config examples/simple.json"
     python3 scripts/validate-yaml.py .subiquity/subiquity-curtin-install.conf
-    if grep passw0rd .subiquity/subiquity-debug.log | grep -v "Loaded answers" | grep -v "answers_action"; then
+    if grep passw0rd .subiquity/subiquity-debug.log.* | grep -v "Loaded answers" | grep -v "answers_action"; then
         echo "password leaked into log file"
         exit 1
     fi

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -4,12 +4,16 @@ python3 -m unittest discover
 export SUBIQUITY_REPLAY_TIMESCALE=100
 for answers in examples/answers*.yaml; do
     rm -f .subiquity/subiquity-curtin-install.conf
-    rm -f .subiquity/subiquity-debug.log.*
+    rm -f .subiquity/subiquity-debug.log
     rm -f .subiquity/run/subiquity/updating
     # The --foreground is important to avoid subiquity getting SIGTTOU-ed.
     timeout --foreground 60 sh -c "LANG=C.UTF-8 python3 -m subiquity.cmd.tui --answers $answers --dry-run --snaps-from-examples --machine-config examples/simple.json"
     python3 scripts/validate-yaml.py .subiquity/subiquity-curtin-install.conf
-    if grep passw0rd .subiquity/subiquity-debug.log.* | grep -v "Loaded answers" | grep -v "answers_action"; then
+    if [ ! -e .subiquity/subiquity-debug.log ]; then
+        echo "log file not created"
+        exit 1
+    fi
+    if grep passw0rd .subiquity/subiquity-debug.log | grep -v "Loaded answers" | grep -v "answers_action"; then
         echo "password leaked into log file"
         exit 1
     fi

--- a/subiquitycore/log.py
+++ b/subiquitycore/log.py
@@ -15,29 +15,19 @@
 
 import logging
 import os
-import sys
-from logging.handlers import TimedRotatingFileHandler
 
 
 def setup_logger(dir):
-    LOGFILE = os.path.join(dir, "subiquity-debug.log")
-    try:
-        os.makedirs(dir, exist_ok=True)
-        log = TimedRotatingFileHandler(LOGFILE,
-                                       when='D',
-                                       interval=1,
-                                       backupCount=7)
-    except PermissionError:
-        err = ("Failed to open logfile: ") + LOGFILE
-        sys.stderr.write(err + '\n')
-        sys.exit(1)
+    os.makedirs(dir, exist_ok=True)
+    LOGFILE = os.path.join(dir, "subiquity-debug.log.{}".format(os.getpid()))
+    handler = logging.FileHandler(LOGFILE)
 
-    log.setLevel('DEBUG')
-    log.setFormatter(
+    handler.setLevel(logging.DEBUG)
+    handler.setFormatter(
         logging.Formatter(
             "%(asctime)s %(levelname)s %(name)s:%(lineno)d %(message)s"))
 
-    logger = logging.getLogger('')
-    logger.setLevel('DEBUG')
-    logger.addHandler(log)
+    logger = logging.getLogger("")
+    logger.setLevel(logging.DEBUG)
+    logger.addHandler(handler)
     return LOGFILE

--- a/subiquitycore/log.py
+++ b/subiquitycore/log.py
@@ -19,8 +19,14 @@ import os
 
 def setup_logger(dir):
     os.makedirs(dir, exist_ok=True)
-    LOGFILE = os.path.join(dir, "subiquity-debug.log.{}".format(os.getpid()))
-    handler = logging.FileHandler(LOGFILE)
+    nopid_file = os.path.join(dir, "subiquity-debug.log")
+    LOGFILE = "{}.{}".format(nopid_file, os.getpid())
+    handler = logging.FileHandler(LOGFILE, mode='w')
+    # os.symlink cannot replace an existing file or symlink so create
+    # it and then rename it over.
+    tmplink = LOGFILE + ".link"
+    os.symlink(os.path.basename(LOGFILE), tmplink)
+    os.rename(tmplink, nopid_file)
 
     handler.setLevel(logging.DEBUG)
     handler.setFormatter(


### PR DESCRIPTION
Log to subiquity-debug.log.$PID instead of just subiquity-debug.log.

When we implement error reports we'll obviously attach the log to the
error report. There's no point adding log messages from previous runs of
subiquity.