### PR TITLE
console_conf: various recover chooser tweaks

### DIFF
--- a/console_conf/controllers/welcome.py
+++ b/console_conf/controllers/welcome.py
@@ -35,4 +35,9 @@ class WelcomeController(BaseController):
 
 
 class RecoveryChooserWelcomeController(WelcomeController):
+
     welcome_view = ChooserWelcomeView
+
+    def __init__(self, app):
+        super().__init__(app)
+        self.model = app.base_model

--- a/console_conf/models/systems.py
+++ b/console_conf/models/systems.py
@@ -95,6 +95,9 @@ class RecoverySystemsModel:
     def select(self, system, action):
         self._selection = SelectedSystemAction(system=system, action=action)
 
+    def unselect(self):
+        self._selection = None
+
     @property
     def selection(self):
         return self._selection

--- a/console_conf/models/tests/test_systems.py
+++ b/console_conf/models/tests/test_systems.py
@@ -209,6 +209,8 @@ class RecoverySystemsModelTests(unittest.TestCase):
                          SelectedSystemAction(
                              system=model.systems[1],
                              action=model.systems[1].actions[0]))
+        model.unselect()
+        self.assertIsNone(model.selection)
 
     def test_to_response_stream(self):
         raw = json.dumps(self.reference)

--- a/console_conf/ui/views/chooser.py
+++ b/console_conf/ui/views/chooser.py
@@ -51,19 +51,17 @@ class ChooserBaseView(BaseView):
     title = "Ubuntu Core"
 
     def __init__(self, current, scr):
+        super().__init__(scr)
+
         if current is not None:
             self.title = current.model.display_name
-
-        super().__init__(scr)
 
 
 def by_preferred_action_type(action):
     """Order action entries by having the 'run' mode first, then 'recover', then
     'install', the rest is ordered alphabetically."""
-    return (action.mode != "run",
-            action.mode != "recover",
-            action.mode != "install",
-            action.title.lower())
+    priority = {"run": 0, "recover": 1, "install": 2}
+    return (priority.get(action.mode, 100), action.title.lower())
 
 
 class ChooserCurrentSystemView(ChooserBaseView):

--- a/console_conf/ui/views/chooser.py
+++ b/console_conf/ui/views/chooser.py
@@ -176,8 +176,8 @@ class ChooserConfirmView(ChooserBaseView):
         "run": "Continue running the system without any changes.",
         "recover": ("You have requested to reboot the system into recovery "
                     "mode."),
