### PR TITLE
subiquity: add --ssh option to print ssh login details.

### DIFF
--- a/console_conf/controllers/identity.py
+++ b/console_conf/controllers/identity.py
@@ -108,12 +108,7 @@ def write_login_details(fp, username, ips):
                                            first_ip=first_ip,
                                            version=version))
 
-
-def write_login_details_standalone():
-    owner = get_device_owner()
-    if owner is None:
-        print("No device owner details found.")
-        return 0
+def get_ips_standalone():
     from probert.prober import Prober
     from subiquitycore.models.network import NETDEV_IGNORED_IFACE_TYPES
     prober = Prober()
@@ -126,6 +121,15 @@ def write_login_details_standalone():
         for addr in l['addresses']:
             if addr['scope'] == "global":
                 ips.append(addr['address'].split('/')[0])
+    return ips
+
+
+def write_login_details_standalone():
+    owner = get_device_owner()
+    if owner is None:
+        print("No device owner details found.")
+        return 0
+    ips = get_ips_standalone()
     if len(ips) == 0:
         tty_name = os.ttyname(0)[5:]
         version = get_core_version() or "16"

--- a/console_conf/controllers/identity.py
+++ b/console_conf/controllers/identity.py
@@ -20,7 +20,7 @@ import shlex
 import sys
 
 from subiquitycore.controller import BaseController
-from subiquitycore.ssh import host_key_info
+from subiquitycore.ssh import host_key_info, get_ips_standalone
 from subiquitycore.utils import disable_console_conf, run_command
 
 from console_conf.ui.views import IdentityView, LoginView
@@ -107,21 +107,6 @@ def write_login_details(fp, username, ips):
                                            tty_name=tty_name,
                                            first_ip=first_ip,
                                            version=version))
-
-def get_ips_standalone():
-    from probert.prober import Prober
-    from subiquitycore.models.network import NETDEV_IGNORED_IFACE_TYPES
-    prober = Prober()
-    prober.probe_network()
-    links = prober.get_results()['network']['links']
-    ips = []
-    for l in sorted(links, key=lambda l: l['netlink_data']['name']):
-        if l['type'] in NETDEV_IGNORED_IFACE_TYPES:
-            continue
-        for addr in l['addresses']:
-            if addr['scope'] == "global":
-                ips.append(addr['address'].split('/')[0])
-    return ips
 
 
 def write_login_details_standalone():

--- a/subiquity/cmd/tui.py
+++ b/subiquity/cmd/tui.py
@@ -47,6 +47,9 @@ def parse_options(argv):
     parser.add_argument('--serial', action='store_true',
                         dest='run_on_serial',
                         help='Run the installer over serial console.')
+    parser.add_argument('--ssh', action='store_true',
+                        dest='ssh',
+                        help='Print ssh login details')
     parser.add_argument('--ascii', action='store_true',
                         dest='ascii',
                         help='Run the installer in ascii mode.')
@@ -159,6 +162,20 @@ def main():
     handler.addFilter(lambda rec: rec.name != 'probert.network')
     logging.getLogger('curtin').addHandler(handler)
     logging.getLogger('block-discover').addHandler(handler)
+
+    if opts.ssh:
+        from subiquity.ui.views.help import ssh_help_texts, get_installer_password
+        from console_conf.controllers.identity import get_ips_standalone
+        texts = ssh_help_texts(get_ips_standalone(), get_installer_password(opts.dry_run))
+        for line in texts:
+            if hasattr(line, 'text'):
+                if line.text.startswith('installer@'):
+                    print(' ' * 4 + line.text)
+                else:
+                    print(line.text)
+            else:
+                print(line)
+        return 0
 
     if opts.answers is None and os.path.exists(AUTO_ANSWERS_FILE):
         logger.debug("Autoloading answers from %s", AUTO_ANSWERS_FILE)

--- a/subiquity/cmd/tui.py
+++ b/subiquity/cmd/tui.py
@@ -164,9 +164,11 @@ def main():
     logging.getLogger('block-discover').addHandler(handler)
 
     if opts.ssh:
-        from subiquity.ui.views.help import ssh_help_texts, get_installer_password
-        from console_conf.controllers.identity import get_ips_standalone
-        texts = ssh_help_texts(get_ips_standalone(), get_installer_password(opts.dry_run))
+        from subiquity.ui.views.help import (
+            ssh_help_texts, get_installer_password)
+        from subiquitycore.ssh import get_ips_standalone
+        texts = ssh_help_texts(
+            get_ips_standalone(), get_installer_password(opts.dry_run))
         for line in texts:
             if hasattr(line, 'text'):
                 if line.text.startswith('installer@'):

