### PR TITLE
remove last-screen file before restarting subiquity

### DIFF
--- a/subiquity/ui/views/error.py
+++ b/subiquity/ui/views/error.py
@@ -244,7 +244,6 @@ class ErrorReportStretchy(Stretchy):
         self.app.debug_shell()
 
     def restart(self, sender):
-        # Should unmount and delete /target.
         # We rely on systemd restarting us.
         self.app.exit()
 

--- a/subiquitycore/core.py
+++ b/subiquitycore/core.py
@@ -465,6 +465,9 @@ class Application:
 # EventLoop -------------------------------------------------------------------
 
     def exit(self):
+        state_path = os.path.join(self.state_dir, 'last-screen')
+        if os.path.exists(state_path):
+            os.unlink(state_path)
         raise urwid.ExitMainLoop()
 
     def run_scripts(self, scripts):


### PR DESCRIPTION
this fixes a crash loop when the users updates the subiquity snap
then hits an install failure and selects restart