### PR TITLE
subiquitycore: do not assume that stdin is /proc/self/fd/0

### DIFF
--- a/subiquitycore/core.py
+++ b/subiquitycore/core.py
@@ -177,7 +177,7 @@ class KeyCodesFilter:
     """
 
     def __init__(self):
-        self._fd = os.open("/proc/self/fd/0", os.O_RDWR)
+        self._fd = os.open("/proc/self/fd/"+str(sys.stdin.fileno()), os.O_RDWR)
         self.filtering = False
 
     def enter_keycodes_mode(self):


### PR DESCRIPTION
The KeyCodesFilter assumed that /proc/self/fd/0 is actual stdin and proceeded to
toy with that fd. This broke the recovery mode chooser where console-conf is fed
a list of recovery systems over stdin. The `sys.stdin` is already correctly
updated to use the real tty and that should be used elsewhere instead of
hardcoding the fd number.