### PR TITLE
switch to AsyncioEventLoop and start using asyncio APIs

### DIFF
--- a/subiquity/async_helpers.py
+++ b/subiquity/async_helpers.py
@@ -1,0 +1,26 @@
+# Copyright 2019 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import asyncio
+
+
+def schedule_task(coro):
+    loop = asyncio.get_event_loop()
+    loop.call_soon(asyncio.create_task, coro)
+
+
+async def run_in_thread(func, *args):
+    loop = asyncio.get_event_loop()
+    return await loop.run_in_executor(None, func, *args)

--- a/subiquity/async_helpers.py
+++ b/subiquity/async_helpers.py
@@ -18,7 +18,7 @@ import asyncio
 
 def schedule_task(coro):
     loop = asyncio.get_event_loop()
-    loop.call_soon(asyncio.create_task, coro)
+    loop.call_soon(asyncio.ensure_future, coro)
 
 
 async def run_in_thread(func, *args):

--- a/subiquity/controllers/error.py
+++ b/subiquity/controllers/error.py
@@ -347,9 +347,7 @@ class ErrorController(BaseController):
             r = ErrorReport.from_file(self, path)
             self.reports.append(r)
             to_load.append(r)
-        loop = asyncio.get_event_loop()
-        loop.call_later(
-            0.0, lambda: asyncio.create_task(self._load_reports(to_load)))
+        self.app.schedule_task(self._load_reports(to_load))
 
     def create_report(self, kind):
         r = ErrorReport.new(self, kind)

--- a/subiquity/controllers/keyboard.py
+++ b/subiquity/controllers/keyboard.py
@@ -55,7 +55,7 @@ class KeyboardController(BaseController):
 
     async def apply_settings(self, setting):
         await self.model.set_keyboard(setting)
-        log.debug("KeyboardController._done next-screen")
+        log.debug("KeyboardController next-screen")
         self.signal.emit_signal('next-screen')
 
     def done(self, setting):

--- a/subiquity/controllers/keyboard.py
+++ b/subiquity/controllers/keyboard.py
@@ -13,11 +13,11 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import asyncio
 import logging
 
 from subiquitycore.controller import BaseController
 
+from subiquity.async_helpers import schedule_task
 from subiquity.models.keyboard import KeyboardSetting
 from subiquity.ui.views import KeyboardView
 
@@ -59,7 +59,7 @@ class KeyboardController(BaseController):
         self.signal.emit_signal('next-screen')
 
     def done(self, setting):
-        asyncio.create_task(self.apply_settings(setting))
+        schedule_task(self.apply_settings(setting))
 
     def cancel(self):
         self.signal.emit_signal('prev-screen')

--- a/subiquity/controllers/keyboard.py
+++ b/subiquity/controllers/keyboard.py
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import asyncio
 import logging
 
 from subiquitycore.controller import BaseController
@@ -52,14 +53,13 @@ class KeyboardController(BaseController):
             variant = self.answers.get('variant', '')
             self.done(KeyboardSetting(layout=layout, variant=variant))
 
-    def done(self, setting):
-        self.run_in_bg(
-            lambda: self.model.set_keyboard(setting),
-            self._done)
-
-    def _done(self, fut):
+    async def apply_settings(self, setting):
+        await self.model.set_keyboard(setting)
         log.debug("KeyboardController._done next-screen")
         self.signal.emit_signal('next-screen')
+
+    def done(self, setting):
+        asyncio.create_task(self.apply_settings(setting))
 
     def cancel(self):
         self.signal.emit_signal('prev-screen')

--- a/subiquity/controllers/mirror.py
+++ b/subiquity/controllers/mirror.py
@@ -19,6 +19,11 @@ import requests
 from xml.etree import ElementTree
 
 from subiquitycore.controller import BaseController
+
+from subiquity.async_helpers import (
+    run_in_thread,
+    schedule_task,
+    )
 from subiquity.ui.views.mirror import MirrorView
 
 log = logging.getLogger('subiquity.controllers.mirror')
