### PR TITLE
restart subiquity when snap refresh completes

### DIFF
--- a/subiquity/ui/views/refresh.py
+++ b/subiquity/ui/views/refresh.py
@@ -256,9 +256,9 @@ class RefreshView(BaseView):
                 self.update_failed(exc_message(e))
                 return
             if change['status'] == 'Done':
-                # Will only get here dry run mode as part of the refresh is us
-                # getting restarted by snapd...
-                self.done()
+                # Clearly if we got here we didn't get restarted by
+                # snapd/systemctl (dry-run mode or logged in via SSH)
+                self.controller.app.restart(remove_last_screen=False)
                 return
             if change['status'] not in ['Do', 'Doing']:
                 self.update_failed(change.get('err', "Unknown error"))

--- a/subiquitycore/controllers/network.py
+++ b/subiquitycore/controllers/network.py
@@ -125,9 +125,7 @@ network:
          name: "eth*"
        dhcp4: true
   wifis:
-    "all-wifi":
-       match:
-         name: "wl*"
+    "wlsp4":
        dhcp4: true
        access-points:
          "some-ap":


### PR DESCRIPTION
we usually do not get to this point, but we do when logged in via ssh.
see https://bugs.launchpad.net/subiquity/+bug/1874034

tested in a VM, seems to work