### PR TITLE
More accurate estimation of the size of a RAID

### DIFF
--- a/scripts/raid-size-tests.py
+++ b/scripts/raid-size-tests.py
@@ -119,7 +119,7 @@ def verify_size_ok(level, sizes):
             print("exactly right!")
             r = True
         else:
-            print("underestimated size by", real_size - calc_size)
+            print("subiquity wasted space", real_size - calc_size)
             r = True
     finally:
         cleanup()

--- a/scripts/raid-size-tests.py
+++ b/scripts/raid-size-tests.py
@@ -1,0 +1,127 @@
+#!/usr/bin/python3
+
+import atexit
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import uuid
+
+import attr
+
+from subiquity.models.filesystem import (
+    dehumanize_size,
+    get_raid_size,
+    humanize_size,
+    raidlevels,
+    )
+
+
+tmpdir = tempfile.mkdtemp()
+
+raids = []
+loopdevs = []
+
+_cmdoutput = []
+
+def run(cmd):
+    try:
+        subprocess.run(
+            cmd, check=True,
+            stdout=subprocess.PIPE, stdin=subprocess.DEVNULL,
+            stderr=subprocess.STDOUT)
+    except subprocess.CalledProcessError as e:
+        print(e.stdout)
+        raise
+
+
+def cleanup():
+    for raid in raids:
+        subprocess.run(
+            ['mdadm', '--verbose', '--stop', raid])
+    for loopdev in loopdevs:
+        subprocess.run(
+            ['losetup', '-d', loopdev])
+    shutil.rmtree(tmpdir)
+
+
+def create_devices_for_sizes(sizes):
+    devs = []
+    for size in sizes:
+        fd, name = tempfile.mkstemp(dir=tmpdir)
+        os.ftruncate(fd, size)
+        os.close(fd)
+        dev = subprocess.run(
+            ['losetup', '-f', '--show', name],
+            stdout=subprocess.PIPE, encoding='ascii').stdout.strip()
+        devs.append(dev)
+        loopdevs.append(dev)
+    return devs
+
+
+def create_raid(level, images):
+    name = '/dev/md/{}'.format(uuid.uuid4())
+    cmd = [
+        'mdadm',
+        '--verbose',
+        '--create',
+        '--metadata', 'default',
+        '--level', level,
+        '-n', str(len(images)),
+        '--assume-clean',
+        name,
+        ] + images
+    run(cmd)
+    raids.append(name)
+    return name
+
+
+def get_real_raid_size(raid):
+    return int(subprocess.run(
+        ['blockdev', '--getsize64', raid],
+        stdout=subprocess.PIPE, encoding='ascii').stdout.strip())
+
+
+@attr.s
+class FakeDev:
+    size = attr.ib()
+
+
+def verify_size_ok(level, sizes):
+    devs = create_devices_for_sizes(sizes)
+    raid = create_raid(level, devs)
+    devs = [FakeDev(size) for size in sizes]
+    calc_size = get_raid_size(level, devs)
+    real_size = get_real_raid_size(raid)
+    if len(set(sizes)) == 1:
+        sz = '[{}]*{}'.format(humanize_size(sizes[0]), len(sizes))
+    else:
+        sz = str([humanize_size(s) for s in sizes])
+    print("level {} sizes {} -> calc_size {} real_size {}".format(
+        level, sz , calc_size, real_size), end=' ')
+    if calc_size > real_size:
+        print("BAAAAAAAAAAAD", real_size - calc_size)
+        r = False
+    else:
+        print("OK by", real_size - calc_size)
+        r = True
+    run(['mdadm', '--verbose', '--stop', raid])
+    raids.remove(raid)
+    return r
+
+
+fails = 0
+for size in '1G', '10G', '100G', '1T', '10T', '100T':
+    size = dehumanize_size(size)
+    for level in raidlevels:
+        for count in range(2, 10):
+            if count >= level.min_devices:
+                if not verify_size_ok(level.value, [size]*count):
+                    fails += 1
+
+if fails > 0:
+    print("{} fails".format(fails))
+    sys.exit(1)
+else:
+    print("all ok!!")

--- a/scripts/raid-size-tests.py
+++ b/scripts/raid-size-tests.py
@@ -7,16 +7,13 @@
 # raid devices (backed by sparse files in a tmpfs) and comparing their sizes
 # with the estimates. It must be run as root.
 
-import atexit
 import os
 import random
-import shutil
 import subprocess
 import sys
 import tempfile
 import uuid
 
