### PR TITLE
do not include unreferenced devices in curtin storage config 

### DIFF
--- a/examples/answers-preserve.yaml
+++ b/examples/answers-preserve.yaml
@@ -1,0 +1,40 @@
+#machine-config: examples/existing-partitions.json
+Welcome:
+  lang: en_US
+Refresh:
+  update: no
+Keyboard:
+  layout: us
+Network:
+  accept-default: yes
+Proxy:
+  proxy: ""
+Mirror:
+  mirror: "http://us.archive.ubuntu.com"
+Filesystem:
+  manual:
+    - obj: [disk serial serial1, part 5]
+      action: EDIT
+      data:
+        fstype: ext4
+        mount: /
+    - action: done
+Identity:
+  realname: Ubuntu
+  username: ubuntu
+  hostname: ubuntu-server
+  # ubuntu
+  password: '$6$wdAcoXrU039hKYPd$508Qvbe7ObUnxoj15DRCkzC3qO7edjH0VV7BPNRDYK4QR8ofJaEEF2heacn0QgD.f8pO8SNp83XNdWG6tocBM1'
+SSH:
+  install_server: true
+  pwauth: false
+  authorized_keys:
+    - |
+      ssh-rsa AAAAAAAAAAAAAAAAAAAAAAAAA # ssh-import-id lp:subiquity
+SnapList:
+  snaps:
+    hello:
+      channel: stable
+      is_classic: false
+InstallProgress:
+  reboot: yes

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -6,8 +6,12 @@ for answers in examples/answers*.yaml; do
     rm -f .subiquity/subiquity-curtin-install.conf
     rm -f .subiquity/subiquity-debug.log
     rm -f .subiquity/run/subiquity/updating
+    config=$(sed -n 's/^#machine-config: \(.*\)/\1/p' $answers || true)
+    if [ -z "$config" ]; then
+        config=examples/simple.json
+    fi
     # The --foreground is important to avoid subiquity getting SIGTTOU-ed.
-    timeout --foreground 60 sh -c "LANG=C.UTF-8 python3 -m subiquity.cmd.tui --answers $answers --dry-run --snaps-from-examples --machine-config examples/simple.json"
+    timeout --foreground 60 sh -c "LANG=C.UTF-8 python3 -m subiquity.cmd.tui --answers $answers --dry-run --snaps-from-examples --machine-config $config"
     python3 scripts/validate-yaml.py .subiquity/subiquity-curtin-install.conf
     if [ ! -e .subiquity/subiquity-debug.log ]; then
         echo "log file not created"

--- a/scripts/validate-yaml.py
+++ b/scripts/validate-yaml.py
@@ -14,12 +14,11 @@ class StorageChecker:
     def _check_partition(self, action):
         assert 'device' in action
         assert 'size' in action
+        assert 'number' in action
         assert action['device'] in self.actions
         assert 'ptable' in self.actions[action['device']]
         if action['flag'] in ('boot', 'bios_grub', 'prep'):
             assert self.actions[action['device']]['type'] == 'disk'
-        if action.get('preserve', True):
-            assert 'number' in action
 
     def _check_format(self, action):
         assert 'volume' in action

--- a/scripts/validate-yaml.py
+++ b/scripts/validate-yaml.py
@@ -18,6 +18,8 @@ class StorageChecker:
         assert 'ptable' in self.actions[action['device']]
         if action['flag'] in ('boot', 'bios_grub', 'prep'):
             assert self.actions[action['device']]['type'] == 'disk'
+        if action.get('preserve', True):
+            assert 'number' in action
 
     def _check_format(self, action):
         assert 'volume' in action

--- a/subiquity/controllers/filesystem.py
+++ b/subiquity/controllers/filesystem.py
@@ -260,6 +260,8 @@ class FilesystemController(SubiquityController):
         if dev_spec[0] == "disk":
             if dev_spec[1] == "index":
                 dev = self.model.all_disks()[int(dev_spec[2])]
+            elif dev_spec[1] == "serial":
+                dev = self.model._one(type='disk', serial=dev_spec[2])
         elif dev_spec[0] == "raid":
             if dev_spec[1] == "name":
                 for r in self.model.all_raids():

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -1474,6 +1474,8 @@ class FilesystemModel(object):
         def can_emit(obj):
             for dep in dependencies(obj):
                 if dep.id not in emitted_ids:
