### PR TITLE
keep dialog titles up to date when on screen

### DIFF
--- a/subiquitycore/ui/stretchy.py
+++ b/subiquitycore/ui/stretchy.py
@@ -66,13 +66,29 @@ class Stretchy(metaclass=urwid.MetaSignals):
         self.widgets = widgets
         self.stretchy_index = stretchy_index
         self.focus_index = focus_index
+        urwid.connect_signal(self, 'opened', self.opened)
+        urwid.connect_signal(self, 'closed', self.closed)
+        self._connections = []
+        urwid.connect_signal(self, 'opened', self._connect)
+        urwid.connect_signal(self, 'closed', self._disconnect)
 
     def opened(self):
         """Called when the stretchy is placed on the screen."""
-        pass
 
     def closed(self):
         """Called when the stretchy is removed from the screen."""
+
+    def add_connection(self, obj, signal, cb, *args, **kw):
+        """Subscribe to a signal on obj while the stretchy is on-screen."""
+        self._connections.append((obj, signal, cb, args, kw))
+
+    def _connect(self):
+        for obj, signal, cb, args, kw in self._connections:
+            urwid.connect_signal(obj, signal, cb, *args, **kw)
+
+    def _disconnect(self):
+        for obj, signal, cb, args, kw in self._connections:
+            urwid.disconnect_signal(obj, signal, cb, *args, **kw)
 
     @property
     def stretchy_w(self):

--- a/subiquitycore/view.py
+++ b/subiquitycore/view.py
@@ -70,13 +70,11 @@ class BaseView(WidgetWrap):
 
     def show_stretchy_overlay(self, stretchy):
         emit_signal(stretchy, 'opened')
-        stretchy.opened()
         self._w = StretchyOverlay(disabled(self._w), stretchy)
 
     def remove_overlay(self):
         if isinstance(self._w, StretchyOverlay):
             emit_signal(self._w.stretchy, 'closed')
-            self._w.stretchy.closed()
         # disabled() wraps a widget in two decorations.
         self._w = self._w.bottom_w.original_widget.original_widget
 


### PR DESCRIPTION
Something I did doing error reporting that has no dependence on the other mounds of stuff.