### PR TITLE
help: strip trailing newline from get_installer_password\n

### DIFF
--- a/subiquity/ui/views/help.py
+++ b/subiquity/ui/views/help.py
@@ -424,7 +424,7 @@ def get_installer_password(dry_run=False):
     with fp:
         for line in fp:
             if line.startswith("installer:"):
-                return line[len("installer:"):]
+                return line[len("installer:"):].strip()
 
     return None
 


### PR DESCRIPTION
ipdb> get_installer_password(opts.dry_run)
'f48BpRGUMSbYjA68nGdQ\n'

Because iterating file object's lines includes them.

LP: #1874009