### PR TITLE
stop testing on disco; start testing on eoan and focal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ dist: xenial
 env:
   - IMAGE=ubuntu-daily:bionic SCRIPT="make lint"
   - IMAGE=ubuntu-daily:bionic SCRIPT=./scripts/runtests.sh
-  - IMAGE=ubuntu-daily:disco SCRIPT=./scripts/runtests.sh
+  - IMAGE=ubuntu-daily:eoan SCRIPT=./scripts/runtests.sh
+  - IMAGE=ubuntu-daily:focal SCRIPT=./scripts/runtests.sh
 
 language: bash
 


### PR DESCRIPTION
Clearly we should do something like this, probert isn't installable in lxd containers though (see travis) :(