### PR TITLE
stop some pointless use of urwid signals

### DIFF
--- a/console_conf/controllers/identity.py
+++ b/console_conf/controllers/identity.py
@@ -246,7 +246,7 @@ class IdentityController(BaseController):
     def cancel(self):
         # You can only go back if we haven't created a user yet.
         if self.model.user is None:
-            self.signal.emit_signal('prev-screen')
+            self.app.prev_screen()
 
     def login(self):
         title = "Configuration Complete"

--- a/console_conf/controllers/identity.py
+++ b/console_conf/controllers/identity.py
@@ -264,4 +264,4 @@ class IdentityController(BaseController):
             # current process).
             disable_console_conf()
 
-        self.signal.emit_signal('quit')
+        self.app.exit()

--- a/console_conf/controllers/welcome.py
+++ b/console_conf/controllers/welcome.py
@@ -25,7 +25,7 @@ class WelcomeController(BaseController):
         self.ui.set_body(view)
 
     def done(self):
-        self.signal.emit_signal('next-screen')
+        self.app.next_screen()
 
     def cancel(self):
         # Can't go back from here!

--- a/subiquity/controllers/filesystem.py
+++ b/subiquity/controllers/filesystem.py
@@ -313,14 +313,14 @@ class FilesystemController(BaseController):
         self.manual()
 
     def cancel(self):
-        self.signal.emit_signal('prev-screen')
+        self.app.prev_screen()
 
     def finish(self):
-        log.debug("FilesystemController.finish next-screen")
+        log.debug("FilesystemController.finish next_screen")
         # start curtin install in background
         self.signal.emit_signal('installprogress:filesystem-config-done')
         # switch to next screen
-        self.signal.emit_signal('next-screen')
+        self.app.next_screen()
 
     def create_mount(self, fs, spec):
         if spec.get('mount') is None:

--- a/subiquity/controllers/identity.py
+++ b/subiquity/controllers/identity.py
@@ -41,14 +41,14 @@ class IdentityController(BaseController):
             self.done(d)
 
     def cancel(self):
-        self.signal.emit_signal('prev-screen')
+        self.app.prev_screen()
 
     def done(self, user_spec):
         safe_spec = user_spec.copy()
         safe_spec['password'] = '<REDACTED>'
         log.debug(
-            "IdentityController.done next-screen user_spec=%s",
+            "IdentityController.done next_screen user_spec=%s",
             safe_spec)
         self.model.add_user(user_spec)
         self.signal.emit_signal('installprogress:identity-config-done')
-        self.signal.emit_signal('next-screen')
+        self.app.next_screen()

--- a/subiquity/controllers/installprogress.py
+++ b/subiquity/controllers/installprogress.py
@@ -407,7 +407,7 @@ class InstallProgressController(BaseController):
     def reboot(self):
         if self.opts.dry_run:
             log.debug('dry-run enabled, skipping reboot, quitting instead')
-            self.signal.emit_signal('quit')
+            self.app.exit()
         else:
             # TODO Possibly run this earlier, to show a warning; or
             # switch to shutdown if chreipl fails

--- a/subiquity/controllers/keyboard.py
+++ b/subiquity/controllers/keyboard.py
@@ -55,11 +55,11 @@ class KeyboardController(BaseController):
 
     async def apply_settings(self, setting):
         await self.model.set_keyboard(setting)
-        log.debug("KeyboardController next-screen")
-        self.signal.emit_signal('next-screen')
+        log.debug("KeyboardController next_screen")
+        self.app.next_screen()
 
     def done(self, setting):
         schedule_task(self.apply_settings(setting))
 
     def cancel(self):
-        self.signal.emit_signal('prev-screen')
+        self.app.prev_screen()

--- a/subiquity/controllers/mirror.py
+++ b/subiquity/controllers/mirror.py
@@ -93,7 +93,7 @@ class MirrorController(BaseController):
             self.done(self.model.mirror)
 
     def cancel(self):
-        self.signal.emit_signal('prev-screen')
+        self.app.prev_screen()
 
     def serialize(self):
         return self.model.mirror
@@ -102,7 +102,7 @@ class MirrorController(BaseController):
         self.model.mirror = data
 
     def done(self, mirror):
-        log.debug("MirrorController.done next-screen mirror=%s", mirror)
+        log.debug("MirrorController.done next_screen mirror=%s", mirror)
         if mirror != self.model.mirror:
             self.model.mirror = mirror
-        self.signal.emit_signal('next-screen')
+        self.app.next_screen()

--- a/subiquity/controllers/proxy.py
+++ b/subiquity/controllers/proxy.py
@@ -35,7 +35,7 @@ class ProxyController(BaseController):
             self.done(self.answers['proxy'])
 
     def cancel(self):
-        self.signal.emit_signal('prev-screen')
+        self.app.prev_screen()
 
     def serialize(self):
         return self.model.proxy
@@ -44,9 +44,9 @@ class ProxyController(BaseController):
         self.model.proxy = data
 
     def done(self, proxy):
-        log.debug("ProxyController.done next-screen proxy=%s", proxy)
+        log.debug("ProxyController.done next_screen proxy=%s", proxy)
         if proxy != self.model.proxy:
             self.model.proxy = proxy
             os.environ['http_proxy'] = os.environ['https_proxy'] = proxy
             self.signal.emit_signal('network-proxy-set')
-        self.signal.emit_signal('next-screen')
+        self.app.next_screen()

--- a/subiquity/controllers/refresh.py
+++ b/subiquity/controllers/refresh.py
@@ -235,8 +235,8 @@ class RefreshController(BaseController):
             raise Skip()
 
     def done(self, sender=None):
