### PR TITLE
obscure race: if no refresh available, only advance past refresh screen

### DIFF
--- a/subiquity/ui/views/refresh.py
+++ b/subiquity/ui/views/refresh.py
@@ -170,7 +170,7 @@ class RefreshView(BaseView):
             return
         if check_state == CheckState.AVAILABLE:
             self.check_state_available()
-        else:
+        elif self.showing:
             self.done()
 
     def check_state_failed(self, exc):


### PR DESCRIPTION
if the user has already moved on, we shouldn't advance!