### PR TITLE
Unbreak console-conf in UC20 images

### DIFF
--- a/console_conf/cmd/tui.py
+++ b/console_conf/cmd/tui.py
@@ -38,6 +38,9 @@ def parse_options(argv):
     parser.add_argument('--serial', action='store_true',
                         dest='run_on_serial',
                         help='Run the installer over serial console.')
+    parser.add_argument('--ascii', action='store_true',
+                        dest='ascii',
+                        help='Run the installer in ascii mode.')
     parser.add_argument('--machine-config', metavar='CONFIG',
                         dest='machine_config',
                         help="Don't Probe. Use probe data file")

--- a/subiquitycore/prober.py
+++ b/subiquitycore/prober.py
@@ -20,7 +20,6 @@ from probert.network import (
     StoredDataObserver,
     UdevObserver,
     )
-from probert.storage import Storage
 
 log = logging.getLogger('subiquitycore.prober')
 
@@ -49,4 +48,5 @@ class Prober():
                     if k not in probe_types:
                         r[k] = {}
             return r
+        from probert.storage import Storage
         return Storage().probe(probe_types=probe_types)


### PR DESCRIPTION
storage is not required in consoleconf, and is not installed, ensure we don't import it.

ascii argument is required.