### PR TITLE
be a bit less cavalier about running the install in autoinstall mode

### DIFF
--- a/examples/autoinstall-interactive.yaml
+++ b/examples/autoinstall-interactive.yaml
@@ -1,8 +1,22 @@
 version: 1
+early-commands:
+        - echo a
+        - sleep 1
+        - echo a
+late-commands:
+        - echo a
+        - sleep 1
+        - echo a
+keyboard:
+        layout: gb
 interactive-sections:
         - keyboard
         - snaps
-        - identity
 snaps:
         - name: etcd
           channel: 3.2/stable
+identity:
+        realname: ''
+        username: ubuntu
+        password: '$6$wdAcoXrU039hKYPd$508Qvbe7ObUnxoj15DRCkzC3qO7edjH0VV7BPNRDYK4QR8ofJaEEF2heacn0QgD.f8pO8SNp83XNdWG6tocBM1'
+        hostname: ubuntu

--- a/subiquity/cmd/tui.py
+++ b/subiquity/cmd/tui.py
@@ -72,6 +72,9 @@ def parse_options(argv):
                         help='Synthesize a click on a button matching PAT')
     parser.add_argument('--answers')
     parser.add_argument('--autoinstall', action='store')
+    with open('/proc/cmdline') as fp:
+        cmdline = fp.read()
+    parser.add_argument('--kernel-cmdline', action='store', default=cmdline)
     parser.add_argument('--source', default=[], action='append',
                         dest='sources', metavar='URL',
                         help='install from url instead of default.')

--- a/subiquity/controllers/filesystem.py
+++ b/subiquity/controllers/filesystem.py
@@ -341,6 +341,7 @@ class FilesystemController(SubiquityController):
         elif action['action'] == 'done':
             if not self.ui.body.done.enabled:
                 raise Exception("answers did not provide complete fs config")
+            self.app.confirm_install()
             self.finish()
         else:
             raise Exception("could not process action {}".format(action))
@@ -348,6 +349,7 @@ class FilesystemController(SubiquityController):
     def manual(self):
         self.ui.set_body(FilesystemView(self.model, self))
         if self.answers['guided']:
+            self.app.confirm_install()
             self.finish()
         if self.answers['manual']:
             self._run_iterator(self._run_actions(self.answers['manual']))

--- a/subiquity/controllers/installprogress.py
+++ b/subiquity/controllers/installprogress.py
@@ -112,6 +112,7 @@ class InstallProgressController(SubiquityController):
         self._log_syslog_identifier = 'curtin_log.%s' % (os.getpid(),)
         self.tb_extractor = TracebackExtractor()
         self.curtin_context = None
+        self.confirmation = asyncio.Event()
 
     def interactive(self):
         return self.app.interactive()
@@ -280,6 +281,8 @@ class InstallProgressController(SubiquityController):
         try:
             await asyncio.wait(
                 {e.wait() for e in self.model.install_events})
+
+            await self.confirmation.wait()
 
             await self.curtin_install(context)
 

--- a/subiquity/controllers/refresh.py
+++ b/subiquity/controllers/refresh.py
@@ -148,10 +148,8 @@ class RefreshController(SubiquityController):
         """Return the channel we should refresh subiquity to."""
         if 'channel' in self.answers:
             return self.answers['channel']
-        with open('/proc/cmdline') as fp:
-            cmdline = fp.read()
         prefix = "subiquity-channel="
-        for arg in cmdline.split():
+        for arg in self.app.kernel_cmdline:
             if arg.startswith(prefix):
                 log.debug(
                     "get_refresh_channel: found %s on kernel cmdline", arg)

--- a/subiquity/core.py
+++ b/subiquity/core.py
@@ -249,6 +249,11 @@ class Subiquity(Application):
                 answer = no
                 if 'autoinstall' in self.kernel_cmdline:
                     answer = yes
+                else:
+                    print(_("Confirmation is required to continue."))
+                    print(_("Add 'autoinstall' to your kernel command line to"
+                            " avoid this"))
+                    print()
                 prompt = "\n\n{} ({}|{})".format(
                     _("Continue with autoinstall?"), yes, no)
                 while answer != yes:

--- a/subiquity/core.py
+++ b/subiquity/core.py
@@ -16,6 +16,7 @@
 import logging
 import os
 import platform
+import shlex
 import signal
 import sys
 import traceback
@@ -119,7 +120,7 @@ class Subiquity(Application):
 
         super().__init__(opts)
         self.block_log_dir = block_log_dir
