### PR TITLE
autoinstall!

### DIFF
--- a/examples/autoinstall-interactive.yaml
+++ b/examples/autoinstall-interactive.yaml
@@ -1,0 +1,3 @@
+version: 1
+interactive-sections:
+        - keyboard

--- a/examples/autoinstall.yaml
+++ b/examples/autoinstall.yaml
@@ -3,6 +3,10 @@ early-commands:
         - echo a
         - sleep 1
         - echo a
+late-commands:
+        - echo a
+        - sleep 1
+        - echo a
 keyboard:
         layout: gb
 identity:

--- a/examples/autoinstall.yaml
+++ b/examples/autoinstall.yaml
@@ -1,0 +1,12 @@
+version: 1
+early-commands:
+        - echo a
+        - sleep 1
+        - echo a
+keyboard:
+        layout: gb
+identity:
+        realname: ''
+        username: ubuntu
+        password: '$6$wdAcoXrU039hKYPd$508Qvbe7ObUnxoj15DRCkzC3qO7edjH0VV7BPNRDYK4QR8ofJaEEF2heacn0QgD.f8pO8SNp83XNdWG6tocBM1'
+        hostname: ubuntu

--- a/subiquity/autoinstall.py
+++ b/subiquity/autoinstall.py
@@ -1,0 +1,28 @@
+# Copyright 2019 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import yaml
+
+from curtin.config import merge_config
+
+
+def merge_autoinstall_configs(source_paths, target_path):
+    config = {}
+    for path in source_paths:
+        with open(path) as fp:
+            c = yaml.safe_load(fp)
+        merge_config(config, c)
+    with open(target_path, 'w') as fp:
+        yaml.dump(config, fp)

--- a/subiquity/cmd/tui.py
+++ b/subiquity/cmd/tui.py
@@ -31,6 +31,13 @@ class ClickAction(argparse.Action):
         namespace.scripts.append("c(" + repr(values) + ")")
 
 
