### PR TITLE
fix some autoinstall network oopses

### DIFF
--- a/examples/autoinstall.yaml
+++ b/examples/autoinstall.yaml
@@ -7,6 +7,13 @@ locale: en_UK.UTF-8
 refresh-installer:
   update: yes
   channel: edge
+network:
+  version: 2
+  ethernets:
+    all-eth:
+      match:
+        name: "eth*"
+      dhcp4: yes
 debconf-selections: eek
 packages:
   - package1

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -18,7 +18,7 @@ validate () {
 clean () {
     rm -f .subiquity/subiquity-curtin-install.conf
     rm -f .subiquity/subiquity-debug.log
-    rm -f .subiquity/run/subiquity/updating
+    rm -rf .subiquity/run/
 }
 
 export SUBIQUITY_REPLAY_TIMESCALE=100

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -1,17 +1,8 @@
 #!/bin/bash
 set -eux
 python3 -m unittest discover
-export SUBIQUITY_REPLAY_TIMESCALE=100
-for answers in examples/answers*.yaml; do
-    rm -f .subiquity/subiquity-curtin-install.conf
-    rm -f .subiquity/subiquity-debug.log
-    rm -f .subiquity/run/subiquity/updating
-    config=$(sed -n 's/^#machine-config: \(.*\)/\1/p' $answers || true)
-    if [ -z "$config" ]; then
-        config=examples/simple.json
-    fi
-    # The --foreground is important to avoid subiquity getting SIGTTOU-ed.
-    timeout --foreground 60 sh -c "LANG=C.UTF-8 python3 -m subiquity.cmd.tui --answers $answers --dry-run --snaps-from-examples --machine-config $config"
+
+validate () {
     python3 scripts/validate-yaml.py .subiquity/subiquity-curtin-install.conf
     if [ ! -e .subiquity/subiquity-debug.log ]; then
         echo "log file not created"
@@ -21,12 +12,33 @@ for answers in examples/answers*.yaml; do
         echo "password leaked into log file"
         exit 1
     fi
+    netplan generate --root .subiquity
+}
+
+clean () {
+    rm -f .subiquity/subiquity-curtin-install.conf
+    rm -f .subiquity/subiquity-debug.log
+    rm -f .subiquity/run/subiquity/updating
+}
+
+export SUBIQUITY_REPLAY_TIMESCALE=100
+for answers in examples/answers*.yaml; do
+    clean
+    config=$(sed -n 's/^#machine-config: \(.*\)/\1/p' $answers || true)
+    if [ -z "$config" ]; then
+        config=examples/simple.json
+    fi
+    # The --foreground is important to avoid subiquity getting SIGTTOU-ed.
+    timeout --foreground 60 sh -c "LANG=C.UTF-8 python3 -m subiquity.cmd.tui --answers $answers --dry-run --snaps-from-examples --machine-config $config"
+    validate
 done
+
 TTY=$(tty || true)
+clean
 timeout --foreground 60 sh -c "LANG=C.UTF-8 python3 -m subiquity.cmd.tui --autoinstall examples/autoinstall.yaml \
                                --dry-run --machine-config examples/simple.json \
                                --kernel-cmdline 'autoinstall console=\"${TTY#/dev/}\"'"
-python3 scripts/validate-yaml.py .subiquity/subiquity-curtin-install.conf
+validate
 python3 scripts/check-yaml-fields.py .subiquity/subiquity-curtin-install.conf \
         debconf_selections.subiquity='"eek"'
 python3 scripts/check-yaml-fields.py .subiquity/var/lib/cloud/seed/nocloud-net/user-data \
@@ -37,7 +49,8 @@ grep -q 'finish: subiquity/InstallProgress/postinstall/install_package2: SUCCESS
      .subiquity/subiquity-debug.log
 grep -q 'switching subiquity to edge' .subiquity/subiquity-debug.log
 
+clean
 timeout --foreground 60 sh -c "LANG=C.UTF-8 python3 -m subiquity.cmd.tui --autoinstall examples/autoinstall-user-data.yaml \
                                --dry-run --machine-config examples/simple.json \
                                --kernel-cmdline 'autoinstall console=\"${TTY#/dev/}\"'"
-python3 scripts/validate-yaml.py .subiquity/subiquity-curtin-install.conf
+validate

--- a/subiquity/controllers/network.py
+++ b/subiquity/controllers/network.py
@@ -96,6 +96,8 @@ class NetworkController(NetworkController, SubiquityController):
             self.app.make_apport_report(
                 ErrorReportKind.NETWORK_FAIL, "applying network",
                 interrupt=True)
+            if not self.interactive():
+                raise
 
     def done(self):
         self.configured()

--- a/subiquity/controllers/network.py
+++ b/subiquity/controllers/network.py
@@ -25,26 +25,60 @@ from subiquity.controllers.error import ErrorReportKind
 
 log = logging.getLogger("subiquity.controllers.network")
 
+MATCH = {
+    'type': 'object',
+    'properties': {
+        'name': {'type': 'string'},
+        'macaddress': {'type': 'string'},
+        'driver': {'type': 'string'},
+        },
+    'additionalProperties': False,
+    }
+
+NETPLAN_SCHEMA = {
+    'type': 'object',
+    'properties': {
+        'version': {
+            'type': 'integer',
+            'minimum': 2,
+            'maximum': 2,
+            },
+        'ethernets': {
+            'type': 'object',
+            'properties': {
+                'match': MATCH,
+                }
+            },
+        'wifis': {
+            'type': 'object',
+            'properties': {
+                'match': MATCH,
+                }
+            },
+        'bridges': {'type': 'object'},
+        'bonds': {'type': 'object'},
+        'tunnels': {'type': 'object'},
+        'vlans': {'type': 'object'},
+        },
+    'required': ['version'],
+    }
+
 
 class NetworkController(NetworkController, SubiquityController):
 
     ai_data = None
     autoinstall_key = "network"
     autoinstall_schema = {
-        'type': 'object',
-        'properties': {
-            'version': {
-                'type': 'integer',
-                'minimum': 2,
-                'maximum': 2,
-                },
-            'ethernets': {'type': 'object'},
-            'wifis': {'type': 'object'},
-            'bridges': {'type': 'object'},
-            'bonds': {'type': 'object'},
-            'tunnels': {'type': 'object'},
-            'vlans': {'type': 'object'},
+        'oneOf': [
+            NETPLAN_SCHEMA,
+            {
+                'type': 'object',
+                'properties': {
+                    'network': NETPLAN_SCHEMA,
+                    },
+                'required': ['network'],
             },
+            ],
         }
 
     def __init__(self, app):
@@ -52,7 +86,19 @@ class NetworkController(NetworkController, SubiquityController):
         app.note_file_for_apport("NetplanConfig", self.netplan_path)
 
     def load_autoinstall_data(self, data):
-        self.ai_data = data
+        if data is not None:
+            self.ai_data = data
+            # The version included with 20.04 accidentally required
+            # that you put:
+            #
+            # network:
+            #   network:
+            #     version: 2
+            #
+            # in your autoinstall config. Continue to support that for
+            # backwards compatibility.
+            if 'network' in self.ai_data:
+                self.ai_data = self.ai_data['network']
 
     def start(self):
         if self.ai_data is not None:
@@ -80,7 +126,7 @@ class NetworkController(NetworkController, SubiquityController):
                 # If we're interactive, we want later renders to
                 # incorporate any changes from the UI.
                 self.ai_data = None
-            return r
+            return {'network': r}
         return super().render_config()
 
     async def _apply_config(self, silent):

--- a/subiquity/core.py
+++ b/subiquity/core.py
@@ -462,7 +462,7 @@ class Subiquity(Application):
 
         report.add_info(_bg_attach_hook, wait)
 
-        if interrupt:
+        if interrupt and self.interactive():
             self.show_error_report(report)
 
         # In the fullness of time we should do the signature thing here.

--- a/subiquity/core.py
+++ b/subiquity/core.py
@@ -158,7 +158,9 @@ class Subiquity(Application):
         self.urwid_loop.screen.stop()
         cmdline = ['snap', 'run', 'subiquity']
         if self.opts.dry_run:
-            cmdline = [sys.executable] + sys.argv
+            cmdline = [
+                sys.executable, '-m', 'subiquity.cmd.tui',
+                ] + sys.argv[1:]
         os.execvp(cmdline[0], cmdline)
 
     def make_screen(self, input=None, output=None):


### PR DESCRIPTION
Mostly this is about allowing the config to look like this:

```
network:
 version: 2
 ethernets:
  eth0: {'dhcp4': True}
```

and not 

```
network:
 network:
  version: 2
  ethernets:
   eth0: {'dhcp4': True}
```

but there are also some fixes around handling netplan apply failures better