### PR TITLE
fix installation hang after refreshing snap

### DIFF
--- a/subiquity/controller.py
+++ b/subiquity/controller.py
@@ -26,6 +26,9 @@ log = logging.getLogger("subiquity.controller")
 
 class SubiquityController(BaseController):
 
+    def deserialize(self, state):
+        self.configured()
+
     def configured(self):
         """Let the world know that this controller's model is now configured.
         """

--- a/subiquity/controllers/mirror.py
+++ b/subiquity/controllers/mirror.py
@@ -101,6 +101,7 @@ class MirrorController(SubiquityController):
         return self.model.mirror
 
     def deserialize(self, data):
+        super().deserialize(data)
         self.model.mirror = data
 
     def done(self, mirror):

--- a/subiquity/controllers/proxy.py
+++ b/subiquity/controllers/proxy.py
@@ -38,6 +38,7 @@ class ProxyController(SubiquityController):
         return self.model.proxy
 
     def deserialize(self, data):
+        super().deserialize(data)
         self.model.proxy = data
 
     def done(self, proxy):

--- a/subiquity/controllers/welcome.py
+++ b/subiquity/controllers/welcome.py
@@ -56,4 +56,5 @@ class WelcomeController(SubiquityController):
         return self.model.selected_language
 
     def deserialize(self, data):
+        super().deserialize(data)
         self.model.switch_language(data)


### PR DESCRIPTION
The installprogress controller waits for various model objects to be
configured before proceeding. But model objects whose state was loaded
from disk after a snap refresh were not marked as configured :( This
meant that, in particular, the postinstall steps waited on the language
being configured indefinitely. The fix is simple: mark model objects as
configured when their state is loaded from disk post-refresh.