-        log.debug("RefreshController.done next-screen")
-        self.signal.emit_signal('next-screen')
+        log.debug("RefreshController.done next_screen")
+        self.app.next_screen()
 
     def cancel(self, sender=None):
-        self.signal.emit_signal('prev-screen')
+        self.app.prev_screen()

--- a/subiquity/controllers/snaplist.py
+++ b/subiquity/controllers/snaplist.py
@@ -161,11 +161,11 @@ class SnapListController(BaseController):
 
     def done(self, snaps_to_install):
         log.debug(
-            "SnapListController.done next-screen snaps_to_install=%s",
+            "SnapListController.done next_screen snaps_to_install=%s",
             snaps_to_install)
         self.model.set_installed_list(snaps_to_install)
         self.signal.emit_signal("installprogress:snap-config-done")
-        self.signal.emit_signal("next-screen")
+        self.app.next_screen()
 
     def cancel(self, sender=None):
-        self.signal.emit_signal("prev-screen")
+        self.app.prev_screen()

--- a/subiquity/controllers/ssh.py
+++ b/subiquity/controllers/ssh.py
@@ -58,7 +58,7 @@ class SSHController(BaseController):
             self.fetch_ssh_keys(d)
 
     def cancel(self):
-        self.signal.emit_signal('prev-screen')
+        self.app.prev_screen()
 
     def _fetch_cancel(self):
         if self._fetch_task is None:
@@ -111,10 +111,10 @@ class SSHController(BaseController):
         self._fetch_task = schedule_task(self._fetch_ssh_keys(user_spec))
 
     def done(self, result):
-        log.debug("SSHController.done next-screen result=%s", result)
+        log.debug("SSHController.done next_screen result=%s", result)
         self.model.install_server = result['install_server']
         self.model.authorized_keys = result.get('authorized_keys', [])
         self.model.pwauth = result.get('pwauth', True)
         self.model.ssh_import_id = result.get('ssh_import_id', None)
         self.signal.emit_signal('installprogress:ssh-config-done')
-        self.signal.emit_signal('next-screen')
+        self.app.next_screen()

--- a/subiquity/controllers/welcome.py
+++ b/subiquity/controllers/welcome.py
@@ -45,10 +45,10 @@ class WelcomeController(BaseController):
             self.done(self.answers['lang'])
 
     def done(self, code):
-        log.debug("WelcomeController.done %s next-screen", code)
+        log.debug("WelcomeController.done %s next_screen", code)
         self.signal.emit_signal('l10n:language-selected', code)
         self.model.switch_language(code)
-        self.signal.emit_signal('next-screen')
+        self.app.next_screen()
 
     def cancel(self):
         # Can't go back from here!

--- a/subiquity/controllers/zdev.py
+++ b/subiquity/controllers/zdev.py
@@ -646,11 +646,11 @@ class ZdevController(BaseController):
         self.ui.set_body(ZdevView(self))
 
     def cancel(self):
-        self.signal.emit_signal('prev-screen')
+        self.app.prev_screen()
 
     def done(self):
         # switch to next screen
-        self.signal.emit_signal('next-screen')
+        self.app.next_screen()
 
     def chzdev(self, action, zdevinfo):
         if self.opts.dry_run:

--- a/subiquitycore/controllers/network.py
+++ b/subiquitycore/controllers/network.py
@@ -194,13 +194,13 @@ class NetworkController(BaseController):
         self.observer.trigger_scan(dev.ifindex)
 
     def done(self):
-        log.debug("NetworkController.done next-screen")
+        log.debug("NetworkController.done next_screen")
         self.model.has_network = bool(
             self.network_event_receiver.default_routes)
-        self.signal.emit_signal('next-screen')
+        self.app.next_screen()
 
     def cancel(self):
-        self.signal.emit_signal('prev-screen')
+        self.app.prev_screen()
 
     def _action_get(self, id):
         dev_spec = id[0].split()

--- a/subiquitycore/core.py
+++ b/subiquitycore/core.py
@@ -413,13 +413,6 @@ class Application:
 
     def _connect_base_signals(self):
         """Connect signals used in the core controller."""
-        signals = [
-            ('quit', self.exit),
-            ]
-        if self.opts.dry_run:
-            signals.append(('control-x-quit', self.exit))
-        self.signal.connect_signals(signals)
-
         # Registers signals from each controller
         for controller in self.controllers.instances:
             controller.register_signals()
@@ -552,8 +545,8 @@ class Application:
         self.loop.screen.clear()
 
     def unhandled_input(self, key):
-        if key == 'ctrl x':
-            self.signal.emit_signal('control-x-quit')
+        if self.opts.dry_run and key == 'ctrl x':
+            self.exit()
         elif key == 'f3':
             self.loop.screen.clear()
         elif key in ['ctrl t', 'f4']:

--- a/subiquitycore/core.py
+++ b/subiquitycore/core.py
@@ -330,7 +330,7 @@ class Application:
     #         "Identity",
     #         "InstallProgress",
     # ]
-    # The 'next-screen' and 'prev-screen' signals move through the list of
+    # The 'next_screen' and 'prev-screen' methods move through the list of
     # controllers in order, calling the start_ui method on the controller
     # instance.
 
@@ -415,8 +415,6 @@ class Application:
         """Connect signals used in the core controller."""
         signals = [
             ('quit', self.exit),
-            ('next-screen', self.next_screen),
-            ('prev-screen', self.prev_screen),
             ]
         if self.opts.dry_run:
             signals.append(('control-x-quit', self.exit))


### PR DESCRIPTION
Signals only make sense when you don't always know who the listener is. For next-screen/prev-screen/quit it's always the app.