### PR TITLE
debian/console-conf.service: ensure correct order with respect to snapd services

### DIFF
--- a/debian/console-conf.console-conf@.service
+++ b/debian/console-conf.console-conf@.service
@@ -5,6 +5,9 @@ After=rc-local.service
 # on core20 the firstboot seeding happens via the core.start-snapd service,
 # make sure to start after so that the 'snap' command is available
 After=core.start-snapd.service
+# on core20 the user may invoke a recovery chooser, make sure the detection
+# service runs before
+After=snapd.recovery-chooser-trigger.service
 IgnoreOnIsolate=yes
 ConditionPathExists=/dev/tty0
 ConditionPathExists=!/var/lib/console-conf/complete

--- a/debian/console-conf.console-conf@.service
+++ b/debian/console-conf.console-conf@.service
@@ -1,7 +1,10 @@
 [Unit]
 Description=Ubuntu Core Firstboot Configuration %I
 After=systemd-user-sessions.service plymouth-quit-wait.service
-After=rc-local.service core18.start-snapd.service
+After=rc-local.service
+# on core20 the firstboot seeding happens via the core.start-snapd service,
+# make sure to start after so that the 'snap' command is available
+After=core.start-snapd.service
 IgnoreOnIsolate=yes
 ConditionPathExists=/dev/tty0
 ConditionPathExists=!/var/lib/console-conf/complete

--- a/debian/console-conf.console-conf@.service
+++ b/debian/console-conf.console-conf@.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Ubuntu Core Firstboot Configuration %I
 After=systemd-user-sessions.service plymouth-quit-wait.service
-After=rc-local.service
+After=rc-local.service core18.start-snapd.service
 IgnoreOnIsolate=yes
 ConditionPathExists=/dev/tty0
 ConditionPathExists=!/var/lib/console-conf/complete

--- a/debian/console-conf.console-conf@.service
+++ b/debian/console-conf.console-conf@.service
@@ -2,9 +2,9 @@
 Description=Ubuntu Core Firstboot Configuration %I
 After=systemd-user-sessions.service plymouth-quit-wait.service
 After=rc-local.service
-# on core20 the firstboot seeding happens via the core.start-snapd service,
+# on core18/core20 the firstboot seeding happens via the core[18].start-snapd service,
 # make sure to start after so that the 'snap' command is available
-After=core.start-snapd.service
+After=core18.start-snapd.service core.start-snapd.service
 # on core20 the user may invoke a recovery chooser, make sure the detection
 # service runs before
 After=snapd.recovery-chooser-trigger.service

--- a/debian/console-conf.serial-console-conf@.service
+++ b/debian/console-conf.serial-console-conf@.service
@@ -3,9 +3,9 @@ Description=Ubuntu Core Firstboot Configuration %I
 BindsTo=dev-%i.device
 After=dev-%i.device systemd-user-sessions.service plymouth-quit-wait.service
 After=rc-local.service
-# on core20 the firstboot seeding happens via the core.start-snapd service,
+# on core18/core20 the firstboot seeding happens via the core[18].start-snapd service,
 # make sure to start after so that the 'snap' command is available
-After=core.start-snapd.service
+After=core18.start-snapd.service core.start-snapd.service
 # on core20 the user may invoke a recovery chooser, make sure the detection
 # service runs before
 After=snapd.recovery-chooser-trigger.service

--- a/debian/console-conf.serial-console-conf@.service
+++ b/debian/console-conf.serial-console-conf@.service
@@ -2,7 +2,10 @@
 Description=Ubuntu Core Firstboot Configuration %I
 BindsTo=dev-%i.device
 After=dev-%i.device systemd-user-sessions.service plymouth-quit-wait.service
-After=rc-local.service core18.start-snapd.service
+After=rc-local.service
+# on core20 the firstboot seeding happens via the core.start-snapd service,
+# make sure to start after so that the 'snap' command is available
+After=core.start-snapd.service
 ConditionPathExists=!/var/lib/console-conf/complete
 StartLimitInterval=0
 

--- a/debian/console-conf.serial-console-conf@.service
+++ b/debian/console-conf.serial-console-conf@.service
@@ -6,6 +6,9 @@ After=rc-local.service
 # on core20 the firstboot seeding happens via the core.start-snapd service,
 # make sure to start after so that the 'snap' command is available
 After=core.start-snapd.service
+# on core20 the user may invoke a recovery chooser, make sure the detection
+# service runs before
+After=snapd.recovery-chooser-trigger.service
 ConditionPathExists=!/var/lib/console-conf/complete
 StartLimitInterval=0
 

--- a/debian/console-conf.serial-console-conf@.service
+++ b/debian/console-conf.serial-console-conf@.service
@@ -2,7 +2,7 @@
 Description=Ubuntu Core Firstboot Configuration %I
 BindsTo=dev-%i.device
 After=dev-%i.device systemd-user-sessions.service plymouth-quit-wait.service
-After=rc-local.service
+After=rc-local.service core18.start-snapd.service
 ConditionPathExists=!/var/lib/console-conf/complete
 StartLimitInterval=0
 


### PR DESCRIPTION
The PR introduces changes to `(serial-)console-conf@.service` that ensure the right ordering on core20 devices.

The first bit for core18 was already included in https://github.com/CanonicalLtd/subiquity/pull/389 for bionic branch from @mvo5. The relevant service is named `core.start-snapd.service` in core20.
The last patches introduces an ordering dependency on `snapd.recovery-chooser-trigger.service`, which is new in core20. The change was moved from https://github.com/snapcore/core20/pull/23 based on advice from @xnox.


