### PR TITLE
Align non-clicable Help title

### DIFF
--- a/subiquity/ui/views/help.py
+++ b/subiquity/ui/views/help.py
@@ -190,7 +190,8 @@ class HelpMenu(WidgetWrap):
                 on_press=self._show_local(local_title, local_doc))
             buttons.add(local)
         else:
-            local = Text(('info_minor header', _("Help on this screen")))
+            local = Text(
+                ('info_minor header', " " + _("Help on this screen") + " "))
         for button in buttons:
             connect_signal(button.base_widget, 'click', self._close)
 


### PR DESCRIPTION
pages without local help, have the inactive Help on this screen button missaligned.