### PR TITLE
ensure partitions are emitted in order

### DIFF
--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -1486,6 +1486,11 @@ class FilesystemModel(object):
                         next_work.append(part)
 
         def can_emit(obj):
+            if obj.type == "partition":
+                ensure_partitions(obj.device)
+                for p in obj.device.partitions():
+                    if p._number < obj._number and p.id not in emitted_ids:
+                        return False
             for dep in dependencies(obj):
                 if dep.id not in emitted_ids:
                     if dep not in work and dep not in next_work:

--- a/subiquity/ui/views/filesystem/tests/test_partition.py
+++ b/subiquity/ui/views/filesystem/tests/test_partition.py
@@ -128,6 +128,7 @@ class PartitionViewTests(unittest.TestCase):
         model, disk = make_model_and_disk()
         partition = model.add_partition(disk, 512*(2**20))
         partition.preserve = True
+        partition.number = 1
         fs = model.add_filesystem(partition, "ext4")
         model._orig_config = model._render_actions()
         fs.preserve = True


### PR DESCRIPTION
kinda ridiculous that this wasn't explicitly ensured before! it came up
with existing partitions and while I think it was probably unlikely to
happen with new ones, I'm not completely sure...