### PR TITLE
snapcraft: inject curtin commit has into version

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -25,6 +25,10 @@ apps:
 
 parts:
   curtin:
+    override-pull: |
+      snapcraftctl pull
+      PACKAGED_VERSION="$(git describe --long --abbrev=9 --match=[0-9][0-9]*)"
+      sed -e "s,@@PACKAGED_VERSION@@,$PACKAGED_VERSION,g" -i curtin/version.py
     plugin: python
     source-type: git
     source: git://git.launchpad.net/curtin


### PR DESCRIPTION
All subiquity logs reference curtin's version which only captures the major.minor value.
For debs builds, the current commit hash is extracted and injected into the source via sed
so that the output at runtime includes a more specific version string identifying what
curtin content was provided.

This PR uses override-pull to inject this commit has in the version module of curtin.
I've done a snapcraft build with this, and confirmed that version.py gets the correct
value.