--- a/subiquity/ui/views/help.py
+++ b/subiquity/ui/views/help.py
@@ -124,6 +124,32 @@ Unfortunately the installer was unable to detect the password that has
 been set.
 """)
 
+def ssh_help_texts(ips, password):
+
+    texts = [_(SSH_HELP_PROLOGUE), ""]
+
+    if len(ips) > 0:
+        if len(ips) > 1:
+            texts.append(rewrap(_(SSH_HELP_MULTIPLE_ADDRESSES)))
+            texts.append("")
+            for ip in ips:
+                texts.append(Text(
+                    "installer@" + str(ip), align='center'))
+        else:
+            texts.append(_(SSH_HELP_ONE_ADDRESSES).format(
+                ip=str(ips[0])))
+        texts.append("")
+        texts.append(
+            rewrap(_(SSH_HELP_EPILOGUE).format(
+                password=password)))
+        texts.append("")
+        texts.append(Text(host_key_info()))
+    else:
+        texts.append("")
+        texts.append(_(SSH_HELP_NO_ADDRESSES))
+
+    return texts
+
 
 class SimpleTextStretchy(Stretchy):
 
@@ -345,29 +371,9 @@ class HelpMenu(WidgetWrap):
         return ips
 
     def _ssh_help(self, sender=None):
-
-        texts = [_(SSH_HELP_PROLOGUE), ""]
-
-        ips = self.get_global_addresses()
-        if len(ips) > 0:
-            if len(ips) > 1:
-                texts.append(rewrap(_(SSH_HELP_MULTIPLE_ADDRESSES)))
-                texts.append("")
-                for ip in ips:
-                    texts.append(Text(
-                        "installer@" + str(ip), align='center'))
-            else:
-                texts.append(_(SSH_HELP_ONE_ADDRESSES).format(
-                    ip=str(ips[0])))
-            texts.append("")
-            texts.append(
-                rewrap(_(SSH_HELP_EPILOGUE).format(
-                    password=self.parent.ssh_password)))
-            texts.append("")
-            texts.append(Text(host_key_info()))
-        else:
-            texts.append("")
-            texts.append(_(SSH_HELP_NO_ADDRESSES))
+        texts = ssh_help_texts(
+            self.get_global_addresses(),
+            self.parent.ssh_password)
 
         self._show_overlay(
             SimpleTextStretchy(
@@ -405,9 +411,9 @@ class HelpMenu(WidgetWrap):
                 self.parent.app.ui.body))
 
 
-def get_installer_password(app):
-    if app.opts.dry_run:
-        fp = io.StringIO('installe:rAnd0Mpass')
+def get_installer_password(dry_run=False):
+    if dry_run:
+        fp = io.StringIO('installer:rAnd0Mpass')
     else:
         try:
             fp = open("/var/log/cloud-init-output.log")
@@ -437,7 +443,7 @@ class HelpButton(PopUpLauncher):
 
     def create_pop_up(self):
         if self.ssh_password is None:
-            self.ssh_password = get_installer_password(self.app)
+            self.ssh_password = get_installer_password(self.app.opts.dry_run)
         self._menu = HelpMenu(self)
         return self._menu
 

--- a/subiquity/ui/views/help.py
+++ b/subiquity/ui/views/help.py
@@ -124,6 +124,7 @@ Unfortunately the installer was unable to detect the password that has
 been set.
 """)
 
+
 def ssh_help_texts(ips, password):
 
     texts = [_(SSH_HELP_PROLOGUE), ""]

--- a/subiquitycore/ssh.py
+++ b/subiquitycore/ssh.py
@@ -75,3 +75,19 @@ def host_key_info():
                                           fingerprint=fingerprint,
                                           width=longest_type))
     return "".join(lines)
+
+
+def get_ips_standalone():
+    from probert.prober import Prober
+    from subiquitycore.models.network import NETDEV_IGNORED_IFACE_TYPES
+    prober = Prober()
+    prober.probe_network()
+    links = prober.get_results()['network']['links']
+    ips = []
+    for l in sorted(links, key=lambda l: l['netlink_data']['name']):
+        if l['type'] in NETDEV_IGNORED_IFACE_TYPES:
+            continue
+        for addr in l['addresses']:
+            if addr['scope'] == "global":
+                ips.append(addr['address'].split('/')[0])
+    return ips


### PR DESCRIPTION
Add --ssh option, which simply prints ssh login details and quits.

```
$ sudo python3 -m subiquity --ssh --dry-run

It is possible to connect to the installer over the network, which
might allow the use of a more capable terminal.

To connect, SSH to any of these addresses:

    installer@192.168.1.103
    installer@2a01:4b00:85fd:d700:c5d5:d33:cfd5:9062
    installer@2a01:4b00:85fd:d700:f17b:dafd:6e61:e6fb
    installer@fd00::c5d5:d33:cfd5:9062
    installer@fd00::f022:ccd1:f8de:53f5

The password you should use is "rAnd0Mpass".

The host key fingerprints are:

    RSA     SHA256:IcNSi/MT/PE3seH5SWYNKld31Quq8GW6K8Tzqt5gHtE
    ECDSA   SHA256:EvXsL7GMuLSjchGhN1oeZWlAsmIP3nimEazn00mr1sc
    ED25519 SHA256:iRM07uEWhq+uouCMRBSZHbeKkC6mT64JHmlyZE2DTnc
```

This is similar to console_conf write-login-details standalone, but uses (refactored) subiquity messaging.

This will be used on s390x to print this information on the line-based consoles.