### PR TITLE
Typo and variable fix

### DIFF
--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -419,7 +419,7 @@ def _generic_can_REMOVE(obj):
     if cd is None:
         return False
     if cd.preserve:
-        return _("Cannot remove selflabel from pre-exsting {cdtype} "
+        return _("Cannot remove {selflabel} from pre-existing {cdtype} "
                  "{cdlabel}").format(
                     selflabel=obj.label,
                     cdtype=cd.desc(),


### PR DESCRIPTION
Noticed these while translating to Hebrew via Launchpad.

Can you please update the new strings in Launchpad? The one I saw in Launchpad had extra arguments which are long gone according to git.