-import attr
 
 from subiquity.models.filesystem import (
     align_down,
@@ -24,6 +21,9 @@ from subiquity.models.filesystem import (
     get_raid_size,
     humanize_size,
     raidlevels,
+    )
+from subiquity.models.tests.test_filesystem import (
+    FakeDev,
     )
 
 
@@ -94,11 +94,6 @@ def get_real_raid_size(raid):
     return int(subprocess.run(
         ['blockdev', '--getsize64', raid],
         stdout=subprocess.PIPE, encoding='ascii').stdout.strip())
-
-
-@attr.s
-class FakeDev:
-    size = attr.ib()
 
 
 def verify_size_ok(level, sizes):

--- a/scripts/raid-size-tests.py
+++ b/scripts/raid-size-tests.py
@@ -1,5 +1,12 @@
 #!/usr/bin/python3
 
+# The fine details of how big a RAID device ends up as a function of the sizes
+# of its components is somewhat hairier than one might think, with a certain
+# fraction of each component device being given over to metadata storage. This
+# script tests the estimates subiquity uses against reality by creating actual
+# raid devices (backed by sparse files in a tmpfs) and comparing their sizes
+# with the estimates. It must be run as root.
+
 import atexit
 import os
 import shutil
@@ -126,7 +133,7 @@ try:
                     if not verify_size_ok(level.value, [size]*count):
                         fails += 1
 finally:
-    run(['umount', tmpdir])
+    run(['umount', '-l', tmpdir])
 
 if fails > 0:
     print("{} fails".format(fails))

--- a/scripts/raid-size-tests.py
+++ b/scripts/raid-size-tests.py
@@ -129,7 +129,7 @@ def verify_size_ok(level, sizes):
 fails = 0
 run(['mount', '-t', 'tmpfs', 'tmpfs', tmpdir])
 try:
-    for size in '1G', '10G', '100G', '1T', '10T', '100T':
+    for size in '1G', '10G', '100G', '1T', '10T':
         size = dehumanize_size(size)
         for level in raidlevels:
             for count in range(2, 10):

--- a/scripts/raid-size-tests.py
+++ b/scripts/raid-size-tests.py
@@ -112,10 +112,14 @@ def verify_size_ok(level, sizes):
             level, sz , calc_size, real_size), end=' ')
         if calc_size > real_size:
             print("BAAAAAAAAAAAD", real_size - calc_size)
-            print(raid)
-            input('waiting: ')
+            if os.environ.get('DEBUG'):
+                print(raid)
+                input('waiting: ')
+        elif calc_size == real_size:
+            print("exactly right!")
+            r = True
         else:
-            print("OK by", real_size - calc_size)
+            print("underestimated size by", real_size - calc_size)
             r = True
     finally:
         cleanup()

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -239,10 +239,11 @@ def round_raid_size(min_size):
     return min_size - data_offset
 
 
+# This this is tested against reality in ./scripts/get-raid-sizes.py
 def get_raid_size(level, devices):
-    min_size = round_raid_size(min(dev.size for dev in devices))
     if len(devices) == 0:
         return 0
+    min_size = round_raid_size(min(dev.size for dev in devices))
     if min_size <= 0:
         return 0
     if level == "raid0":

--- a/subiquity/models/tests/test_filesystem.py
+++ b/subiquity/models/tests/test_filesystem.py
@@ -16,15 +16,17 @@
 from collections import namedtuple
 import unittest
 
+import attr
+
 from subiquity.models.filesystem import (
     Bootloader,
     dehumanize_size,
     DeviceAction,
     Disk,
     FilesystemModel,
+    get_raid_size,
     humanize_size,
     Partition,
-    round_raid_size,
     )
 
 
@@ -109,7 +111,14 @@ class TestDehumanizeSize(unittest.TestCase):
 class TestRoundRaidSize(unittest.TestCase):
 
     def test_lp1816777(self):
-        self.assertLessEqual(round_raid_size(500107862016), 499972571136)
+
+        @attr.s
+        class FakeDev:
+            size = attr.ib()
+
+        self.assertLessEqual(
+            get_raid_size("raid1", [FakeDev(500107862016)]*2),
+            499972571136)
 
 
 FakeStorageInfo = namedtuple(

--- a/subiquity/models/tests/test_filesystem.py
+++ b/subiquity/models/tests/test_filesystem.py
@@ -24,6 +24,7 @@ from subiquity.models.filesystem import (
     FilesystemModel,
     humanize_size,
     Partition,
+    round_raid_size,
     )
 
 
@@ -103,6 +104,12 @@ class TestDehumanizeSize(unittest.TestCase):
                     self.fail(
                         "dehumanize_size({!r}) did not error".format(input))
                 self.assertEqual(expected_error, actual_error)
+
+
+class TestRoundRaidSize(unittest.TestCase):
+
+    def test_lp1816777(self):
+        self.assertLessEqual(round_raid_size(500107862016), 499972571136)
 
 
 FakeStorageInfo = namedtuple(

--- a/subiquity/models/tests/test_filesystem.py
+++ b/subiquity/models/tests/test_filesystem.py
@@ -19,6 +19,7 @@ import unittest
 import attr
 
 from subiquity.models.filesystem import (
+    attributes,
     Bootloader,
     dehumanize_size,
     DeviceAction,
@@ -108,13 +109,16 @@ class TestDehumanizeSize(unittest.TestCase):
                 self.assertEqual(expected_error, actual_error)
 
 
+@attr.s
+class FakeDev:
+
+    size = attr.ib()
+    id = attributes.idfield("fakedev")
+
+
 class TestRoundRaidSize(unittest.TestCase):
 
     def test_lp1816777(self):
-
-        @attr.s
-        class FakeDev:
-            size = attr.ib()
 
         self.assertLessEqual(
             get_raid_size("raid1", [FakeDev(500107862016)]*2),


### PR DESCRIPTION
I found the code in mdadm that decides how much of a device is usable
for data and copied it. It's a bit hairy!

For https://bugs.launchpad.net/subiquity/+bug/1816777 and many similar
bugs.