@@ -48,11 +53,11 @@ class MirrorController(BaseController):
     def snapd_network_changed(self):
         if self.check_state != CheckState.DONE:
             self.check_state = CheckState.CHECKING
-            self.app.schedule_task(self.lookup())
+            schedule_task(self.lookup())
 
     async def lookup(self):
         try:
-            response = await self.app.run_in_thread(
+            response = await run_in_thread(
                 requests.get, "https://geoip.ubuntu.com/lookup")
             response.raise_for_status()
         except requests.exceptions.RequestException:

--- a/subiquity/controllers/snaplist.py
+++ b/subiquity/controllers/snaplist.py
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from functools import partial
 import logging
 
 import requests.exceptions
@@ -28,9 +29,9 @@ log = logging.getLogger('subiquity.controllers.snaplist')
 
 class SnapdSnapInfoLoader:
 
-    def __init__(self, model, run_in_bg, connection, store_section):
+    def __init__(self, model, app, connection, store_section):
         self.model = model
-        self.run_in_bg = run_in_bg
+        self.app = app
         self.store_section = store_section
 
         self._running = False
@@ -44,41 +45,62 @@ class SnapdSnapInfoLoader:
     def start(self):
         self._running = True
         log.debug("loading list of snaps")
+        self.app.schedule_task(self._start())
 
-        def cb(snap_list):
-            if not self._running:
-                return
-            self.snap_list_fetched = True
-            self.pending_info_snaps = snap_list
-            log.debug("fetched list of %s snaps", len(self.pending_info_snaps))
-            self._fetch_next_info()
-        self.ongoing[None] = [cb]
-        self.run_in_bg(self._bg_fetch_list, self._fetched_list)
-
-    def stop(self):
-        self._running = False
-
-    def _bg_fetch_list(self):
-        return self.connection.get('v2/find', section=self.store_section)
-
-    def _fetched_list(self, fut):
-        if not self._running:
-            return
+    async def _start(self):
+        self.ongoing[None] = []
         try:
-            response = fut.result()
+            response = await self.app.run_in_thread(
+                partial(
+                    self.connection.get,
+                    'v2/find',
+                    section=self.store_section))
             response.raise_for_status()
         except requests.exceptions.RequestException:
             log.exception("loading list of snaps failed")
             self.failed = True
             self._running = False
-        else:
-            self.model.load_find_data(response.json())
+            return
+        if not self._running:
+            return
+        self.model.load_find_data(response.json())
+        self.snap_list_fetched = True
+        self.pending_snaps = self.model.get_snap_list()
+        log.debug("fetched list of %s snaps", len(self.model.get_snap_list()))
         for cb in self.ongoing.pop(None):
-            cb(self.model.get_snap_list())
+            cb()
+        while self.pending_snaps and self._running:
+            snap = self.pending_snaps.pop(0)
+            self.ongoing[snap] = []
+            await self._fetch_info_for_snap(snap)
+
+    def stop(self):
+        self._running = False
+
+    async def _fetch_info_for_snap(self, snap):
+        log.debug('starting fetch for %s', snap.name)
+        try:
+            response = await self.app.run_in_thread(
+                partial(
+                    self.connection.get,
+                    'v2/find',
+                    name=snap.name))
+            response.raise_for_status()
+        except requests.exceptions.RequestException:
+            log.exception("loading snap info failed")
+            # XXX something better here?
+            return
+        if not self._running:
+            return
+        data = response.json()
+        log.debug('got data for %s', snap.name)
+        self.model.load_info_data(data)
+        for cb in self.ongoing.pop(snap):
+            cb()
 
     def get_snap_list(self, callback):
         if self.snap_list_fetched:
-            callback(self.model.get_snap_list())
+            callback()
         elif None in self.ongoing:
             self.ongoing[None].append(callback)
         else:
@@ -89,43 +111,13 @@ class SnapdSnapInfoLoader:
         if len(snap.channels) > 0:
             callback()
             return
-        if snap in self.ongoing:
-            self.ongoing[snap].append(callback)
-            return
-        if snap in self.pending_info_snaps:
-            self.pending_info_snaps.remove(snap)
-        self._fetch_info_for_snap(snap, callback)
-
-    def _fetch_info_for_snap(self, snap, callback):
-        self.ongoing[snap] = [callback]
-        log.debug('starting fetch for %s', snap.name)
-        self.run_in_bg(
-            lambda: self._bg_fetch_next_info(snap),
-            lambda fut: self._fetched_info(snap, fut))
-
-    def _fetch_next_info(self):
-        if not self.pending_info_snaps:
-            return
-        snap = self.pending_info_snaps.pop(0)
-        self._fetch_info_for_snap(snap, self._fetch_next_info)
-
-    def _bg_fetch_next_info(self, snap):
-        return self.connection.get('v2/find', name=snap.name)
-
-    def _fetched_info(self, snap, fut):
-        if not self._running:
-            return
-        try:
-            response = fut.result()
-            response.raise_for_status()
-        except requests.exceptions.RequestException:
-            log.exception("loading snap info failed")
-            # XXX something better here?
-        else:
-            data = response.json()
-            self.model.load_info_data(data)
-        for cb in self.ongoing.pop(snap):
-            cb()
+        if snap not in self.ongoing:
+            if snap in self.pending_snaps:
+                self.pending_snaps.remove(snap)
+            self.ongoing[snap] = []
+            self.app.schedule_task(
+                self._fetch_info_for_snap(snap))
+        self.ongoing[snap].append(callback)
 
 
 class SnapListController(BaseController):
@@ -136,7 +128,7 @@ class SnapListController(BaseController):
 
     def _make_loader(self):
         return SnapdSnapInfoLoader(
-            self.model, self.run_in_bg, self.app.snapd_connection,
+            self.model, self.app, self.app.snapd_connection,
             self.opts.snap_section)
 
     def __init__(self, app):

--- a/subiquity/core.py
+++ b/subiquity/core.py
@@ -13,7 +13,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import asyncio
 import logging
 import os
 import platform
@@ -176,14 +175,6 @@ class Subiquity(Application):
 
     def note_data_for_apport(self, key, value):
         self._apport_data.append((key, value))
-
-    def schedule_task(self, coro):
-        loop = asyncio.get_event_loop()
-        loop.call_soon(asyncio.create_task, coro)
-
-    async def run_in_thread(self, func, *args):
-        loop = asyncio.get_event_loop()
-        return await loop.run_in_executor(None, func, *args)
 
     def make_apport_report(self, kind, thing, *, interrupt, wait=False, **kw):
         log.debug("generating crash report")

--- a/subiquity/core.py
+++ b/subiquity/core.py
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import asyncio
 import logging
 import os
 import platform
@@ -175,6 +176,14 @@ class Subiquity(Application):
 
     def note_data_for_apport(self, key, value):
         self._apport_data.append((key, value))
+
+    def schedule_task(self, coro):
+        loop = asyncio.get_event_loop()
+        loop.call_soon(asyncio.create_task, coro)
+
+    async def run_in_thread(self, func, *args):
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(None, func, *args)
 
     def make_apport_report(self, kind, thing, *, interrupt, wait=False, **kw):
         log.debug("generating crash report")

--- a/subiquity/core.py
+++ b/subiquity/core.py
@@ -29,6 +29,7 @@ from subiquity.controllers.error import (
     )
 from subiquity.models.subiquity import SubiquityModel
 from subiquity.snapd import (
+    AsyncSnapd,
     FakeSnapdConnection,
     SnapdConnection,
     )
@@ -98,7 +99,7 @@ class Subiquity(Application):
                     "examples", "snaps"))
         else:
             connection = SnapdConnection(self.root, self.snapd_socket_path)
