### PR TITLE
debian/console-conf*.service: add core18 services as After deps

### DIFF
--- a/debian/console-conf.console-conf@.service
+++ b/debian/console-conf.console-conf@.service
@@ -2,6 +2,8 @@
 Description=Ubuntu Core Firstboot Configuration %I
 After=systemd-user-sessions.service plymouth-quit-wait.service
 After=rc-local.service
+# Ubuntu Core specific services
+After=core18.start-snapd.service core.start-snapd.service
 IgnoreOnIsolate=yes
 ConditionPathExists=/dev/tty0
 ConditionPathExists=!/var/lib/console-conf/complete

--- a/debian/console-conf.serial-console-conf@.service
+++ b/debian/console-conf.serial-console-conf@.service
@@ -3,6 +3,8 @@ Description=Ubuntu Core Firstboot Configuration %I
 BindsTo=dev-%i.device
 After=dev-%i.device systemd-user-sessions.service plymouth-quit-wait.service
 After=rc-local.service
+# Ubuntu Core specific services
+After=core18.start-snapd.service core.start-snapd.service
 ConditionPathExists=!/var/lib/console-conf/complete
 StartLimitInterval=0
 


### PR DESCRIPTION
These are currently applied with hacks in the core18 repo when building the core18 snap, but that was always meant to be a temporary thing until it was upstreamed... here's the upstreaming.

See https://github.com/CanonicalLtd/subiquity/pull/389 and https://github.com/snapcore/core18/pull/74 for a bit of historical context.