### PR TITLE
bin/console-conf-wrapper: detect whether snapd recovery chooser should run

### DIFF
--- a/bin/console-conf-wrapper
+++ b/bin/console-conf-wrapper
@@ -10,6 +10,15 @@ trap echo_on EXIT
 # happened and need to force it on. Yay UNIX!
 stty icrnl -echo
 
+if [ -e /run/snapd-recovery-chooser-triggered ]; then
+    # make sure the chooser binary is there to avoid getting into an awkward
+    # state and locking out the user
+    if [ -x /usr/lib/snapd/snap-recovery-chooser ]; then
+        # when recovery chooser is invoked it takes over the terminal
+        exec /usr/lib/snapd/snap-recovery-chooser
+    fi
+fi
+
 if [ "$(snap managed)" = "true" ]; then
     # check if we have extrausers that have no password set
     if grep -qE '^[-a-z0-9+.-_]+:x:' /var/lib/extrausers/passwd && ! grep -qE '^[-a-z0-9+.-_]+:\$[0-9]+\$.*:' /var/lib/extrausers/shadow; then


### PR DESCRIPTION
On UC20 devices, there's a specialized process that monitors the user activity on input devices during the boot process in an attempt to detect when the user wants to invoke the UC20 recovery menu. Once the interrupt is detected an empty file at `/run/snapd-recovery-chooser-triggered` is created. See related PR https://github.com/snapcore/snapd/pull/8156.

When the file is present, the console-conf-wrapper should be replaced with the actual chooser UI. By the time this runs, the `usr-lib-snapd.mount` should already be done, but I've added some extra checks to make sure that the chooser binary is present.

The naming of the chooser binary is agreed on within the snapd team (well, mostly). We haven't agreed whether there should be a way to limit the chooser to specific ttys only. In which case, the PR is going to need little more tweaks.