-        self.snapd_connection = connection
+        self.snapd = AsyncSnapd(connection)
         self.signal.connect_signals([
             ('network-proxy-set', self._proxy_set),
             ('network-change', self._network_change),
@@ -129,7 +130,7 @@ class Subiquity(Application):
 
     def _proxy_set(self):
         self.run_in_bg(
-            lambda: self.snapd_connection.configure_proxy(
+            lambda: self.snapd.connection.configure_proxy(
                 self.base_model.proxy),
             lambda fut: (
                 fut.result(), self.signal.emit_signal('snapd-network-change')),

--- a/subiquity/models/keyboard.py
+++ b/subiquity/models/keyboard.py
@@ -1,5 +1,4 @@
 
-import asyncio
 from collections import defaultdict
 import logging
 import os
@@ -7,7 +6,7 @@ import re
 
 import attr
 
-from subiquitycore.utils import run_command
+from subiquitycore.utils import arun_command
 
 log = logging.getLogger("subiquity.models.keyboard")
 
@@ -207,14 +206,12 @@ class KeyboardModel:
         if setting != self.setting:
             self.setting = setting
             if self.root == '/':
-                run_command([
+                await arun_command([
                     'setupcon', '--save', '--force', '--keyboard-only'])
-                run_command(['/snap/bin/subiquity.subiquity-loadkeys'])
+                await arun_command(['/snap/bin/subiquity.subiquity-loadkeys'])
             else:
                 scale = os.environ.get('SUBIQUITY_REPLAY_TIMESCALE', "1")
-                p = await asyncio.create_subprocess_exec(
-                    'sleep', str(1/float(scale)))
-                await p.communicate()
+                await arun_command(['sleep', str(1/float(scale))])
 
     def render(self):
         return {

--- a/subiquity/models/keyboard.py
+++ b/subiquity/models/keyboard.py
@@ -1,4 +1,5 @@
 
+import asyncio
 from collections import defaultdict
 import logging
 import os
@@ -198,7 +199,7 @@ class KeyboardModel:
         else:
             return self.layouts.get(code, '?'), None
 
-    def set_keyboard(self, setting):
+    async def set_keyboard(self, setting):
         path = self.config_path
         os.makedirs(os.path.dirname(path), exist_ok=True)
         with open(path, 'w') as fp:
@@ -211,7 +212,9 @@ class KeyboardModel:
                 run_command(['/snap/bin/subiquity.subiquity-loadkeys'])
             else:
                 scale = os.environ.get('SUBIQUITY_REPLAY_TIMESCALE', "1")
-                run_command(['sleep', str(1/float(scale))])
+                p = await asyncio.create_subprocess_exec(
+                    'sleep', str(1/float(scale)))
+                await p.communicate()
 
     def render(self):
         return {

--- a/subiquity/ui/views/snaplist.py
+++ b/subiquity/ui/views/snaplist.py
@@ -375,11 +375,12 @@ class SnapListView(BaseView):
         spinner = None
         called = False
 
-        def callback(snap_list):
+        def callback():
             nonlocal called
             called = True
             if spinner is not None:
                 spinner.stop()
+            snap_list = self.model.get_snap_list()
             if len(snap_list) == 0:
                 self.offer_retry()
             else:

--- a/subiquitycore/core.py
+++ b/subiquitycore/core.py
@@ -610,7 +610,8 @@ class Application:
             self.ui, palette=self.color_palette, screen=screen,
             handle_mouse=False, pop_ups=True,
             input_filter=self.input_filter.filter,
-            unhandled_input=self.unhandled_input)
+            unhandled_input=self.unhandled_input,
+            event_loop=urwid.AsyncioEventLoop())
 
         if self.opts.ascii:
             urwid.util.set_encoding('ascii')


### PR DESCRIPTION
The thought of implementing autoinstall stuff with our existing concurrency APIs just seemed too painful so I tried moving to first trio (which is neat but requires quite a new Python and isn't packaged for bionic) and then asyncio. There are many more things that could be switched to asyncio but this is enough to prove to my own satisfaction that it's worth it.