### PR TITLE
Refactor how we track what filesystem a volume originally had

### DIFF
--- a/subiquity/controllers/filesystem.py
+++ b/subiquity/controllers/filesystem.py
@@ -377,14 +377,16 @@ class FilesystemController(SubiquityController):
 
     def create_filesystem(self, volume, spec):
         if spec['fstype'] is None:
-            fs = volume.original_fs()
-            if fs is None:
-                return
-            self.model.re_add_filesystem(fs)
+            fstype = volume.original_fstype()
+            if fstype is None:
+                return None
+            preserve = True
         else:
-            fs = self.model.add_filesystem(volume, spec['fstype'])
+            fstype = spec['fstype']
+            preserve = False
+        fs = self.model.add_filesystem(volume, fstype, preserve)
         if isinstance(volume, Partition):
-            if spec['fstype'] == "swap":
+            if fstype == "swap":
                 volume.flag = "swap"
             elif volume.flag == "swap":
                 volume.flag = ""

--- a/subiquity/models/tests/test_filesystem.py
+++ b/subiquity/models/tests/test_filesystem.py
@@ -311,7 +311,7 @@ class TestFilesystemModel(unittest.TestCase):
         self.assertEqual(
             partition.usage_labels(),
             ["to be formatted as ext4", "not mounted"])
-        partition._original_fs = fs
+        model._orig_config = model._render_actions()
         fs.preserve = True
         partition.preserve = True
         self.assertEqual(

--- a/subiquity/ui/views/filesystem/partition.py
+++ b/subiquity/ui/views/filesystem/partition.py
@@ -147,9 +147,9 @@ class PartitionForm(Form):
         self.device = device
         self.existing_fs_type = None
         if device:
-            existing_fs = device.original_fs()
-            if existing_fs:
-                self.existing_fs_type = existing_fs.fstype
+            ofstype = device.original_fstype()
+            if ofstype:
+                self.existing_fs_type = ofstype
         initial_path = initial.get('mount')
         self.mountpoints = {
             m.path: m.device.volume for m in self.model.all_mounts()
@@ -378,7 +378,7 @@ class PartitionStretchy(Stretchy):
 
         if partition is not None:
             if partition.flag == "boot":
-                if partition.original_fs():
+                if partition.original_fstype():
                     opts = [
                         Option((
                             _("Use existing fat32 filesystem"),
@@ -470,7 +470,7 @@ class PartitionStretchy(Stretchy):
         log.debug("Add Partition Result: {}".format(form.as_data()))
         data = form.as_data()
         if self.partition is not None and self.partition.flag == "boot":
-            if self.partition.original_fs() is None:
+            if self.partition.original_fstype() is None:
                 data['fstype'] = self.partition.fs().fstype
             if self.partition.fs().mount() is not None:
                 data['mount'] = self.partition.fs().mount().path

--- a/subiquity/ui/views/filesystem/tests/test_partition.py
+++ b/subiquity/ui/views/filesystem/tests/test_partition.py
@@ -130,7 +130,7 @@ class PartitionViewTests(unittest.TestCase):
         partition.preserve = True
         fs = model.add_filesystem(partition, "ext4")
         fs.preserve = True
-        partition._original_fs = fs
+        model._orig_config = model._render_actions()
         view, stretchy = make_partition_view(model, disk, partition)
         self.assertFalse(stretchy.form.size.enabled)
         self.assertTrue(stretchy.form.done_btn.enabled)
@@ -191,7 +191,7 @@ class PartitionViewTests(unittest.TestCase):
         model, disk = make_model_and_disk()
         partition = model.add_partition(disk, 512*(2**20), "boot")
         fs = model.add_filesystem(partition, "fat32")
-        partition._original_fs = fs
+        model._orig_config = model._render_actions()
         disk.preserve = partition.preserve = fs.preserve = True
         view, stretchy = make_partition_view(model, disk, partition)
 
@@ -213,7 +213,7 @@ class PartitionViewTests(unittest.TestCase):
         model, disk = make_model_and_disk()
         partition = model.add_partition(disk, 512*(2**20), "boot")
         fs = model.add_filesystem(partition, "fat32")
-        partition._original_fs = fs
+        model._orig_config = model._render_actions()
         disk.preserve = partition.preserve = fs.preserve = True
         model.add_mount(fs, '/boot/efi')
         view, stretchy = make_partition_view(model, disk, partition)
@@ -236,7 +236,7 @@ class PartitionViewTests(unittest.TestCase):
         model, disk = make_model_and_disk()
         fs = model.add_filesystem(disk, "ntfs")
         fs.preserve = True
-        disk._original_fs = fs
+        model._orig_config = model._render_actions()
         view, stretchy = make_format_entire_view(model, disk)
         self.assertEqual(
             stretchy.form.fstype.value, None)


### PR DESCRIPTION
This makes things a bit more generic, because I am going to need to
track which partition table type a disk originally.

The special cases around swap are annoying.