### PR TITLE
wrap actionmenu/selector popups in Color.body

### DIFF
--- a/subiquitycore/ui/actionmenu.py
+++ b/subiquitycore/ui/actionmenu.py
@@ -88,7 +88,7 @@ class _ActionMenuDialog(WidgetWrap):
                 btn = AttrWrap(btn, 'info_minor')
             group.append(btn)
         self.width = width
-        super().__init__(LineBox(ListBox(group)))
+        super().__init__(Color.body(LineBox(ListBox(group))))
 
     def close(self, sender):
         self.parent.close_pop_up()

--- a/subiquitycore/ui/selector.py
+++ b/subiquitycore/ui/selector.py
@@ -29,7 +29,10 @@ from subiquitycore.ui.container import (
     ListBox,
     WidgetWrap,
     )
-from subiquitycore.ui.utils import ClickableIcon
+from subiquitycore.ui.utils import (
+    ClickableIcon,
+    Color,
+    )
 
 
 class _PopUpSelectDialog(WidgetWrap):
@@ -58,7 +61,7 @@ class _PopUpSelectDialog(WidgetWrap):
             group.append(btn)
         list_box = ListBox(group)
         list_box.base_widget.focus_position = cur_index
-        super().__init__(LineBox(list_box))
+        super().__init__(Color.body(LineBox(list_box)))
 
     def click(self, btn, index):
         self.parent.index = index


### PR DESCRIPTION
this fixes a slight visual glitch in gnome-terminal