-        self.kernel_cmdline = opts.kernel_cmdline.split()
+        self.kernel_cmdline = shlex.split(opts.kernel_cmdline)
         if opts.snaps_from_examples:
             connection = FakeSnapdConnection(
                 os.path.join(

--- a/subiquity/core.py
+++ b/subiquity/core.py
@@ -119,6 +119,7 @@ class Subiquity(Application):
 
         super().__init__(opts)
         self.block_log_dir = block_log_dir
+        self.kernel_cmdline = opts.kernel_cmdline.split()
         if opts.snaps_from_examples:
             connection = FakeSnapdConnection(
                 os.path.join(

--- a/subiquity/core.py
+++ b/subiquity/core.py
@@ -244,11 +244,15 @@ class Subiquity(Application):
                 self.ui.body.show_stretchy_overlay(
                     InstallConfirmation(self.ui.body, self))
             else:
-                answer = 'no'
+                yes = _('yes')
+                no = _('no')
+                answer = no
                 if 'autoinstall' in self.kernel_cmdline:
-                    answer = 'yes'
-                while answer != 'yes':
-                    print("\n\nContinue with autoinstall? (yes|no)")
+                    answer = yes
+                prompt = "\n\n{} ({}|{})".format(
+                    _("Continue with autoinstall?"), yes, no)
+                while answer != yes:
+                    print(prompt)
                     answer = input()
                 self.confirm_install()
                 super().next_screen()

--- a/subiquity/core.py
+++ b/subiquity/core.py
@@ -236,11 +236,19 @@ class Subiquity(Application):
     def next_screen(self):
         can_install = all(e.is_set() for e in self.base_model.install_events)
         if can_install and not self.install_confirmed:
-            from subiquity.ui.views.installprogress import (
-                InstallConfirmation,
-                )
-            self.ui.body.show_stretchy_overlay(
-                InstallConfirmation(self.ui.body, self))
+            if self.interactive():
+                from subiquity.ui.views.installprogress import (
+                    InstallConfirmation,
+                    )
+                self.ui.body.show_stretchy_overlay(
+                    InstallConfirmation(self.ui.body, self))
+            else:
+                answer = 'no'
+                while answer != 'yes':
+                    print("\n\nContinue with autoinstall? (yes|no)")
+                    answer = input()
+                self.confirm_install()
+                super().next_screen()
         else:
             super().next_screen()
 

--- a/subiquity/core.py
+++ b/subiquity/core.py
@@ -244,6 +244,8 @@ class Subiquity(Application):
                     InstallConfirmation(self.ui.body, self))
             else:
                 answer = 'no'
+                if 'autoinstall' in self.kernel_cmdline:
+                    answer = 'yes'
                 while answer != 'yes':
                     print("\n\nContinue with autoinstall? (yes|no)")
                     answer = input()

--- a/subiquity/ui/views/filesystem/filesystem.py
+++ b/subiquity/ui/views/filesystem/filesystem.py
@@ -35,8 +35,6 @@ from subiquitycore.ui.actionmenu import (
     )
 from subiquitycore.ui.buttons import (
     back_btn,
-    cancel_btn,
-    danger_btn,
     done_btn,
     menu_btn,
     other_btn,
@@ -75,40 +73,6 @@ from .partition import PartitionStretchy, FormatEntireStretchy
 from .raid import RaidStretchy
 
 log = logging.getLogger('subiquity.ui.filesystem.filesystem')
-
-
-confirmation_text = _("""\
-Selecting Continue below will begin the installation process and \
-result in the loss of data on the disks selected to be formatted.
-
-You will not be able to return to this or a previous screen once \
-the installation has started.
-
-Are you sure you want to continue?""")
-
-
-class FilesystemConfirmation(Stretchy):
-    def __init__(self, parent, controller):
-        self.parent = parent
-        self.controller = controller
-        widgets = [
-            Text(_(confirmation_text)),
-            Text(""),
-            button_pile([
-                cancel_btn(_("No"), on_press=self.cancel),
-                danger_btn(_("Continue"), on_press=self.ok)]),
-            ]
-        super().__init__(
-            _("Confirm destructive action"),
-            widgets,
-            stretchy_index=0,
-            focus_index=2)
-
-    def ok(self, sender):
-        self.controller.finish()
-
-    def cancel(self, sender):
-        self.parent.remove_overlay()
 
 
 @attr.s
@@ -557,5 +521,4 @@ class FilesystemView(BaseView):
         self.controller.reset()
 
     def done(self, button):
-        self.show_stretchy_overlay(FilesystemConfirmation(self,
-                                                          self.controller))
+        self.controller.finish()


### PR DESCRIPTION
Currently, if subiquity finds an autoinstall config, it just runs. This would make it too easy to create a USB stick that destroys a machine it is plugged into at boot, so this branch stops and asks unless 'autoinstall' is on the kernel command line.

I added a small bit of docs about this: https://wiki.ubuntu.com/FoundationsTeam/AutomatedServerInstalls?action=diff&rev2=51&rev1=50

This branch also refactors the interactive confirmation so that it is shown even if we are not showing the filesystem screen at all.