+                    if dep not in work:
+                        work.append(dep)
                     return False
             if isinstance(obj, Mount):
                 # Any mount actions for a parent of this one have to be emitted
@@ -1491,7 +1493,10 @@ class FilesystemModel(object):
         mountpoints = {m.path: m.id for m in self.all_mounts()}
         log.debug('mountpoints %s', mountpoints)
 
-        work = self._actions[:]
+        work = [
+            a for a in self._actions
+            if not getattr(a, 'preserve', False)
+            ]
 
         while work:
             next_work = []

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -883,6 +883,7 @@ class Partition(_Formattable):
 
     wipe = attr.ib(default=None)
     flag = attr.ib(default=None)
+    number = attr.ib(default=None)
     preserve = attr.ib(default=False)
 
     @property
@@ -927,7 +928,10 @@ class Partition(_Formattable):
 
     @property
     def _number(self):
-        return self.device._partitions.index(self) + 1
+        if self.preserve:
+            return self.number
+        else:
+            return self.device._partitions.index(self) + 1
 
     supported_actions = [
         DeviceAction.EDIT,

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -1481,8 +1481,8 @@ class FilesystemModel(object):
         def can_emit(obj):
             for dep in dependencies(obj):
                 if dep.id not in emitted_ids:
-                    if dep not in work:
-                        work.append(dep)
+                    if dep not in work and dep not in next_work:
+                        next_work.append(dep)
                     return False
             if isinstance(obj, Mount):
                 # Any mount actions for a parent of this one have to be emitted
@@ -1512,7 +1512,7 @@ class FilesystemModel(object):
                     emit(obj)
                 else:
                     next_work.append(obj)
-            if len(next_work) == len(work):
+            if {a.id for a in next_work} == {a.id for a in work}:
                 msg = ["rendering block devices made no progress processing:"]
                 for w in work:
                     msg.append(" - " + str(w))

--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -926,6 +926,9 @@ class Partition(_Formattable):
             return True
         return self._fs._available()
 
+    def serialize_number(self):
+        return self._number
+
     @property
     def _number(self):
         if self.preserve:

--- a/subiquity/models/tests/test_filesystem.py
+++ b/subiquity/models/tests/test_filesystem.py
@@ -1072,3 +1072,17 @@ class TestAutoInstallConfig(unittest.TestCase):
             if action['id'] != disk1p1.id:
                 continue
             self.assertEqual(action['number'], 1)
+
+    def test_render_includes_unmounted_new_partition(self):
+        model = make_model(Bootloader.NONE)
+        disk1 = make_disk(model, preserve=True)
+        disk2 = make_disk(model)
+        disk1p1 = make_partition(model, disk1, preserve=True)
+        disk2p1 = make_partition(model, disk2)
+        fs = model.add_filesystem(disk1p1, 'ext4')
+        model.add_mount(fs, '/')
+        rendered_ids = {action['id'] for action in model._render_actions()}
+        self.assertTrue(disk1.id in rendered_ids)
+        self.assertTrue(disk1p1.id in rendered_ids)
+        self.assertTrue(disk2.id in rendered_ids)
+        self.assertTrue(disk2p1.id in rendered_ids)

--- a/subiquity/ui/views/filesystem/tests/test_partition.py
+++ b/subiquity/ui/views/filesystem/tests/test_partition.py
@@ -129,8 +129,8 @@ class PartitionViewTests(unittest.TestCase):
         partition = model.add_partition(disk, 512*(2**20))
         partition.preserve = True
         fs = model.add_filesystem(partition, "ext4")
-        fs.preserve = True
         model._orig_config = model._render_actions()
+        fs.preserve = True
         view, stretchy = make_partition_view(model, disk, partition)
         self.assertFalse(stretchy.form.size.enabled)
         self.assertTrue(stretchy.form.done_btn.enabled)


### PR DESCRIPTION
This also includes the fix for including the partition number in the config for preserved partitions, as we will quite often be not including some partitions in the config now.