### PR TITLE
first cut at error report ui

### DIFF
--- a/subiquity/controllers/error.py
+++ b/subiquity/controllers/error.py
@@ -132,6 +132,9 @@ class ErrorReport:
         with open(self.meta_path, 'w') as fp:
             json.dump(self.meta, fp, indent=4)
 
+    def mark_seen(self):
+        self.set_meta("seen", True)
+
     @property
     def kind(self):
         k = self.meta.get("kind", "UNKNOWN")

--- a/subiquity/controllers/error.py
+++ b/subiquity/controllers/error.py
@@ -25,6 +25,8 @@ import apport.hookutils
 
 import attr
 
+import urwid
+
 from subiquitycore.controller import BaseController
 
 
@@ -46,7 +48,10 @@ class ErrorReportKind(enum.Enum):
 
 
 @attr.s(cmp=False)
-class ErrorReport:
+class ErrorReport(metaclass=urwid.MetaSignals):
+
+    signals = ["changed"]
+
     controller = attr.ib()
     base = attr.ib()
     pr = attr.ib()
@@ -110,6 +115,7 @@ class ErrorReport:
                 self.state = ErrorReportState.DONE
             self._file.close()
             self._file = None
+            urwid.emit_signal(self, "changed")
         if wait:
             _bg_add_info()
         else:

--- a/subiquity/controllers/error.py
+++ b/subiquity/controllers/error.py
@@ -146,6 +146,10 @@ class ErrorReport(metaclass=urwid.MetaSignals):
         k = self.meta.get("kind", "UNKNOWN")
         return getattr(ErrorReportKind, k, ErrorReportKind.UNKNOWN)
 
+    @property
+    def seen(self):
+        return self.meta.get("seen", False)
+
 
 class ErrorController(BaseController):
 

--- a/subiquity/controllers/error.py
+++ b/subiquity/controllers/error.py
@@ -82,7 +82,7 @@ class ErrorReport(metaclass=urwid.MetaSignals):
     def from_file(cls, controller, fpath):
         base = os.path.splitext(os.path.basename(fpath))[0]
         report = cls(
-            controller, base, pr=apport.Report(),
+            controller, base, pr=apport.Report(date='???'),
             state=ErrorReportState.LOADING, file=open(fpath, 'rb'))
         try:
             fp = open(report.meta_path, 'r')
@@ -179,6 +179,7 @@ class ErrorReport(metaclass=urwid.MetaSignals):
 
     def mark_seen(self):
         self.set_meta("seen", True)
+        urwid.emit_signal(self, "changed")
 
     @property
     def kind(self):

--- a/subiquity/controllers/error.py
+++ b/subiquity/controllers/error.py
@@ -197,7 +197,7 @@ class ErrorReport(metaclass=urwid.MetaSignals):
         # findmnt(1).
         looking_for = os.path.abspath(
             os.path.normpath(self.controller.crash_directory))
-        for line in open('/proc/self/mountinfo'):
+        for line in open('/proc/self/mountinfo').readlines():
             parts = line.strip().split()
             if os.path.normpath(parts[4]) == looking_for:
                 devname = parts[9]

--- a/subiquity/controllers/error.py
+++ b/subiquity/controllers/error.py
@@ -64,7 +64,7 @@ class ErrorReport(metaclass=urwid.MetaSignals):
 
     @classmethod
     def new(cls, controller, kind):
-        base = "installer.{:.9f}.{}".format(time.time(), kind.name.lower())
+        base = "{:.9f}.{}".format(time.time(), kind.name.lower())
         crash_file = open(
             os.path.join(controller.crash_directory, base + ".crash"),
             'wb')
@@ -204,6 +204,11 @@ class ErrorReport(metaclass=urwid.MetaSignals):
                 root = parts[3]
                 break
         else:
+            if self.controller.opts.dry_run:
+                path = ('install-logs/2019-11-06.0/crash/' +
+                        self.base +
+                        '.crash')
+                return "casper-rw", path
             return None, None
         import pyudev
         c = pyudev.Context()

