### PR TITLE
asyncio.CancelledError inherits from Exception in Python 3.6 :(

### DIFF
--- a/subiquity/controllers/filesystem.py
+++ b/subiquity/controllers/filesystem.py
@@ -143,6 +143,10 @@ class FilesystemController(SubiquityController):
                         # gets cancelled, we should be cancelled too.
                         await asyncio.wait_for(
                             self._probe_once_task.task, 15.0)
+                except asyncio.CancelledError:
+                    # asyncio.CancelledError is a subclass of Exception in
+                    # Python 3.6 (sadface)
+                    raise
                 except Exception:
                     block_discover_log.exception(
                         "block probing failed restricted=%s", restricted)


### PR DESCRIPTION
In https://bugs.launchpad.net/subiquity/+bug/1868817 we see reports of block probing failing with CancelledError. That's not supposed to happen: if block probing is cancelled (usually because a udev block event is seen before probing completes) we should restart block probing, not fail. And I tested all this stuff, carefully, when I implemented it. But! I was testing on focal (or maybe eoan) and not bionic, which is where the Python in the subiquity snap comes from. And in Python 3.6 asyncio.CancelledError inherits from Exception and so is caught by the "except Exception" block and reported as a failure. Argh.