-        "install": ("You are about to {action} the system version {version} "
-                    "for {model} from {publisher}.\n\n"
+        "install": ("You are about to {action_lower} the system version "
+                    "{version} for {model} from {publisher}.\n\n"
                     "This will remove all existing user data on the "
                     "device.\n\n"
                     "The system will reboot in the process."),
@@ -198,6 +198,7 @@ class ChooserConfirmView(ChooserBaseView):
         fmt = self.canned_summary.get(selection.action.mode,
                                       self.default_summary)
         summary = fmt.format(action=selection.action.title,
+                             action_lower=selection.action.title.lower(),
                              model=selection.system.model.display_name,
                              publisher=selection.system.brand.display_name,
                              version=selection.system.label)

--- a/console_conf/ui/views/chooser.py
+++ b/console_conf/ui/views/chooser.py
@@ -26,8 +26,8 @@ from urwid import (
     )
 from subiquitycore.ui.buttons import (
     danger_btn,
-    reset_btn,
     forward_btn,
+    back_btn,
     )
 from subiquitycore.ui.actionmenu import (
     Action,
@@ -47,23 +47,36 @@ from subiquitycore.view import BaseView
 log = logging.getLogger("console_conf.views.chooser")
 
 
-class ChooserCurrentSystemView(BaseView):
+class ChooserBaseView(BaseView):
     title = "Ubuntu Core"
 
-    def __init__(self, controller, current, has_more=False):
-        fmt = "Select one of available actions for \"{}\" by \"{}\"{}."
-        maybe_more = " or view all available systems" if has_more else ""
-        excerpt = fmt.format(current.model.display_name,
-                             current.brand.display_name,
-                             maybe_more)
+    def __init__(self, current, scr):
+        if current is not None:
+            self.title = current.model.display_name
 
+        super().__init__(scr)
+
+
+def by_preferred_action_type(action):
+    """Order action entries by having the 'run' mode first, then 'recover', then
+    'install', the rest is ordered alphabetically."""
+    return (action.mode != "run",
+            action.mode != "recover",
+            action.mode != "install",
+            action.title.lower())
+
+
+class ChooserCurrentSystemView(ChooserBaseView):
+    excerpt = "Select action:"
+
+    def __init__(self, controller, current, has_more=False):
         self.controller = controller
-        log.debug('current system: %s', current)
         log.debug('more systems available: %s', has_more)
+        log.debug('current system: %s', current)
 
         actions = []
-        for action in current.actions:
-            actions.append(forward_btn(label=action.title,
+        for action in sorted(current.actions, key=by_preferred_action_type):
+            actions.append(forward_btn(label=action.title.capitalize(),
                                        on_press=self._current_system_action,
                                        user_arg=(current, action)))
 
@@ -75,16 +88,11 @@ class ChooserCurrentSystemView(BaseView):
 
         lb = ListBox(actions)
 
-        buttons = [
-            reset_btn("ABORT", on_press=self.abort),
-        ]
-
-        super().__init__(screen(
-            lb,
-            buttons=button_pile(buttons),
-            focus_buttons=False,
-            narrow_rows=True,
-            excerpt=excerpt))
+        super().__init__(current,
+                         screen(
+                             lb,
+                             narrow_rows=True,
+                             excerpt=self.excerpt))
 
     def _current_system_action(self, sender, arg):
         current, action = arg
@@ -93,12 +101,11 @@ class ChooserCurrentSystemView(BaseView):
     def _more_options(self, sender):
         self.controller.more_options()
 
-    def abort(self, result):
-        self.controller.cancel()
+    def back(self, result):
+        self.controller.back()
 
 
-class ChooserView(BaseView):
-    title = "Ubuntu Core"
+class ChooserView(ChooserBaseView):
     excerpt = ("Select one of available recovery systems and a desired "
                "action to execute.")
 
@@ -123,8 +130,8 @@ class ChooserView(BaseView):
         for s in systems:
             actions = []
             log.debug('actions: %s', s.actions)
-            for act in s.actions:
-                actions.append(Action(label=act.title,
+            for act in sorted(s.actions, key=by_preferred_action_type):
+                actions.append(Action(label=act.title.capitalize(),
                                       value=act,
                                       enabled=True))
             menu = ActionMenu(actions)
@@ -133,7 +140,7 @@ class ChooserView(BaseView):
                 Text(s.label),
                 Text(s.model.display_name),
                 Text(s.brand.display_name),
-                Text("(current)" if s.current else ""),
+                Text("(installed)" if s.current else ""),
                 menu,
             ], menu)
             trows.append(srow)
@@ -144,56 +151,67 @@ class ChooserView(BaseView):
             Pile([heading_table, systems_table]),
         ]
 
-        buttons = [
-            reset_btn("ABORT", on_press=self.abort),
-        ]
+        buttons = []
+        if controller.model.current is not None:
+            # back to options of current system
+            buttons.append(back_btn("BACK", on_press=self.back))
 
-        super().__init__(screen(
-            rows=rows,
-            buttons=button_pile(buttons),
-            focus_buttons=False,
-            excerpt=self.excerpt))
+        super().__init__(controller.model.current,
+                         screen(
+                             rows=rows,
+                             buttons=button_pile(buttons),
+                             focus_buttons=False,
+                             excerpt=self.excerpt))
 
     def _system_action(self, sender, action, system):
         self.controller.select(system, action)
 
-    def abort(self, result):
-        self.controller.cancel()
+    def back(self, result):
+        self.controller.back()
 
 
-class ChooserConfirmView(BaseView):
-    title = "Ubuntu Core"
-    excerpt = ("Summary of the selected action.")
+class ChooserConfirmView(ChooserBaseView):
+
+    canned_summary = {
+        "run": "Continue running the system without any changes.",
+        "recover": ("You have requested to reboot the system into recovery "
+                    "mode."),
+        "install": ("You are about to {action} the system version {version} "
+                    "for {model} from {publisher}.\n\n"
+                    "This will remove all existing user data on the "
+                    "device.\n\n"
+                    "The system will reboot in the process."),
+    }
+    default_summary = ("You are about to execute action \"{action}\" using "
+                       "system version {version} for device {model} from "
+                       "{publisher}.\n\n"
+                       "Make sure you understand the consequences of doing "
+                       "so.")
 
     def __init__(self, controller, selection):
         self.controller = controller
 
         buttons = [
             danger_btn("CONFIRM", on_press=self.confirm),
-            reset_btn("ABORT", on_press=self.abort),
+            back_btn("BACK", on_press=self.back),
         ]
-        using_summary = "System seed of device {} version {} from {}".format(
-                          selection.system.model.display_name,
-                          selection.system.label,
-                          selection.system.brand.display_name
-                      )
-        summary = [
-            TableRow([Text("Action:"), Color.info_error(Text(
-                selection.action.title))]),
-            TableRow([Text("Using:"), Text(using_summary)]),
-        ]
+        fmt = self.canned_summary.get(selection.action.mode,
+                                      self.default_summary)
+        summary = fmt.format(action=selection.action.title,
+                             model=selection.system.model.display_name,
+                             publisher=selection.system.brand.display_name,
+                             version=selection.system.label)
         rows = [
-            Pile([Text("")]),
-            Pile([TablePile(summary)])
+            Text(summary),
         ]
-        super().__init__(screen(
-            rows=rows,
-            buttons=button_pile(buttons),
-            focus_buttons=False,
-            excerpt=self.excerpt))
-
-    def abort(self, result):
-        self.controller.cancel()
+        super().__init__(controller.model.current,
+                         screen(
+                             rows=rows,
+                             buttons=button_pile(buttons),
+                             focus_buttons=False))
 
     def confirm(self, result):
         self.controller.confirm()
+
+    def back(self, result):
+        self.controller.back()

--- a/console_conf/ui/views/chooser.py
+++ b/console_conf/ui/views/chooser.py
@@ -185,8 +185,8 @@ class ChooserConfirmView(ChooserBaseView):
     default_summary = ("You are about to execute action \"{action}\" using "
                        "system version {version} for device {model} from "
                        "{publisher}.\n\n"
-                       "Make sure you understand the consequences of doing "
-                       "so.")
+                       "Make sure you understand the consequences of "
+                       "performing this action.")
 
     def __init__(self, controller, selection):
         self.controller = controller

--- a/console_conf/ui/views/tests/test_chooser.py
+++ b/console_conf/ui/views/tests/test_chooser.py
@@ -1,0 +1,43 @@
+# Copyright 2020 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import unittest
+
+from console_conf.models.systems import (
+    SystemAction,
+    )
+from console_conf.ui.views.chooser import (
+    by_preferred_action_type,
+    )
+
+
+class TestSorting(unittest.TestCase):
+
+    def test_simple(self):
+        data = [
+            SystemAction(title="b-other", mode="unknown"),
+            SystemAction(title="reinstall", mode="install"),
+            SystemAction(title="run normally", mode="run"),
+            SystemAction(title="a-other", mode="some-other"),
+            SystemAction(title="recover", mode="recover"),
+        ]
+        exp = [
+            SystemAction(title="run normally", mode="run"),
+            SystemAction(title="recover", mode="recover"),
+            SystemAction(title="reinstall", mode="install"),
+            SystemAction(title="a-other", mode="some-other"),
+            SystemAction(title="b-other", mode="unknown"),
+        ]
+        self.assertSequenceEqual(sorted(data, key=by_preferred_action_type),
+                                 exp)

--- a/console_conf/ui/views/welcome.py
+++ b/console_conf/ui/views/welcome.py
@@ -51,6 +51,13 @@ class WelcomeView(BaseView):
 
 class ChooserWelcomeView(WelcomeView):
     excerpt = (
-        "System recovery triggered. Proceed to select one of available "
-        "systems and execute a recovery action."
+        "System mode selection triggered. Proceed to select one of available "
+        "systems and actions."
     )
+
+    def __init__(self, controller):
+        current = controller.model.current
+        if current is not None:
+            self.title = current.model.display_name
+
+        super().__init__(controller)

--- a/console_conf/ui/views/welcome.py
+++ b/console_conf/ui/views/welcome.py
@@ -56,8 +56,8 @@ class ChooserWelcomeView(WelcomeView):
     )
 
     def __init__(self, controller):
+        super().__init__(controller)
+
         current = controller.model.current
         if current is not None:
             self.title = current.model.display_name
-
-        super().__init__(controller)

--- a/subiquitycore/core.py
+++ b/subiquitycore/core.py
@@ -310,7 +310,7 @@ class Application:
     #         "Identity",
     #         "InstallProgress",
     # ]
-    # The 'next_screen' and 'prev-screen' methods move through the list of
+    # The 'next_screen' and 'prev_screen' methods move through the list of
     # controllers in order, calling the start_ui method on the controller
     # instance.
 


### PR DESCRIPTION
A bunch of tweaks for the recovery chooser UI based on the discussion with @niemeyer.

Most important changes:
- drop the ABORT button
- introduce BACK button, goes back to the correct previous screen
- sort actions in the order of run -> recover -> install -> rest
- capitalize action title strings
- simplify current model actions screen
- user hints in the confirm screen for well known modes
- generic hint for unknown modes
- use model's display name in the top banner
- use `(installed)` instead of `(current)` in the all-systems screen for the current system
