### PR TITLE
tweak autoinstall command lists

### DIFF
--- a/examples/autoinstall-invalid.yaml
+++ b/examples/autoinstall-invalid.yaml
@@ -1,7 +1,7 @@
 version: 1
 early-commands:
         - echo a
-        - sleep 1
+        - ["sleep", "1"]
         - echo a
 late-commands:
         - echo a

--- a/subiquity/controllers/error.py
+++ b/subiquity/controllers/error.py
@@ -326,6 +326,7 @@ class ErrorReport(metaclass=urwid.MetaSignals):
 class ErrorController(CmdListController):
 
     autoinstall_key = 'error-commands'
+    cmd_check = False
 
     def __init__(self, app):
         super().__init__(app)


### PR DESCRIPTION
allow commands to be lists or strings
consider errors to be failures (except in error-commands)