### PR TITLE
add post-refresh hook to restart subiquity on the serial line

### DIFF
--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# snapd will restart snap.subiquity.subiquity-service.service for us,
+# but any processes running on the serial lines are created via
+# systemd overrides in the installer layer of the squashfs and so need
+# restarting separately.
+systemctl restart 'serial-subiquity@*.service'


### PR DESCRIPTION
For https://bugs.launchpad.net/subiquity/+bug/1848182.

This was easy? As a bonus, the hook from the refresh-to snap is executed so this will work even when the user is running current media.