### PR TITLE
add a controlled way to make various things fail

### DIFF
--- a/scripts/replay-curtin-log.py
+++ b/scripts/replay-curtin-log.py
@@ -30,4 +30,13 @@ for line in open(json_file):
         report(prev_ev)
         time.sleep(min((time_for_entry(ev) - time_for_entry(prev_ev)), 8)/scale_factor)
     prev_ev = ev
-report(prev_ev)
+rc = 0
+
+# See subiquitycore/controller.py for the other flags that can be in
+# SUBIQUITY_DEBUG.
+debug_flags = os.environ.get('SUBIQUITY_DEBUG', '').split(',')
+if 'install-fail' in debug_flags:
+    ev["CURTIN_RESULT"] = "FAILURE"
+    rc = 1
+report(ev)
+sys.exit(rc)

--- a/subiquity/controllers/filesystem.py
+++ b/subiquity/controllers/filesystem.py
@@ -17,6 +17,7 @@ import enum
 import json
 import logging
 import os
+import time
 
 import urwid
 
@@ -77,6 +78,13 @@ class Probe:
             probe_types = {'blockdev'}
         else:
             probe_types = None
+        debug_flags = self.controller.debug_flags
+        if 'bpfail-full' in debug_flags and not self.restricted:
+            time.sleep(2)
+            1/0
+        if 'bpfail-restricted' in debug_flags and self.restricted:
+            time.sleep(2)
+            1/0
         # Should consider invoking probert in a subprocess here (so we
         # can kill it if it gets stuck).
         return self.controller.app.prober.get_storage(probe_types=probe_types)

--- a/subiquity/controllers/installprogress.py
+++ b/subiquity/controllers/installprogress.py
@@ -498,6 +498,8 @@ class InstallProgressController(BaseController):
           transitions={'reboot': 'reboot'})
     def _bg_copy_logs_to_target(self):
         if self.opts.dry_run:
+            if 'copy-logs-fail' in self.debug_flags:
+                raise PermissionError()
             return
         target_logs = self.tpath('var/log/installer')
         utils.run_command(['cp', '-aT', '/var/log/installer', target_logs])

--- a/subiquity/core.py
+++ b/subiquity/core.py
@@ -114,6 +114,8 @@ class Subiquity(Application):
         if key == 'f1':
             if not self.ui.right_icon.showing_something:
                 self.ui.right_icon.open_pop_up()
+        elif self.opts.dry_run and key == 'ctrl u':
+            1/0
         elif key in ['ctrl z', 'f2']:
             self.debug_shell()
         else:

--- a/subiquity/ui/views/help.py
+++ b/subiquity/ui/views/help.py
@@ -121,6 +121,7 @@ GLOBAL_KEYS = (
 
 DRY_RUN_KEYS = (
     (_('Control-X'), _('quit (dry-run only)')),
+    (_('Control-U'), _('crash the ui (dry-run only)')),
     )
 
 

--- a/subiquitycore/controller.py
+++ b/subiquitycore/controller.py
@@ -16,6 +16,7 @@
 
 from abc import ABC, abstractmethod
 import logging
+import os
 
 log = logging.getLogger("subiquitycore.controller")
 
@@ -33,6 +34,16 @@ class BaseController(ABC):
         self.ui = app.ui
         self.signal = app.signal
         self.opts = app.opts
+        self.debug_flags = ()
+        if self.opts.dry_run:
+            # Recognized flags are:
+            #  - install-fail: makes curtin install fail, see
+            #    scripts/replay-curtin-log.py
+            #  - bpfail-full, bpfail-restricted: makes block probing fail, see
+            #    subiquity/controllers/filesystem.py
+            #  - copy-logs-fail: makes post-install copying of logs fail, see
+            #    subiquity/controllers/installprogress.py
+            self.debug_flags = os.environ.get('SUBIQUITY_DEBUG', '').split(',')
         self.loop = app.loop
         self.run_in_bg = app.run_in_bg
         self.app = app


### PR DESCRIPTION
In dry-run mode, treat SUBIQUITY_DEBUG as a comma-separated list of
things to fail:

 * install-fail: curtin install fails
 * bpfail-full: full block device probing fails
 * bpfail-restricuted: restricted block device probing fails

In addition, control-u makes the UI crash in dry-run mode.

(This is all for testing of crash report generation but does not depend
on that).