### PR TITLE
Don't mark 'DHCPv{v}' as translatable

### DIFF
--- a/subiquitycore/ui/views/network.py
+++ b/subiquitycore/ui/views/network.py
@@ -208,7 +208,7 @@ class NetworkView(BaseView):
                 elif dev.dhcp_state(v) == "TIMEDOUT":
                     address_info.append((label, Text(_("timed out"))))
                 elif dev.dhcp_state(v) == "RECONFIGURE":
-                    address_info.append((label, Text(_("-"))))
+                    address_info.append((label, Text("-")))
                 else:
                     address_info.append((
                         label,

--- a/subiquitycore/ui/views/network.py
+++ b/subiquitycore/ui/views/network.py
@@ -195,7 +195,7 @@ class NetworkView(BaseView):
         dhcp_addresses = dev.dhcp_addresses()
         for v in 4, 6:
             if dev.dhcp_enabled(v):
-                label = Text(_("DHCPv{v}").format(v=v))
+                label = Text("DHCPv{v}".format(v=v))
                 addrs = dhcp_addresses.get(v)
                 if addrs:
                     address_info.extend(


### PR DESCRIPTION
I don't think the strings 'DHCPv4' and 'DHCPv6' warrant translation because they are names, not words; and almost no translator is going to know what to do with the {v} syntax (gettext does provide some guardrails, marking this as "python-brace-format", but I'm not sure that results in an error early enough to be useful to translators).