### PR TITLE
add helper to avoid SingleInstanceTask clients caring about cancellation

### DIFF
--- a/subiquity/controllers/filesystem.py
+++ b/subiquity/controllers/filesystem.py
@@ -108,6 +108,9 @@ class FilesystemController(BaseController):
                     desc = "restricted={}".format(restricted)
                     with context.child("probe_once", desc):
                         await self._probe_once_task.start(restricted)
+                        # We wait on the task directly here, not
+                        # self._probe_once_task.wait as if _probe_once_task
+                        # gets cancelled, we should be cancelled too.
                         await asyncio.wait_for(self._probe_once_task.task, 5.0)
                 except Exception:
                     block_discover_log.exception(
@@ -166,7 +169,7 @@ class FilesystemController(BaseController):
 
     async def _wait_for_probing(self):
         await self._start_task
-        await self._probe_task.task
+        await self._probe_task.wait()
         if isinstance(self.ui.body, SlowProbing):
             self.start_ui()
 

--- a/subiquity/controllers/mirror.py
+++ b/subiquity/controllers/mirror.py
@@ -20,7 +20,7 @@ from xml.etree import ElementTree
 
 from subiquitycore.async_helpers import (
     run_in_thread,
-    schedule_task,
+    SingleInstanceTask,
     )
 from subiquitycore.controller import BaseController
 
@@ -49,11 +49,12 @@ class MirrorController(BaseController):
         if 'country-code' in self.answers:
             self.check_state = CheckState.DONE
             self.model.set_country(self.answers['country-code'])
+        self.lookup_task = SingleInstanceTask(self.lookup)
 
     def snapd_network_changed(self):
         if self.check_state != CheckState.DONE:
             self.check_state = CheckState.CHECKING
-            schedule_task(self.lookup())
+            self.lookup_task.start_sync()
 
     async def lookup(self):
         with self.context.child("lookup"):

--- a/subiquity/ui/views/refresh.py
+++ b/subiquity/ui/views/refresh.py
@@ -163,18 +163,11 @@ class RefreshView(BaseView):
         schedule_task(self._wait_check_result())
 
     async def _wait_check_result(self):
-        while True:
-            try:
-                check_state = await self.controller.check_task.task
-            except asyncio.CancelledError:
-                # If the task was cancelled, another will have been
-                # started.
-                continue
-            except Exception as e:
-                self.check_state_failed(e)
-                return
-            else:
-                break
+        try:
+            check_state = await self.controller.check_task.wait()
+        except Exception as e:
+            self.check_state_failed(e)
+            return
         if check_state == CheckState.AVAILABLE:
             self.check_state_available()
         else:

--- a/subiquitycore/async_helpers.py
+++ b/subiquitycore/async_helpers.py
@@ -72,3 +72,10 @@ class SingleInstanceTask:
         else:
             self.task = coro
         return schedule_task(self._start(old))
+
+    async def wait(self):
+        while True:
+            try:
+                return await self.task
+            except asyncio.CancelledError:
+                pass


### PR DESCRIPTION
I think this will fix an observed failure mode where block probing is endlessly cancelled.