### PR TITLE
fix various restarting snafus

### DIFF
--- a/subiquity/controller.py
+++ b/subiquity/controller.py
@@ -72,7 +72,7 @@ class SubiquityController(BaseController):
             self.app.base_model.configured(self.model_name)
 
     def deserialize(self, state):
-        self.configured()
+        pass
 
     def make_autoinstall(self):
         return {}

--- a/subiquity/controllers/mirror.py
+++ b/subiquity/controllers/mirror.py
@@ -124,7 +124,6 @@ class MirrorController(SubiquityController):
         return self.model.get_mirror()
 
     def deserialize(self, data):
-        super().deserialize(data)
         self.model.set_mirror(data)
 
     def done(self, mirror):

--- a/subiquity/controllers/proxy.py
+++ b/subiquity/controllers/proxy.py
@@ -53,7 +53,6 @@ class ProxyController(SubiquityController):
         return self.model.proxy
 
     def deserialize(self, data):
-        super().deserialize(data)
         self.model.proxy = data
 
     def done(self, proxy):

--- a/subiquity/controllers/refresh.py
+++ b/subiquity/controllers/refresh.py
@@ -92,7 +92,7 @@ class RefreshController(SubiquityController):
             if change['status'] == 'Done':
                 # Clearly if we got here we didn't get restarted by
                 # snapd/systemctl (dry-run mode or logged in via SSH)
-                self.app.restart()
+                self.app.restart(remove_last_screen=False)
             if change['status'] not in ['Do', 'Doing']:
                 raise Exception("update failed")
             await asyncio.sleep(0.1)

--- a/subiquity/controllers/welcome.py
+++ b/subiquity/controllers/welcome.py
@@ -62,7 +62,6 @@ class WelcomeController(SubiquityController):
         return self.model.selected_language
 
     def deserialize(self, data):
-        super().deserialize(data)
         self.model.switch_language(data)
 
     def make_autoinstall(self):

--- a/subiquity/core.py
+++ b/subiquity/core.py
@@ -131,7 +131,9 @@ class Subiquity(Application):
         else:
             super().exit()
 
-    def restart(self):
+    def restart(self, remove_last_screen=True):
+        if remove_last_screen:
+            self._remove_last_screen()
         self.urwid_loop.screen.stop()
         cmdline = ['snap', 'run', 'subiquity']
         if self.opts.dry_run:
@@ -168,6 +170,7 @@ class Subiquity(Application):
             report = self.make_apport_report(
                 ErrorReportKind.UI, "Installer UI", interrupt=False, wait=True)
             print("report saved to {}".format(report.path))
+            self._remove_last_screen()
             raise
 
     def report_start_event(self, name, description, level="INFO"):

--- a/subiquitycore/core.py
+++ b/subiquitycore/core.py
@@ -600,6 +600,9 @@ class Application:
         for i, controller in enumerate(self.controllers.instances):
             if controller.name == last_screen:
                 controller_index = i
+        # Screens that have already been seen should be marked as configured.
+        for controller in self.controllers.instances[:controller_index]:
+            controller.configured()
         return controller_index
 
     def setraw(self):

--- a/subiquitycore/core.py
+++ b/subiquitycore/core.py
@@ -485,10 +485,13 @@ class Application:
 
 # EventLoop -------------------------------------------------------------------
 
-    def exit(self):
+    def _remove_last_screen(self):
         state_path = os.path.join(self.state_dir, 'last-screen')
         if os.path.exists(state_path):
             os.unlink(state_path)
+
+    def exit(self):
+        self._remove_last_screen()
         self.aio_loop.stop()
 
     def run_scripts(self, scripts):


### PR DESCRIPTION
There is a broken situation in tip: if you refresh the snap, installation subsequently fails and you chose to restart, things get very confusing. What happens is that subiquity goes into the "restarting after snap refresh" mode, loads state for all screens and marks them all configured. This means the install starts again, but with a super bogus config and fails very quickly.

This PR tackles this by removing the last-state file before restarting, and using different logic for when to consider an already-seen screen as configured.