+AUTO_INSTALL_LOCATIONS = (
+    "/run/initrd-autoinstall.yaml",
+    "/autoinstall.yaml",
+    "/autoinstall/autoinstall.yaml",
+    )
+
+
 def parse_options(argv):
     parser = argparse.ArgumentParser(
         description='SUbiquity - Ubiquity for Servers',
@@ -39,7 +46,9 @@ def parse_options(argv):
         ascii_default = os.ttyname(0) == "/dev/ttysclp0"
     except OSError:
         ascii_default = False
-    parser.set_defaults(ascii=ascii_default)
+    autoinstall_files = [
+        p for p in AUTO_INSTALL_LOCATIONS if os.path.exists(p)]
+    parser.set_defaults(ascii=ascii_default, autoinstall=autoinstall_files)
     parser.add_argument('--dry-run', action='store_true',
                         dest='dry_run',
                         help='menu-only, do not call installer function')
@@ -67,6 +76,7 @@ def parse_options(argv):
     parser.add_argument('--click', metavar="PAT", action=ClickAction,
                         help='Synthesize a click on a button matching PAT')
     parser.add_argument('--answers')
+    parser.add_argument('--autoinstall', action='append')
     parser.add_argument('--source', default=[], action='append',
                         dest='sources', metavar='URL',
                         help='install from url instead of default.')

--- a/subiquity/controller.py
+++ b/subiquity/controller.py
@@ -26,8 +26,35 @@ log = logging.getLogger("subiquity.controller")
 
 class SubiquityController(BaseController):
 
-    def deserialize(self, state):
-        self.configured()
+    autoinstall_key = None
+    autoinstall_default = None
+
+    def __init__(self, app):
+        super().__init__(app)
+        self.autoinstall_applied = False
+        if app.autoinstall_config:
+            self.load_autoinstall_data(
+                app.autoinstall_config.get(
+                    self.autoinstall_key,
+                    self.autoinstall_default))
+
+    def load_autoinstall_data(self, data):
+        """Load autoinstall data.
+
+        This is called if there is an autoinstall happening. This
+        controller may not have any data, and this controller may still
+        be interactive.
+        """
+        pass
+
+    async def apply_autoinstall_config(self):
+        """Apply autoinstall configuration.
+
+        This is only called for a non-interactive controller. It should
+        block until the configuration has been applied. (self.configured()
+        is called after this is done).
+        """
+        pass
 
     def interactive(self):
         if not self.app.autoinstall_config:
@@ -44,6 +71,9 @@ class SubiquityController(BaseController):
         if self.model_name is not None:
             self.app.base_model.configured(self.model_name)
 
+    def deserialize(self, state):
+        self.configured()
+
 
 class NoUIController(SubiquityController):
 
@@ -58,6 +88,16 @@ class NoUIController(SubiquityController):
 
 
 class RepeatedController(RepeatedController):
+
+    def __init__(self, orig, index):
+        super().__init__(orig, index)
+        self.autoinstall_applied = False
+
+    async def apply_autoinstall_config(self):
+        await self.orig.apply_autoinstall_config(self.index)
+
+    def configured(self):
+        self.orig.configured()
 
     def interactive(self):
         return self.orig.interactive()

--- a/subiquity/controller.py
+++ b/subiquity/controller.py
@@ -29,6 +29,15 @@ class SubiquityController(BaseController):
     def deserialize(self, state):
         self.configured()
 
+    def interactive(self):
+        if not self.app.autoinstall_config:
+            return True
+        i_sections = self.app.autoinstall_config.get(
+            'interactive-sections', [])
+        if '*' in i_sections or self.autoinstall_key in i_sections:
+            return True
+        return False
+
     def configured(self):
         """Let the world know that this controller's model is now configured.
         """
@@ -44,7 +53,11 @@ class NoUIController(SubiquityController):
     def cancel(self):
         pass
 
+    def interactive(self):
+        return False
+
 
 class RepeatedController(RepeatedController):
 
-    pass
+    def interactive(self):
+        return self.orig.interactive()

--- a/subiquity/controllers/__init__.py
+++ b/subiquity/controllers/__init__.py
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from .cmdlist import EarlyController, LateController
 from .error import ErrorController
 from .filesystem import FilesystemController
 from .identity import IdentityController
@@ -29,11 +30,13 @@ from .ssh import SSHController
 from .welcome import WelcomeController
 from .zdev import ZdevController
 __all__ = [
+    'EarlyController',
     'ErrorController',
     'FilesystemController',
     'IdentityController',
     'InstallProgressController',
     'KeyboardController',
+    'LateController',
     'ProxyController',
     'MirrorController',
     'NetworkController',

--- a/subiquity/controllers/cmdlist.py
+++ b/subiquity/controllers/cmdlist.py
@@ -1,0 +1,43 @@
+# Copyright 2019 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import asyncio
+
+from subiquity.controller import NoUIController
+
+
+class CmdListController(NoUIController):
+
+    autoinstall_default = []
+    cmds = ()
+
+    def load_autoinstall_data(self, data):
+        self.cmds = data
+
+    async def run(self):
+        for i, cmd in enumerate(self.cmds):
+            with self.context.child("command_{}".format(i), cmd):
+                proc = await asyncio.create_subprocess_shell(cmd)
+                await proc.communicate()
+
+
+class EarlyController(CmdListController):
+
+    autoinstall_key = 'early-commands'
+
+
+class LateController(CmdListController):
+
+    autoinstall_key = 'late-commands'

--- a/subiquity/controllers/filesystem.py
+++ b/subiquity/controllers/filesystem.py
@@ -62,6 +62,7 @@ UEFI_GRUB_SIZE_BYTES = 512 * 1024 * 1024  # 512MiB EFI partition
 
 class FilesystemController(SubiquityController):
 
+    autoinstall_key = "storage"
     model_name = "filesystem"
 
     def __init__(self, app):

--- a/subiquity/controllers/identity.py
+++ b/subiquity/controllers/identity.py
@@ -25,6 +25,14 @@ class IdentityController(SubiquityController):
 
     autoinstall_key = model_name = "identity"
 
+    def load_autoinstall_data(self, data):
+        if data is not None:
+            self.model.add_user(data)
+
+    async def apply_autoinstall_config(self):
+        if not self.model.user:
+            raise Exception("no identity data provided")
+
     def start_ui(self):
         self.ui.set_body(IdentityView(self.model, self))
         if all(elem in self.answers for elem in

--- a/subiquity/controllers/identity.py
+++ b/subiquity/controllers/identity.py
@@ -23,7 +23,7 @@ log = logging.getLogger('subiquity.controllers.identity')
 
 class IdentityController(SubiquityController):
 
-    model_name = "identity"
+    autoinstall_key = model_name = "identity"
 
     def start_ui(self):
         self.ui.set_body(IdentityView(self.model, self))

--- a/subiquity/controllers/installprogress.py
+++ b/subiquity/controllers/installprogress.py
@@ -120,6 +120,7 @@ class InstallProgressController(SubiquityController):
 
     async def apply_autoinstall_config(self):
         await self.install_task
+        self.app.reboot_on_exit = True
 
     def tpath(self, *path):
         return os.path.join(self.model.target, *path)

--- a/subiquity/controllers/installprogress.py
+++ b/subiquity/controllers/installprogress.py
@@ -118,6 +118,9 @@ class InstallProgressController(SubiquityController):
     def start(self):
         self.install_task = schedule_task(self.install(self.context))
 
+    async def apply_autoinstall_config(self):
+        await self.install_task
+
     def tpath(self, *path):
         return os.path.join(self.model.target, *path)
 
@@ -297,6 +300,8 @@ class InstallProgressController(SubiquityController):
             await self.copy_logs_to_target(context)
         except Exception:
             self.curtin_error()
+            if not self.interactive():
+                raise
 
     async def move_on(self):
         await asyncio.wait(

--- a/subiquity/controllers/installprogress.py
+++ b/subiquity/controllers/installprogress.py
@@ -112,6 +112,9 @@ class InstallProgressController(SubiquityController):
         self.tb_extractor = TracebackExtractor()
         self.curtin_context = None
 
+    def interactive(self):
+        return self.app.interactive()
+
     def start(self):
         self.install_task = schedule_task(self.install(self.context))
 

--- a/subiquity/controllers/keyboard.py
+++ b/subiquity/controllers/keyboard.py
@@ -26,7 +26,7 @@ log = logging.getLogger('subiquity.controllers.keyboard')
 
 class KeyboardController(SubiquityController):
 
-    model_name = "keyboard"
+    autoinstall_key = model_name = "keyboard"
     signals = [
         ('l10n:language-selected', 'language_selected'),
         ]

--- a/subiquity/controllers/keyboard.py
+++ b/subiquity/controllers/keyboard.py
@@ -31,6 +31,13 @@ class KeyboardController(SubiquityController):
         ('l10n:language-selected', 'language_selected'),
         ]
 
+    def load_autoinstall_data(self, data):
+        if data is not None:
+            self.model.setting = KeyboardSetting(**data)
+
+    async def apply_autoinstall_config(self):
+        await self.model.set_keyboard(self.model.setting)
+
     def language_selected(self, code):
         log.debug("language_selected %s", code)
         if not self.model.has_language(code):

--- a/subiquity/controllers/mirror.py
+++ b/subiquity/controllers/mirror.py
@@ -38,6 +38,7 @@ class CheckState(enum.IntEnum):
 
 class MirrorController(SubiquityController):
 
+    autoinstall_key = "apt"
     model_name = "mirror"
     signals = [
         ('snapd-network-change', 'snapd_network_changed'),

--- a/subiquity/controllers/network.py
+++ b/subiquity/controllers/network.py
@@ -20,6 +20,8 @@ from subiquity.controller import SubiquityController
 
 class NetworkController(NetworkController, SubiquityController):
 
+    autoinstall_key = "network"
+
     def done(self):
         self.configured()
         super().done()

--- a/subiquity/controllers/proxy.py
+++ b/subiquity/controllers/proxy.py
@@ -26,6 +26,21 @@ class ProxyController(SubiquityController):
 
     autoinstall_key = model_name = "proxy"
 
+    def load_autoinstall_data(self, data):
+        if data is not None:
+            self.model.proxy = data
+
+    def start(self):
+        if self.model.proxy:
+            os.environ['http_proxy'] = os.environ['https_proxy'] = \
+              self.model.proxy
+            self.signal.emit_signal('network-proxy-set')
+
+    async def apply_autoinstall_config(self):
+        # XXX want to wait until signal sent by .start() has been seen
+        # by everything; don't have a way to do that today.
+        pass
+
     def start_ui(self):
         self.ui.set_body(ProxyView(self.model, self))
         if 'proxy' in self.answers:

--- a/subiquity/controllers/proxy.py
+++ b/subiquity/controllers/proxy.py
@@ -24,7 +24,7 @@ log = logging.getLogger('subiquity.controllers.proxy')
 
 class ProxyController(SubiquityController):
 
-    model_name = "proxy"
+    autoinstall_key = model_name = "proxy"
 
     def start_ui(self):
         self.ui.set_body(ProxyView(self.model, self))

--- a/subiquity/controllers/refresh.py
+++ b/subiquity/controllers/refresh.py
@@ -44,6 +44,8 @@ class CheckState(enum.IntEnum):
 
 class RefreshController(SubiquityController):
 
+    autoinstall_key = "refresh-installer"
+
     signals = [
         ('snapd-network-change', 'snapd_network_changed'),
     ]

--- a/subiquity/controllers/refresh.py
+++ b/subiquity/controllers/refresh.py
@@ -65,6 +65,9 @@ class RefreshController(SubiquityController):
             self.check_for_update, propagate_errors=False)
         self.check_task.start_sync()
 
+    async def apply_autoinstall_config(self, index=1):
+        pass
+
     @property
     def check_state(self):
         task = self.check_task.task

--- a/subiquity/controllers/refresh.py
+++ b/subiquity/controllers/refresh.py
@@ -60,18 +60,47 @@ class RefreshController(SubiquityController):
         self.new_snap_version = ""
 
         self.offered_first_time = False
+        self.active = self.interactive()
+
+    def load_autoinstall_data(self, data):
+        if data is not None and data.get('refresh'):
+            self.active = True
 
     def start(self):
+        if not self.active:
+            return
         self.configure_task = schedule_task(self.configure_snapd())
         self.check_task = SingleInstanceTask(
             self.check_for_update, propagate_errors=False)
         self.check_task.start_sync()
 
     async def apply_autoinstall_config(self, index=1):
-        pass
+        if not self.active:
+            return
+        try:
+            await asyncio.wait_for(self.check_task.wait(), 60)
+        except asyncio.TimeoutError:
+            return
+        if self.check_state != CheckState.AVAILABLE:
+            return
+        change_id = await self.start_update()
+        while True:
+            try:
+                change = await self.controller.get_progress(change_id)
+            except requests.exceptions.RequestException as e:
+                raise e
+            if change['status'] == 'Done':
+                # Will only get here dry run mode as part of the refresh is us
+                # getting restarted by snapd...
+                return
+            if change['status'] not in ['Do', 'Doing']:
+                raise Exception("update failed")
+            await asyncio.sleep(0.1)
 
     @property
     def check_state(self):
+        if not self.active:
+            return CheckState.UNAVAILABLE
         task = self.check_task.task
         if not task.done() or task.cancelled():
             return CheckState.UNKNOWN

--- a/subiquity/controllers/reporting.py
+++ b/subiquity/controllers/reporting.py
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import copy
 import logging
 
 from curtin.reporter import (
@@ -41,19 +42,27 @@ class LogHandler(LogHandler):
 available_handlers.unregister_item('log')
 available_handlers.register_item('log', LogHandler)
 
+INITIAL_CONFIG = {'logging': {'type': 'log'}}
+NON_INTERACTIVE_CONFIG = {'builtin': {'type': 'print'}}
+
 
 class ReportingController(NoUIController):
 
     autoinstall_key = "reporting"
 
     def __init__(self, app):
+        self.config = copy.deepcopy(INITIAL_CONFIG)
         super().__init__(app)
 
+    def load_autoinstall_data(self, data):
+        if self.app.interactive():
+            return
+        self.config.update(copy.deepcopy(NON_INTERACTIVE_CONFIG))
+        if data is not None:
+            self.config.update(copy.deepcopy(data))
+
     def start(self):
-        conf = {'logging': {'type': 'log'}}
-        if not self.app.interactive():
-            conf['print'] = {'type': 'print'}
-        update_configuration(conf)
+        update_configuration(self.config)
 
     def report_start_event(self, name, description, level):
         report_start_event(name, description, level=level)

--- a/subiquity/controllers/reporting.py
+++ b/subiquity/controllers/reporting.py
@@ -44,6 +44,8 @@ available_handlers.register_item('log', LogHandler)
 
 class ReportingController(NoUIController):
 
+    autoinstall_key = "reporting"
+
     def __init__(self, app):
         super().__init__(app)
 

--- a/subiquity/controllers/reporting.py
+++ b/subiquity/controllers/reporting.py
@@ -48,7 +48,10 @@ class ReportingController(NoUIController):
         super().__init__(app)
 
     def start(self):
-        update_configuration({'logging': {'type': 'log', 'level': 'INFO'}})
+        conf = {'logging': {'type': 'log'}}
+        if not self.app.interactive():
+            conf['print'] = {'type': 'print'}
+        update_configuration(conf)
 
     def report_start_event(self, name, description, level):
         report_start_event(name, description, level=level)

--- a/subiquity/controllers/snaplist.py
+++ b/subiquity/controllers/snaplist.py
@@ -104,6 +104,7 @@ class SnapdSnapInfoLoader:
 
 class SnapListController(SubiquityController):
 
+    autoinstall_key = "snaps"
     model_name = "snaplist"
     signals = [
         ('snapd-network-change', 'snapd_network_changed'),

--- a/subiquity/controllers/snaplist.py
+++ b/subiquity/controllers/snaplist.py
@@ -119,9 +119,13 @@ class SnapListController(SubiquityController):
         super().__init__(app)
         self.loader = self._make_loader()
 
+    # XXX load_autoinstall_data / apply_autoinstall_config go here
+
     def snapd_network_changed(self):
         # If the loader managed to load the list of snaps, the
         # network must basically be working.
+        if not self.interactive():
+            return
         if self.loader.snap_list_fetched:
             return
         else:

--- a/subiquity/controllers/ssh.py
+++ b/subiquity/controllers/ssh.py
@@ -39,6 +39,15 @@ class SSHController(SubiquityController):
         super().__init__(app)
         self._fetch_task = None
 
+    def load_autoinstall_data(self, data):
+        if data is None:
+            return
+        self.model.install_server = data.get('install_server', False)
+        self.model.authorized_keys = self.autoinstall_data.get(
+            'authorized-keys', [])
+        self.model.pwauth = self.autoinstall_data.get(
+            'allow-pw', not self.model.authorized_keys)
+
     def start_ui(self):
         self.ui.set_body(SSHView(self.model, self))
         if self.answers:

--- a/subiquity/controllers/ssh.py
+++ b/subiquity/controllers/ssh.py
@@ -33,7 +33,7 @@ class FetchSSHKeysFailure(Exception):
 
 class SSHController(SubiquityController):
 
-    model_name = "ssh"
+    autoinstall_key = model_name = "ssh"
 
     def __init__(self, app):
         super().__init__(app)

--- a/subiquity/controllers/tests/test_filesystem.py
+++ b/subiquity/controllers/tests/test_filesystem.py
@@ -37,6 +37,7 @@ class Thing:
 class MiniApplication:
     ui = signal = loop = None
     project = "mini"
+    autoinstall_config = {}
     answers = {}
     opts = Thing()
     opts.dry_run = True

--- a/subiquity/controllers/welcome.py
+++ b/subiquity/controllers/welcome.py
@@ -26,6 +26,10 @@ log = logging.getLogger('subiquity.controllers.welcome')
 class WelcomeController(SubiquityController):
 
     autoinstall_key = model_name = "locale"
+    autoinstall_default = 'en_US.UTF-8'
+
+    def load_autoinstall_data(self, data):
+        os.environ["LANG"] = data
 
     def start(self):
         lang = os.environ.get("LANG")
@@ -34,6 +38,8 @@ class WelcomeController(SubiquityController):
         for code, name in self.model.supported_languages:
             if code == lang:
                 self.model.switch_language(code)
+        else:
+            self.model.selected_language = code
 
     def start_ui(self):
         view = WelcomeView(self.model, self)

--- a/subiquity/controllers/welcome.py
+++ b/subiquity/controllers/welcome.py
@@ -25,7 +25,7 @@ log = logging.getLogger('subiquity.controllers.welcome')
 
 class WelcomeController(SubiquityController):
 
-    model_name = "locale"
+    autoinstall_key = model_name = "locale"
 
     def start(self):
         lang = os.environ.get("LANG")

--- a/subiquity/core.py
+++ b/subiquity/core.py
@@ -18,6 +18,7 @@ import os
 import platform
 import sys
 import traceback
+import yaml
 
 import apport.hookutils
 
@@ -28,6 +29,7 @@ from subiquitycore.async_helpers import (
 from subiquitycore.core import Application
 from subiquitycore.utils import run_command
 
+from subiquity.autoinstall import merge_autoinstall_configs
 from subiquity.controllers.error import (
     ErrorReportKind,
     )
@@ -112,6 +114,10 @@ class Subiquity(Application):
             ])
         self._apport_data = []
         self._apport_files = []
+
+        self.autoinstall_config = {}
+        self.merged_autoinstall_path = os.path.join(
+            self.root, 'autoinstall.yaml')
         self.note_data_for_apport("SnapUpdated", str(self.updated))
         self.note_data_for_apport("UsingAnswers", str(bool(self.answers)))
 
@@ -124,6 +130,11 @@ class Subiquity(Application):
             super().exit()
 
     def run(self):
+        if self.opts.autoinstall:
+            merge_autoinstall_configs(
+                self.opts.autoinstall, self.merged_autoinstall_path)
+            with open(self.merged_autoinstall_path) as fp:
+                self.autoinstall_config = yaml.safe_load(fp)
         try:
             super().run()
         except Exception:

--- a/subiquity/core.py
+++ b/subiquity/core.py
@@ -192,7 +192,6 @@ class Subiquity(Application):
     def select_screen(self, new):
         if new.interactive():
             super().select_screen(new)
-            return
         elif self.autoinstall_config and not new.autoinstall_applied:
             schedule_task(self._apply(new))
         else:

--- a/subiquity/core.py
+++ b/subiquity/core.py
@@ -152,6 +152,11 @@ class Subiquity(Application):
         self.controllers.Reporting.report_finish_event(
             name, description, status, level)
 
+    def interactive(self):
+        if not self.autoinstall_config:
+            return True
+        return bool(self.autoinstall_config.get('interactive-sections'))
+
     def select_initial_screen(self, index):
         super().select_initial_screen(index)
         for report in self.controllers.Error.reports:

--- a/subiquity/core.py
+++ b/subiquity/core.py
@@ -19,6 +19,7 @@ import os
 import platform
 import sys
 import traceback
+import urwid
 import yaml
 
 import apport.hookutils
@@ -130,6 +131,16 @@ class Subiquity(Application):
             run_command(["/sbin/reboot"])
         else:
             super().exit()
+
+    def make_screen(self):
+        if self.interactive():
+            return super().make_screen()
+        else:
+            r, w = os.pipe()
+            s = urwid.raw_display.Screen(
+                input=os.fdopen(r), output=open('/dev/null', 'w'))
+            s.get_cols_rows = lambda: (80, 24)
+            return s
 
     def run(self):
         if self.opts.autoinstall:

--- a/subiquity/models/mirror.py
+++ b/subiquity/models/mirror.py
@@ -49,10 +49,13 @@ class MirrorModel(object):
         self.architecture = get_architecture()
         self.default_mirror = self.get_mirror()
 
+    def is_default(self):
+        return self.get_mirror() == self.default_mirror
+
     def set_country(self, cc):
-        uri = self.get_mirror()
-        if uri != self.default_mirror:
+        if not self.is_default():
             return
+        uri = self.get_mirror()
         parsed = parse.urlparse(uri)
         new = parsed._replace(netloc=cc + '.' + parsed.netloc)
         self.set_mirror(parse.urlunparse(new))

--- a/subiquitycore/core.py
+++ b/subiquitycore/core.py
@@ -363,10 +363,15 @@ class Application:
         self.updated = os.path.exists(os.path.join(self.state_dir, 'updating'))
         self.signal = Signal()
         self.prober = prober
-        self.aio_loop = asyncio.get_event_loop()
+        self.new_event_loop()
         self.urwid_loop = None
         self.controllers = ControllerSet(self, self.controllers)
         self.context = Context.new(self)
+
+    def new_event_loop(self):
+        new_loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(new_loop)
+        self.aio_loop = new_loop
 
     def run_command_in_foreground(self, cmd, before_hook=None, after_hook=None,
                                   **kw):


### PR DESCRIPTION
The branch implements the first cut of autoinstall for subiquity. What is there:

 * support for fully non-interactive and partially interactive installs
 * support for early and late commands

What is not there:

 * any sort of decent error handling
    * this includes any sort of sensible data validation. Get your autoinstall.yaml wrong and things will just blow up in a mess
 * support for the packages, debconf-selections, snaplist, user-data sections of the config file
 * sensible behaviour when more than one subiquity is running (e.g. on tty1 and serial)
 * generation of an autoinstall file at the end of install
 * any kind of sensible storage configuration, it just supports lvm or direct installation on the largest disk in the system

But I have plans for all of these things :)
