### PR TITLE
stop block probing failures from crashing the process

### DIFF
--- a/subiquity/controllers/filesystem.py
+++ b/subiquity/controllers/filesystem.py
@@ -73,7 +73,8 @@ class FilesystemController(BaseController):
         self.answers.setdefault('manual', [])
         self._monitor = None
         self._crash_reports = {}
-        self._probe_once_task = SingleInstanceTask(self._probe_once)
+        self._probe_once_task = SingleInstanceTask(
+            self._probe_once, propagate_errors=False)
         self._probe_task = SingleInstanceTask(self._probe)
 
     async def _probe_once(self, restricted):


### PR DESCRIPTION
There is a common problem in concurrent / asynchronous code of what to
do with unhandled exceptions. If a (conceptual) thread of execution
fails, there's no guarantee (and no way of telling) if there's anything
listening.  By default, I chose to have a failing task propagate the
exception up to the run loop for two reasons:

 1) Unhandled exceptions are generally bad
 2) urwid.ExitMainLoop needs to be propagated to the run loop to have
    any effect

But this means that tasks that are expected to fail (and have this
failure handled) like block probing crash the process, which is
obviously a Bad Thing. This branch adds a way to turn off exception
propagation per-task, which is a bit hackish but works ok it seems.