### PR TITLE
refactor how subiquity is exited after install

### DIFF
--- a/subiquity/core.py
+++ b/subiquity/core.py
@@ -26,6 +26,7 @@ from subiquitycore.async_helpers import (
     schedule_task,
     )
 from subiquitycore.core import Application
+from subiquitycore.utils import run_command
 
 from subiquity.controllers.error import (
     ErrorReportKind,
@@ -113,6 +114,14 @@ class Subiquity(Application):
         self._apport_files = []
         self.note_data_for_apport("SnapUpdated", str(self.updated))
         self.note_data_for_apport("UsingAnswers", str(bool(self.answers)))
+
+        self.reboot_on_exit = False
+
+    def exit(self):
+        if self.reboot_on_exit and not self.opts.dry_run:
+            run_command(["/sbin/reboot"])
+        else:
+            super().exit()
 
     def run(self):
         try:

--- a/subiquitycore/core.py
+++ b/subiquitycore/core.py
@@ -440,9 +440,13 @@ class Application:
         if old is not None:
             old.context.exit("completed")
             old.end_ui()
+        cur_index = self.controllers.index
         while True:
             self.controllers.index += increment
-            if self.controllers.out_of_bounds():
+            if self.controllers.index < 0:
+                self.controllers.index = cur_index
+                return
+            if self.controllers.index >= len(self.controllers.instances):
                 self.exit()
             new = self.controllers.cur
             try:
@@ -480,7 +484,7 @@ class Application:
         state_path = os.path.join(self.state_dir, 'last-screen')
         if os.path.exists(state_path):
             os.unlink(state_path)
-        raise urwid.ExitMainLoop()
+        self.aio_loop.stop()
 
     def run_scripts(self, scripts):
         # run_scripts runs (or rather arranges to run, it's all async)


### PR DESCRIPTION
if we want to do things after install has completed (e.g.: run late
commands), we can't have the code that runs the install invoking
/sbin/reboot directly.