--- a/subiquity/controllers/filesystem.py
+++ b/subiquity/controllers/filesystem.py
@@ -108,7 +108,7 @@ class Probe:
             block_discover_log.exception(
                 "probing failed restricted=%s", self.restricted)
             self.crash_report = self.controller.app.make_apport_report(
-                self.kind, "block probing")
+                self.kind, "block probing", interrupt=False)
             self.state = ProbeState.FAILED
         else:
             block_discover_log.exception(
@@ -120,7 +120,7 @@ class Probe:
         if self.state != ProbeState.PROBING:
             return
         self.crash_report = self.controller.app.make_apport_report(
-            self.kind, "block probing timed out")
+            self.kind, "block probing timed out", interrupt=False)
         block_discover_log.exception(
             "probing timed out restricted=%s", self.restricted)
         self.state = ProbeState.FAILED

--- a/subiquity/controllers/filesystem.py
+++ b/subiquity/controllers/filesystem.py
@@ -141,6 +141,7 @@ class FilesystemController(BaseController):
         self._cur_probe = None
         self._monitor = None
         self._udev_listen_handle = None
+        self._probes = {}
 
     def start(self):
         self._start_probe(restricted=False)
@@ -177,9 +178,10 @@ class FilesystemController(BaseController):
             log.debug("_udev_event %s %s", action, dev)
         self._start_probe(restricted=False)
 
-    def _start_probe(self, *, restricted):
-        self._cur_probe = Probe(self, restricted, 5.0, self._probe_done)
-        self._cur_probe.start()
+    def _start_probe(self, *, restricted=False):
+        p = Probe(self, restricted, 5.0, self._probe_done)
+        self._cur_probe = self._probes[restricted] = p
+        p.start()
 
     def _probe_done(self, probe):
         if probe is not self._cur_probe:
@@ -209,7 +211,7 @@ class FilesystemController(BaseController):
             block_discover_log.exception(
                 "load_probe_data failed restricted=%s", probe.restricted)
             probe.crash_report = self.app.make_apport_report(
-                probe.kind, "loading probe data")
+                probe.kind, "loading probe data", interrupt=False)
             if not probe.restricted:
                 self._start_probe(restricted=True)
             else:
@@ -227,15 +229,18 @@ class FilesystemController(BaseController):
             self.ui.set_body(SlowProbing(self))
         elif self._cur_probe.state == ProbeState.FAILED:
             self.ui.set_body(ProbingFailed(self))
+            self.ui.body.show_error()
         else:
             # Once we've shown the filesystem UI, we stop listening for udev
             # events as merging system changes with configuration the user has
             # performed would be tricky.  Possibly worth doing though! Just
             # not today.
             self.stop_listening_udev()
-            # Should display a message if self._cur_probe.restricted,
-            # i.e. full device probing failed.
             self.ui.set_body(GuidedFilesystemView(self))
+            if self._cur_probe.restricted:
+                pr = self._probes[False].crash_report
+                if pr is not None:
+                    self.app.show_error_report(pr)
             if self.answers['guided']:
                 self.guided(self.answers.get('guided-method', 'direct'))
             elif self.answers['manual']:

--- a/subiquity/controllers/installprogress.py
+++ b/subiquity/controllers/installprogress.py
@@ -254,15 +254,15 @@ class InstallProgressController(BaseController):
 
     def curtin_error(self):
         self.install_state = InstallState.ERROR
-        self.app.make_apport_report(
-            ErrorReportKind.INSTALL_FAIL, "install failed", interrupt=True)
+        crash_report = self.app.make_apport_report(
+            ErrorReportKind.INSTALL_FAIL, "install failed", interrupt=False)
         self.progress_view.spinner.stop()
         if sys.exc_info()[0] is not None:
             self.progress_view.add_log_line(traceback.format_exc())
         self.progress_view.set_status(('info_error',
                                        _("An error has occurred")))
-        self.progress_view.show_complete(True)
         self.start_ui()
+        self.progress_view.show_error(crash_report)
 
     def _bg_run_command_logged(self, cmd, **kwargs):
         cmd = ['systemd-cat', '--level-prefix=false',

--- a/subiquity/controllers/installprogress.py
+++ b/subiquity/controllers/installprogress.py
@@ -255,7 +255,7 @@ class InstallProgressController(BaseController):
     def curtin_error(self):
         self.install_state = InstallState.ERROR
         self.app.make_apport_report(
-            ErrorReportKind.INSTALL_FAIL, "install failed")
+            ErrorReportKind.INSTALL_FAIL, "install failed", interrupt=True)
         self.progress_view.spinner.stop()
         if sys.exc_info()[0] is not None:
             self.progress_view.add_log_line(traceback.format_exc())

