### PR TITLE
Use apport hooks from snap

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -39,7 +39,7 @@ parts:
      - libc6
      - try:
        - efibootmgr
-  apport-data:
+  apport-hooks:
     plugin: nil
     stage-packages:
       - apport

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -39,6 +39,12 @@ parts:
      - libc6
      - try:
        - efibootmgr
+  apport-data:
+    plugin: nil
+    stage-packages:
+      - apport
+    stage:
+      - usr/share/apport/general-hooks/*
   subiquity:
     plugin: python
     build-packages:

--- a/subiquity/cmd/tui.py
+++ b/subiquity/cmd/tui.py
@@ -110,6 +110,7 @@ def main():
             os.path.join(snap, 'usr', 'bin'),
             os.environ['PATH'],
         ])
+        os.environ["APPORT_DATA_DIR"] = os.path.join(snap, 'usr/share/apport')
     opts = parse_options(sys.argv[1:])
     global LOGDIR
     if opts.dry_run:

--- a/subiquity/cmd/tui.py
+++ b/subiquity/cmd/tui.py
@@ -26,8 +26,6 @@ from cloudinit import atomic_helper, safeyaml, stages
 from subiquitycore.log import setup_logger
 from subiquitycore.utils import run_command
 
-from subiquity.core import Subiquity
-
 
 class ClickAction(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
@@ -111,6 +109,8 @@ def main():
             os.environ['PATH'],
         ])
         os.environ["APPORT_DATA_DIR"] = os.path.join(snap, 'usr/share/apport')
+    # This must come after setting $APPORT_DATA_DIR.
+    from subiquity.core import Subiquity
     opts = parse_options(sys.argv[1:])
     global LOGDIR
     if opts.dry_run:


### PR DESCRIPTION
This fixes https://bugs.launchpad.net/subiquity/+bug/1872349

It's slightly poor in that we now only run the apport hooks from apport in bionic, but at least we know that they work with the python3-apport code subiquity is using...