### PR TITLE
disable curtin networking entirely

### DIFF
--- a/subiquity/models/subiquity.py
+++ b/subiquity/models/subiquity.py
@@ -22,6 +22,7 @@ import sys
 import uuid
 import yaml
 
+from curtin.commands.install import CONFIG_BUILTIN
 from curtin.config import merge_config
 
 from subiquitycore.file_util import write_file
@@ -233,7 +234,15 @@ class SubiquityModel:
             return fp.read()
 
     def render(self, syslog_identifier):
+        # Until https://bugs.launchpad.net/curtin/+bug/1876984 gets
+        # fixed, the only way to get curtin to leave the network
+        # config entirely alone is to omit the 'network' stage.
+        stages = [
+            stage for stage in CONFIG_BUILTIN['stages'] if stage != 'network'
+            ]
         config = {
+            'stages': stages,
+
             'sources': {
                 'ubuntu00': 'cp:///media/filesystem'
                 },


### PR DESCRIPTION
this does not actually have much effect, because we write out a config file
that disables cloud-init networking anyway, but it is confusing to still have
a curtin-written cloud-init networking config too