--- a/subiquity/core.py
+++ b/subiquity/core.py
@@ -219,8 +219,4 @@ class Subiquity(Application):
             # Don't show an error if already looking at one.
             return
         self.ui.body.show_stretchy_overlay(
-            ErrorReportStretchy(
-                self,
-                self.error_controller,
-                report,
-                self.ui.body))
+            ErrorReportStretchy(self, self.ui.body, report))

--- a/subiquity/core.py
+++ b/subiquity/core.py
@@ -116,6 +116,14 @@ class Subiquity(Application):
             print("report saved to {}".format(report.path))
             raise
 
+    def select_initial_screen(self, index):
+        super().select_initial_screen(index)
+        for report in self.error_controller.reports:
+            if report.kind == ErrorReportKind.UI and not report.seen:
+                log.debug("showing new error %r", report.base)
+                self.show_error_report(report)
+                return
+
     def _network_change(self):
         self.signal.emit_signal('snapd-network-change')
 

--- a/subiquity/ui/views/error.py
+++ b/subiquity/ui/views/error.py
@@ -126,9 +126,9 @@ class ErrorReportStretchy(Stretchy):
             'debug_shell': other_btn(
                 _("Switch to a shell"), on_press=self.debug_shell),
             'restart': other_btn(
-                _("Restart installer"), on_press=self.restart),
+                _("Restart the installer"), on_press=self.restart),
             'view': other_btn(
-                _("View Full Report"), on_press=self.view_report),
+                _("View full report"), on_press=self.view_report),
             }
         w = 0
         for n, b in self.btns.items():

--- a/subiquity/ui/views/error.py
+++ b/subiquity/ui/views/error.py
@@ -1,0 +1,132 @@
+# Copyright 2019 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+
+from urwid import (
+    connect_signal,
+    Padding,
+    Text,
+    )
+
+from subiquitycore.ui.buttons import other_btn
+from subiquitycore.ui.container import (
+    Pile,
+    )
+from subiquitycore.ui.form import (
+    Toggleable,
+    )
+from subiquitycore.ui.spinner import Spinner
+from subiquitycore.ui.stretchy import Stretchy
+from subiquitycore.ui.utils import (
+    rewrap,
+    )
+from subiquitycore.ui.width import (
+    widget_width,
+    )
+
+from subiquity.controllers.error import (
+    ErrorReportKind,
+    ErrorReportState,
+    )
+
+
+log = logging.getLogger('subiquity.ui.error')
+
+
+def close_btn(parent, label=None):
+    if label is None:
+        label = _("Close")
+    return other_btn(label, on_press=lambda sender: parent.remove_overlay())
+
+
+error_report_intros = {
+    ErrorReportKind.BLOCK_PROBE_FAIL: _("""
+Sorry, there was a problem examining the storage devices on this system.
+"""),
+    ErrorReportKind.DISK_PROBE_FAIL: _("""
+Sorry, there was a problem examining the storage devices on this system.
+"""),
+    ErrorReportKind.INSTALL_FAIL: _("""
+Sorry, there was a problem completing the installation.
+"""),
+    ErrorReportKind.UI: _("""
+Sorry, the installer has restarted because of an error.
+"""),
+    ErrorReportKind.UNKNOWN: _("""
+Sorry, an unknown error occurred.
+"""),
+}
+
+incomplete_text = _("""
+Information is being collected from the system that will help the
+developers diagnose the report.
+""")
+
+
+class ErrorReportStretchy(Stretchy):
+
+    def __init__(self, app, ec, report, parent):
+        self.app = app
+        self.ec = ec
+        self.report = report
+        self.parent = parent
+
+        self.view_btn = Toggleable(
+                other_btn(
+                    _("View Error Report"),
+                    on_press=self.view_report))
+        self.close_btn = close_btn(parent)
+        btn_attrs = {'view_btn', 'close_btn'}
+        w = 0
+        for a in btn_attrs:
+            w = max(w, widget_width(getattr(self, a)))
+        for a in btn_attrs:
+            b = getattr(self, a)
+            setattr(self, a, Padding(b, width=w, align='center'))
+
+        self.pile = Pile(self._pile_elements())
+        self.spinner = Spinner(app.loop, style='dots')
+        super().__init__("", [self.pile], 0, 0)
+        connect_signal(self, 'closed', self.spinner.stop)
+
+    def _pile_elements(self):
+        widgets = [
+            Text(rewrap(_(error_report_intros[self.report.kind]))),
+            Text(""),
+            ]
+
+        if self.report.state == ErrorReportState.INCOMPLETE:
+            self.spinner.start()
+            widgets.extend([
+                Text(rewrap(_(incomplete_text))),
+                Text(""),
+                self.spinner])
+        else:
+            self.spinner.stop()
+            widgets.append(self.view_btn)
+
+        widgets.extend([
+            Text(""),
+            self.close_btn,
+            ])
+
+        return widgets
+
+    def view_report(self, sender):
+        self.app.run_command_in_foreground(["less", self.report.path])
+
+    def opened(self):
+        self.report.mark_seen()

