### PR TITLE
always emit actions for all partitions, even if otherwise unused

### DIFF
--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -1479,11 +1479,19 @@ class FilesystemModel(object):
             r.append(asdict(obj))
             emitted_ids.add(obj.id)
 
+        def ensure_partitions(dev):
+            for part in dev.partitions():
+                if part.id not in emitted_ids:
+                    if part not in work and part not in next_work:
+                        next_work.append(part)
+
         def can_emit(obj):
             for dep in dependencies(obj):
                 if dep.id not in emitted_ids:
                     if dep not in work and dep not in next_work:
                         next_work.append(dep)
+                        if dep.type in ['disk', 'raid']:
+                            ensure_partitions(dep)
                     return False
             if isinstance(obj, Mount):
                 # Any mount actions for a parent of this one have to be emitted

--- a/subiquity/models/tests/test_filesystem.py
+++ b/subiquity/models/tests/test_filesystem.py
@@ -1061,6 +1061,18 @@ class TestAutoInstallConfig(unittest.TestCase):
         self.assertTrue(disk2.id not in rendered_ids)
         self.assertTrue(disk2p1.id not in rendered_ids)
 
+    def test_render_includes_all_partitions(self):
+        model = make_model(Bootloader.NONE)
+        disk1 = make_disk(model, preserve=True)
+        disk1p1 = make_partition(model, disk1, preserve=True)
+        disk1p2 = make_partition(model, disk1, preserve=True)
+        fs = model.add_filesystem(disk1p2, 'ext4')
+        model.add_mount(fs, '/')
+        rendered_ids = {action['id'] for action in model._render_actions()}
+        self.assertTrue(disk1.id in rendered_ids)
+        self.assertTrue(disk1p1.id in rendered_ids)
+        self.assertTrue(disk1p2.id in rendered_ids)
+
     def test_render_numbers_existing_partitions(self):
         model = make_model(Bootloader.NONE)
         disk1 = make_disk(model, preserve=True)


### PR DESCRIPTION
curtin gets upset otherwise