### PR TITLE
enable turning colors on and off

### DIFF
--- a/subiquity/palette.py
+++ b/subiquity/palette.py
@@ -73,8 +73,8 @@ STYLES = [
 
 
 STYLES_MONO = [
-    ('frame_header_fringe', 'black',   'white'),
-    ('frame_header',        'white',   'black'),
+    ('frame_header_fringe', 'white',   'black'),
+    ('frame_header',        'black',   'white'),
     ('body',                'white',   'black'),
 
     ('done_button',         'white',   'black'),
@@ -86,9 +86,12 @@ STYLES_MONO = [
 
     ('menu_button',         'white',   'black'),
     ('menu_button focus',   'black',   'white'),
+    ('frame_button',        'black',   'white'),
+    ('frame_button focus',  'white',   'black'),
 
     ('info_primary',        'white',   'black'),
     ('info_minor',          'white',   'black'),
+    ('info_minor header',   'black',   'white'),
     ('info_error',          'white',   'black'),
 
     ('string_input',        'white',   'black'),

--- a/subiquity/ui/views/help.py
+++ b/subiquity/ui/views/help.py
@@ -112,10 +112,11 @@ GLOBAL_KEY_HELP = _("""\
 The following keys can be used at any time:""")
 
 GLOBAL_KEYS = (
-    (_('Control-Z, F2'), _('switch to shell')),
     (_("ESC"),           _('go back')),
-    (_('Control-L'),     _('redraw screen')),
     (_('F1'),            _('open help menu')),
+    (_('Control-Z, F2'), _('switch to shell')),
+    (_('Control-L, F3'), _('redraw screen')),
+    (_('Control-T, F4'), _('toggle color on and off')),
     )
 
 DRY_RUN_KEYS = (

--- a/subiquity/ui/views/help.py
+++ b/subiquity/ui/views/help.py
@@ -174,11 +174,14 @@ class HelpMenu(WidgetWrap):
             _("Help on keyboard shortcuts"), on_press=self._shortcuts)
         drop_to_shell = menu_item(
             _("Switch to shell"), on_press=self._debug_shell)
+        color = menu_item(
+            _("Toggle color on/off"), on_press=self._toggle_color)
         buttons = {
             close,
             about,
             keys,
             drop_to_shell,
+            color,
             }
         local_title, local_doc = parent.app.ui.body.local_help()
         if local_title is not None:
@@ -188,6 +191,9 @@ class HelpMenu(WidgetWrap):
             buttons.add(local)
         else:
             local = Text(('info_minor header', _("Help on this screen")))
+        for button in buttons:
+            connect_signal(button.base_widget, 'click', self._close)
+
         entries = [
             about,
             local,
@@ -195,9 +201,9 @@ class HelpMenu(WidgetWrap):
             keys,
             hline,
             drop_to_shell,
+            hline,
+            color,
             ]
-        for button in buttons:
-            connect_signal(button.base_widget, 'click', self._close)
 
         rows = [
             Columns([
@@ -291,6 +297,9 @@ class HelpMenu(WidgetWrap):
 
     def _debug_shell(self, sender):
         self.parent.app.debug_shell()
+
+    def _toggle_color(self, sender):
+        self.parent.app.toggle_color()
 
 
 class HelpButton(PopUpLauncher):


### PR DESCRIPTION
Oops, this wasn't what I was supposed to be working on today...

This adds a way to turn colors on and off (a hot key and a help menu item). It also refactors the screen implementation we use away from the linux console to be more compatible in mono mode.