--- a/subiquity/ui/views/error.py
+++ b/subiquity/ui/views/error.py
@@ -76,10 +76,22 @@ Sorry, an unknown error occurred.
 """),
 }
 
-incomplete_text = _("""
+error_report_state_descriptions = {
+    ErrorReportState.INCOMPLETE: (_("""
 Information is being collected from the system that will help the
 developers diagnose the report.
-""")
+"""), True),
+    ErrorReportState.LOADING: (_("""
+Loading report...
+"""), True),
+    ErrorReportState.ERROR_GENERATING: (_("""
+Collecting information from the system failed. See the files in
+/var/log/installer for more.
+"""), False),
+    ErrorReportState.ERROR_LOADING: (_("""
+Loading the report failed. See the files in /var/log/installer for more.
+"""), False),
+}
 
 
 class ErrorReportStretchy(Stretchy):
@@ -114,15 +126,18 @@ class ErrorReportStretchy(Stretchy):
             Text(""),
             ]
 
-        if self.report.state == ErrorReportState.INCOMPLETE:
-            self.spinner.start()
-            widgets.extend([
-                Text(rewrap(_(incomplete_text))),
-                Text(""),
-                self.spinner])
-        else:
-            self.spinner.stop()
+        self.spinner.stop()
+
+        if self.report.state == ErrorReportState.DONE:
             widgets.append(self.view_btn)
+        else:
+            text, spin = error_report_state_descriptions[self.report.state]
+            widgets.append(Text(rewrap(_(text))))
+            if spin:
+                self.spinner.start()
+                widgets.extend([
+                    Text(""),
+                    self.spinner])
 
         fs_label, fs_loc = self.report.persistent_details
         if fs_label is not None:

--- a/subiquity/ui/views/error.py
+++ b/subiquity/ui/views/error.py
@@ -181,7 +181,7 @@ class ErrorReportStretchy(Stretchy):
                     widgets.extend([Text(""), self.btns[b]])
         else:
             widgets.extend([
-                Text(),
+                Text(""),
                 self.btns['close'],
                 ])
 

--- a/subiquity/ui/views/error.py
+++ b/subiquity/ui/views/error.py
@@ -124,6 +124,17 @@ class ErrorReportStretchy(Stretchy):
             self.spinner.stop()
             widgets.append(self.view_btn)
 
+        fs_label, fs_loc = self.report.persistent_details
+        if fs_label is not None:
+            location_text = _(
+                "The error report has been saved to\n\n  {loc}\n\non the "
+                "filesystem with label {label!r}.").format(
+                    loc=fs_loc, label=fs_label)
+            widgets.extend([
+                Text(""),
+                Text(location_text),
+                ])
+
         widgets.extend([
             Text(""),
             self.close_btn,

--- a/subiquity/ui/views/error.py
+++ b/subiquity/ui/views/error.py
@@ -25,9 +25,6 @@ from subiquitycore.ui.buttons import other_btn
 from subiquitycore.ui.container import (
     Pile,
     )
-from subiquitycore.ui.form import (
-    Toggleable,
-    )
 from subiquitycore.ui.spinner import Spinner
 from subiquitycore.ui.stretchy import Stretchy
 from subiquitycore.ui.utils import (
@@ -84,10 +81,9 @@ class ErrorReportStretchy(Stretchy):
         self.report = report
         self.parent = parent
 
-        self.view_btn = Toggleable(
-                other_btn(
-                    _("View Error Report"),
-                    on_press=self.view_report))
+        self.view_btn = other_btn(
+            _("View Error Report"),
+            on_press=self.view_report)
         self.close_btn = close_btn(parent)
         btn_attrs = {'view_btn', 'close_btn'}
         w = 0
@@ -97,8 +93,8 @@ class ErrorReportStretchy(Stretchy):
             b = getattr(self, a)
             setattr(self, a, Padding(b, width=w, align='center'))
 
-        self.pile = Pile(self._pile_elements())
         self.spinner = Spinner(app.loop, style='dots')
+        self.pile = Pile(self._pile_elements())
         super().__init__("", [self.pile], 0, 0)
         connect_signal(self, 'closed', self.spinner.stop)
 

--- a/subiquity/ui/views/filesystem/probing.py
+++ b/subiquity/ui/views/filesystem/probing.py
@@ -19,10 +19,14 @@ from urwid import (
     Text,
     )
 
+from subiquitycore.ui.buttons import (
+    other_btn,
+    )
 from subiquitycore.ui.spinner import (
     Spinner,
     )
 from subiquitycore.ui.utils import (
+    button_pile,
     screen,
     )
 from subiquitycore.view import BaseView
@@ -45,7 +49,12 @@ class SlowProbing(BaseView):
                        "to. Please wait until it completes.")),
                 Text(""),
                 self.spinner,
-            ]))
+            ],
+            [other_btn(_("Back"), on_press=self.cancel)]
+            ))
+
+    def cancel(self, result=None):
+        self.controller.cancel()
 
 
 fail_text = _(
@@ -60,4 +69,17 @@ class ProbingFailed(BaseView):
 
     def __init__(self, controller):
         self.controller = controller
-        super().__init__(screen([Text(_(fail_text))]))
+        super().__init__(screen([
+            Text(_(fail_text)),
+            Text(""),
+            button_pile(
+                [other_btn("Show Error Report", on_press=self.show_error)]),
+            ],
+            [other_btn(_("Back"), on_press=self.cancel)]))
+
+    def cancel(self, result=None):
+        self.controller.cancel()
+
+    def show_error(self, sender=None):
+        self.controller.app.show_error_report(
+            self.controller._cur_probe.crash_report)

--- a/subiquity/ui/views/help.py
+++ b/subiquity/ui/views/help.py
@@ -54,6 +54,7 @@ from subiquitycore.ui.width import (
     widget_width,
     )
 
+from subiquity.ui.views.error import ErrorReportListStretchy
 
 log = logging.getLogger('subiquity.ui.help')
 
@@ -119,6 +120,8 @@ GLOBAL_KEYS = (
 
 DRY_RUN_KEYS = (
     (_('Control-X'), _('quit (dry-run only)')),
+    (_('Control-E'), _('generate noisy error report (dry-run only)')),
+    (_('Control-R'), _('generate quiet error report (dry-run only)')),
     (_('Control-U'), _('crash the ui (dry-run only)')),
     )
 
@@ -191,6 +194,16 @@ class HelpMenu(WidgetWrap):
         else:
             local = Text(
                 ('info_minor header', " " + _("Help on this screen") + " "))
+
+        if self.parent.app.error_controller.reports:
+            view_errors = menu_item(
+                _("View error reports").format(local_title),
+                on_press=self._show_errors)
+            buttons.add(view_errors)
+        else:
+            view_errors = Text(
+                ('info_minor header', " " + _("View error reports") + " "))
+
         for button in buttons:
             connect_signal(button.base_widget, 'click', self._close)
 
@@ -198,6 +211,7 @@ class HelpMenu(WidgetWrap):
             local,
             keys,
             drop_to_shell,
+            view_errors,
             hline,
             about,
             hline,
@@ -299,6 +313,12 @@ class HelpMenu(WidgetWrap):
 
     def _toggle_color(self, sender):
         self.parent.app.toggle_color()
+
+    def _show_errors(self, sender):
+        self._show_overlay(
+            ErrorReportListStretchy(
+                self.parent.app,
+                self.parent.app.ui.body))
 
 
 class HelpButton(PopUpLauncher):

--- a/subiquity/ui/views/help.py
+++ b/subiquity/ui/views/help.py
@@ -47,6 +47,9 @@ from subiquitycore.ui.table import (
     TablePile,
     TableRow,
     )
+from subiquitycore.ui.utils import (
+    rewrap,
+    )
 from subiquitycore.ui.width import (
     widget_width,
     )
@@ -90,11 +93,6 @@ return) and the occasional bit of typing.
 
 This is version {snap_version} of the installer.
 """)
-
-
-def rewrap(text):
-    paras = text.split("\n\n")
-    return "\n\n".join([p.replace('\n', ' ') for p in paras]).strip()
 
 
 class SimpleTextStretchy(Stretchy):

--- a/subiquity/ui/views/installprogress.py
+++ b/subiquity/ui/views/installprogress.py
@@ -45,8 +45,8 @@ class ProgressView(BaseView):
 
         self.reboot_btn = Toggleable(ok_btn(
             _("Reboot Now"), on_press=self.reboot))
-        self.exit_btn = cancel_btn(
-            _("Exit To Shell"), on_press=self.quit)
+        self.view_error_btn = cancel_btn(
+            _("View error report"), on_press=self.view_error)
         self.view_log_btn = other_btn(
             _("View full log"), on_press=self.view_log)
 
@@ -117,14 +117,19 @@ class ProgressView(BaseView):
         self.reboot_btn.base_widget.set_label(_("Reboot"))
         self._set_button_width()
 
-    def show_complete(self, include_exit=False, running_updates=False):
-        if include_exit:
-            btns = [self.view_log_btn, self.exit_btn, self.reboot_btn]
-        else:
-            btns = [self.view_log_btn, self.reboot_btn]
+    def show_complete(self):
+        btns = [self.view_log_btn, self.reboot_btn]
         self._set_buttons(btns)
         self.event_buttons.base_widget.focus_position = 1
         self.event_pile.base_widget.focus_position = 2
+
+    def show_error(self, crash_report):
+        btns = [self.view_log_btn, self.view_error_btn, self.reboot_btn]
+        self._set_buttons(btns)
+        self.event_buttons.base_widget.focus_position = 1
+        self.event_pile.base_widget.focus_position = 2
+        self.crash_report = crash_report
+        self.controller.app.show_error_report(crash_report)
 
     def reboot(self, btn):
         self.reboot_btn.base_widget.set_label(_("Rebooting..."))
@@ -133,8 +138,8 @@ class ProgressView(BaseView):
         self.controller.click_reboot()
         self._set_button_width()
 
-    def quit(self, btn):
-        self.controller.quit()
+    def view_error(self, btn):
+        self.controller.app.show_error_report(self.crash_report)
 
     def view_log(self, btn):
         self._w = self.log_pile

--- a/subiquitycore/core.py
+++ b/subiquitycore/core.py
@@ -596,6 +596,12 @@ class Application:
         else:
             return 0
 
+    def select_initial_screen(self, index):
+        try:
+            self.select_screen(index)
+        except Skip:
+            self.next_screen()
+
     def run(self):
         log.debug("Application.run")
         screen = make_screen(self.COLORS, self.is_linux_tty, self.opts.ascii)
@@ -625,16 +631,11 @@ class Application:
             if self.updated:
                 initial_controller_index = self.load_serialized_state()
 
-            def select_initial_screen(loop, index):
-                try:
-                    self.select_screen(index)
-                except Skip:
-                    self.next_screen()
-
             self.loop.set_alarm_in(
                 0.00, lambda loop, ud: tty.setraw(0))
             self.loop.set_alarm_in(
-                0.05, select_initial_screen, initial_controller_index)
+                0.05, lambda loop, ud: self.select_initial_screen(
+                    initial_controller_index))
             self._connect_base_signals()
 
             self.start_controllers()

--- a/subiquitycore/ui/utils.py
+++ b/subiquitycore/ui/utils.py
@@ -317,3 +317,8 @@ def make_action_menu_row(
     connect_signal(menu, 'open', lambda menu: am.set_attr_map(focus_map))
     connect_signal(menu, 'close', lambda menu: am.set_attr_map(attr_map))
     return am
+
+
+def rewrap(text):
+    paras = text.split("\n\n")
+    return "\n\n".join([p.replace('\n', ' ') for p in paras]).strip()


### PR DESCRIPTION
What this conspicuously lacks is any support for submitting reports to Daisy or reporting bugs via apport. We'll decide what to do about those later I guess. You can play around with various kinds of failures in dry-run mode by using control-e, control-r, control-u or setting SUBIQUITY_DEBUG.