### PR TITLE
Move PATH setup from agetty service into subiquity itself

### DIFF
--- a/bin/subiquity-service
+++ b/bin/subiquity-service
@@ -4,7 +4,6 @@ if [ -n "$1" ]; then
    port=$1
 fi
 /bin/dmesg -n 1
-export PATH=$SNAP/bin:$SNAP/usr/bin:$PATH
 if [ "$port" = "tty1" ]; then
 	$SNAP/usr/bin/subiquity-loadkeys
 	setfont $SNAP/subiquity.psf

--- a/subiquity/cmd/tui.py
+++ b/subiquity/cmd/tui.py
@@ -84,6 +84,14 @@ AUTO_ANSWERS_FILE = "/subiquity_config/answers.yaml"
 
 
 def main():
+    # Preffer utils from $SNAP, over system-wide
+    snap = os.environ.get('SNAP')
+    if snap:
+        os.environ['PATH'] = os.pathsep.join([
+            os.path.join(snap, 'bin'),
+            os.path.join(snap, 'usr', 'bin'),
+            os.environ['PATH'],
+        ])
     opts = parse_options(sys.argv[1:])
     global LOGDIR
     if opts.dry_run:


### PR DESCRIPTION
This way `sudo snap run subiquity` will have the correct PATH for
probert/utils/curtin, as needed when running subiquity from ssh
session.