### PR TITLE
attempt to make providing a good translation easier

### DIFF
--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -764,7 +764,7 @@ class Disk(_Device):
 
     def desc(self):
         if self.multipath:
-            return "multipath device"
+            return _("multipath device")
         return _("local disk")
 
     @property
@@ -889,27 +889,27 @@ class Partition(_Formattable):
             r.append("PReP")
             if self.preserve:
                 if self.grub_device:
-                    r.append("configured")
+                    r.append(_("configured"))
                 else:
-                    r.append("unconfigured")
+                    r.append(_("unconfigured"))
         elif self.flag == "boot":
             if self.fs() and self.fs().mount():
-                r.append("primary ESP")
+                r.append(_("primary ESP"))
             elif self.grub_device:
-                r.append("backup ESP")
+                r.append(_("backup ESP"))
             else:
-                r.append("unused ESP")
+                r.append(_("unused ESP"))
         elif self.flag == "bios_grub":
             if self.preserve:
                 if self.device.grub_device:
-                    r.append("configured")
+                    r.append(_("configured"))
                 else:
-                    r.append("unconfigured")
+                    r.append(_("unconfigured"))
             r.append("bios_grub")
         elif self.flag == "extended":
-            r.append("extended")
+            r.append(_("extended"))
         elif self.flag == "logical":
-            r.append("logical")
+            r.append(_("logical"))
         return r
 
     def usage_labels(self):
@@ -918,15 +918,16 @@ class Partition(_Formattable):
         return super().usage_labels()
 
     def desc(self):
-        return _("partition of {}").format(self.device.desc())
+        return _("partition of {device}").format(device=self.device.desc())
 
     @property
     def label(self):
-        return _("partition {} of {}").format(self._number, self.device.label)
+        return _("partition {number} of {device}").format(
+            number=self._number, device=self.device.label)
 
     @property
     def short_label(self):
-        return _("partition {}").format(self._number)
+        return _("partition {number}").format(number=self._number)
 
     def available(self):
         if self.flag in ['bios_grub', 'prep'] or self.grub_device:
@@ -1015,7 +1016,7 @@ class Raid(_Device):
         return self.name
 
     def desc(self):
-        return _("software RAID {}").format(self.raidlevel[4:])
+        return _("software RAID {level}").format(level=self.raidlevel[4:])
 
     supported_actions = [
         DeviceAction.EDIT,
@@ -1083,7 +1084,7 @@ class LVM_VolGroup(_Device):
         r = super().annotations
         member = next(iter(self.devices))
         if member.type == "dm_crypt":
-            r.append("encrypted")
+            r.append(_("encrypted"))
         return r
 
     @property
@@ -1091,7 +1092,7 @@ class LVM_VolGroup(_Device):
         return self.name
 
     def desc(self):
-        return "LVM volume group"
+        return _("LVM volume group")
 
     supported_actions = [
         DeviceAction.EDIT,
@@ -1144,7 +1145,7 @@ class LVM_LogicalVolume(_Formattable):
         return None  # hack!
 
     def desc(self):
-        return "LVM logical volume"
+        return _("LVM logical volume")
 
     @property
     def short_label(self):

--- a/subiquity/ui/views/filesystem/delete.py
+++ b/subiquity/ui/views/filesystem/delete.py
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from gettext import ngettext
 import logging
 from urwid import Text
 
@@ -58,17 +59,16 @@ class ConfirmDeleteStretchy(Stretchy):
         elif hasattr(obj, 'partitions') and len(obj.partitions()) > 0:
             n = len(obj.partitions())
             if obj.type == "lvm_volgroup":
-                if n == 1:
-                    things = _("logical volume")
-                else:
-                    things = _("logical volumes")
+                line = ngettext(
+                    _("It contains 1 logical volume"),
+                    _("It contains {n} logical volumes"),
+                    n)
             else:
-                if n == 1:
-                    things = _("partition")
-                else:
-                    things = _("partitions")
-            lines.append(Text(_("It contains {n} {things}:").format(
-                n=n, things=things)))
+                line = ngettext(
+                    _("It contains 1 partition"),
+                    _("It contains {n} partitions"),
+                    n)
+            lines.append(Text(line.format(n=n)))
             lines.append(Text(""))
             stretchy_index = len(lines)
             rows = []

--- a/subiquity/ui/views/filesystem/filesystem.py
+++ b/subiquity/ui/views/filesystem/filesystem.py
@@ -95,9 +95,9 @@ class MountInfo:
     def fstype(self):
         fstype = self.mount.device.fstype
         if self.mount.device.preserve:
-            fstype = "existing" + " " + fstype
+            fstype = _("existing {fstype}").format(fstype=fstype)
         else:
-            fstype = "new" + " " + fstype
+            fstype = _("new {fstype}").format(fstype=fstype)
         return fstype
 
     @property
@@ -317,13 +317,13 @@ class DeviceList(WidgetWrap):
     def _label_REMOVE(self, action, device):
         cd = device.constructed_device()
         if cd:
-            return _("Remove from {}").format(cd.desc())
+            return _("Remove from {device}").format(device=cd.desc())
         else:
             return _(action.value)
 
     def _label_PARTITION(self, action, device):
-        return _("Add {} Partition").format(
-            device.ptable_for_new_partition().upper())
+        return _("Add {ptype} Partition").format(
+            ptype=device.ptable_for_new_partition().upper())
 
     def _label_TOGGLE_BOOT(self, action, device):
         if device._is_boot_device():
@@ -478,7 +478,7 @@ class FilesystemView(BaseView):
             return None
         rows = [
             TableRow([
-                Text("To continue you need to:"),
+                Text(_("To continue you need to:")),
                 Text(todos[0]),
                 ]),
             ]

--- a/subiquity/ui/views/filesystem/guided.py
+++ b/subiquity/ui/views/filesystem/guided.py
@@ -199,12 +199,12 @@ class GuidedDiskSelectionView (BaseView):
         elif found_disk:
             super().__init__(
                 screen(
-                    [Text(_(rewrap(no_big_disks)))],
+                    [Text(rewrap(_(no_big_disks)))],
                     [other_btn(_("OK"), on_press=self.manual)]))
         else:
             super().__init__(
                 screen(
-                    [Text(_(rewrap(no_disks)))],
+                    [Text(rewrap(_(no_disks)))],
                     []))
 
     def local_help(self):

--- a/subiquity/ui/views/filesystem/lvm.py
+++ b/subiquity/ui/views/filesystem/lvm.py
@@ -110,11 +110,11 @@ class VolGroupForm(CompoundDiskForm):
         if v.startswith('-'):
             return _("The name of a volume group cannot start with a hyphen")
         if v in ('.', '..', 'md') or os.path.exists('/dev/' + v):
-            return _("{} is not a valid name for a volume group").format(
-                v)
+            return _("{name} is not a valid name for a volume group").format(
+                name=v)
         if v in self.vg_names:
-            return _("There is already a volume group named '{}'").format(
-                self.name.value)
+            return _("There is already a volume group named '{name}'").format(
+                name=self.name.value)
 
     def validate_password(self):
         if self.encrypt.value and len(self.password.value) < 1:
@@ -147,7 +147,7 @@ class VolGroupStretchy(Stretchy):
                 }
         else:
             vg_names.remove(existing.name)
-            title = _('Edit volume group "{}"').format(existing.name)
+            title = _('Edit volume group "{name}"').format(name=existing.name)
             label = _('Save')
             devices = {}
             key = ""

--- a/subiquity/ui/views/filesystem/partition.py
+++ b/subiquity/ui/views/filesystem/partition.py
@@ -75,7 +75,8 @@ class FSTypeField(FormField):
                 (_('Leave unformatted'), True, None),
                 ]
         else:
-            label = _('Leave formatted as {}').format(form.existing_fs_type)
+            label = _('Leave formatted as {fstype}').format(
+                fstype=form.existing_fs_type)
             options = [
                 (label, True, None),
                 ('---', False),
@@ -107,13 +108,15 @@ class SizeWidget(StringEditor):
             self.value = self.form.size_str
             self.form.size.show_extra(
                 ('info_minor',
-                 _("Capped partition size at {}").format(self.form.size_str)))
+                 _("Capped partition size at {size}").format(
+                     size=self.form.size_str)))
         elif (align_up(sz) != sz and
               humanize_size(align_up(sz)) != self.form.size.value):
             sz_str = humanize_size(align_up(sz))
             self.value = sz_str
             self.form.size.show_extra(
-                ('info_minor', _("Rounded size up to {}").format(sz_str)))
+                ('info_minor', _("Rounded size up to {size}").format(
+                    size=sz_str)))
 
 
 class SizeField(FormField):
@@ -158,7 +161,8 @@ class PartitionForm(Form):
         self.max_size = max_size
         if max_size is not None:
             self.size_str = humanize_size(max_size)
-            self.size.caption = _("Size (max {}):").format(self.size_str)
+            self.size.caption = _("Size (max {size}):").format(
+                size=self.size_str)
         self.lvm_names = lvm_names
         super().__init__(initial)
         if max_size is None:
@@ -248,17 +252,18 @@ class PartitionForm(Form):
             return _('Path exceeds PATH_MAX')
         dev = self.mountpoints.get(mount)
         if dev is not None:
-            return _("{} is already mounted at {}.").format(
-                dev.label.title(), mount)
+            return _("{device} is already mounted at {path}.").format(
+                device=dev.label.title(), path=mount)
         if self.existing_fs_type is not None:
             if self.fstype.value is None:
                 if mount in common_mountpoints:
                     if mount not in suitable_mountpoints_for_existing_fs:
                         self.mount.show_extra(
                             ('info_error',
-                             _("Mounting an existing filesystem at {} is "
-                               "usually a bad idea, proceed only with "
-                               "caution.").format(mount)))
+                             _("Mounting an existing filesystem at "
+                               "{mountpoint} is usually a bad idea, "
+                               "proceed only with caution.").format(
+                                   mountpoint=mount)))
 
     def as_rows(self):
         r = super().as_rows()
@@ -499,17 +504,23 @@ class PartitionStretchy(Stretchy):
 
         if partition is None:
             if isinstance(disk, LVM_VolGroup):
-                add_name = _("logical volume")
+                title = _("Adding logical volume to {vgname}").format(
+                    vgname=disk.label)
             else:
-                add_name = _("{} partition").format(
-                    disk.ptable_for_new_partition().upper())
-            title = _("Adding {} to {}").format(add_name, disk.label)
+                title = _("Adding {ptype} partition to {device}").format(
+                    ptype=disk.ptable_for_new_partition().upper(),
+                    device=disk.label)
         else:
             if isinstance(disk, LVM_VolGroup):
-                desc = _("logical volume {}").format(partition.name)
+                title = _(
+                    "Editing logical volume {lvname} of {vgname}"
+                    ).format(
+                        lvname=partition.name,
+                        vgname=disk.label)
             else:
-                desc = partition.short_label
-            title = _("Editing {} of {}").format(desc, disk.label)
+                title = _("Editing partition {number} of {device}").format(
+                    number=partition.number,
+                    device=disk.label)
 
         super().__init__(title, widgets, 0, focus_index)
 

--- a/subiquity/ui/views/filesystem/probing.py
+++ b/subiquity/ui/views/filesystem/probing.py
@@ -73,7 +73,7 @@ class ProbingFailed(BaseView):
             Text(_(fail_text)),
             Text(""),
             button_pile(
-                [other_btn("Show Error Report", on_press=self.show_error)]),
+                [other_btn(_("Show Error Report"), on_press=self.show_error)]),
             ],
             [other_btn(_("Back"), on_press=self.cancel)]))
 

--- a/subiquity/ui/views/filesystem/raid.py
+++ b/subiquity/ui/views/filesystem/raid.py
@@ -110,8 +110,10 @@ class RaidForm(CompoundDiskForm):
         active_device_count = len(self.devices.widget.active_devices)
         if active_device_count < self.level.value.min_devices:
             return _(
-                'RAID Level "{}" requires at least {} active devices').format(
-                self.level.value.name, self.level.value.min_devices)
+                'RAID Level "{level}" requires at least {min_active} active'
+                ' devices').format(
+                    level=self.level.value.name,
+                    min_active=self.level.value.min_devices)
         return super().validate_devices()
 
 
@@ -137,7 +139,8 @@ class RaidStretchy(Stretchy):
                 }
         else:
             raid_names.remove(existing.name)
-            title = _('Edit software RAID disk "{}"').format(existing.name)
+            title = _('Edit software RAID disk "{name}"').format(
+                name=existing.name)
             label = _('Save')
             name = existing.name
             if name.startswith('md/'):

--- a/subiquity/ui/views/refresh.py
+++ b/subiquity/ui/views/refresh.py
@@ -196,7 +196,7 @@ class RefreshView(BaseView):
         self.spinner.stop()
 
         rows = [
-            Text("You can read the release notes for each version at:"),
+            Text(_("You can read the release notes for each version at:")),
             Text(""),
             Text(
                 "https://github.com/CanonicalLtd/subiquity/releases",
@@ -238,7 +238,7 @@ class RefreshView(BaseView):
             other_btn(_("Cancel update"), on_press=self.check_state_available),
             ]
 
-        self.controller.ui.set_header("Downloading update...")
+        self.controller.ui.set_header(_(self.progress_title))
         self._w = screen(
             self.lb_tasks, buttons, excerpt=_(self.progress_excerpt))
         schedule_task(self._update())

--- a/subiquity/ui/views/snaplist.py
+++ b/subiquity/ui/views/snaplist.py
@@ -141,21 +141,21 @@ class SnapInfoView(WidgetWrap):
         first_info_row = TableRow([
             (3, Text(
                 [
-                    ('info_minor', "LICENSE: "),
+                    ('info_minor', _("LICENSE: ")),
                     snap.license,
                 ], wrap='clip')),
             (3, Text(
                 [
-                    ('info_minor', "LAST UPDATED: "),
+                    ('info_minor', _("LAST UPDATED: ")),
                     format_datetime(latest_update),
                 ])),
             ])
         heading_row = Color.info_minor(TableRow([
-            Text("CHANNEL"),
-            (2, Text("VERSION")),
-            Text("SIZE"),
-            Text("PUBLISHED"),
-            Text("CONFINEMENT"),
+            Text(_("CHANNEL")),
+            (2, Text(_("VERSION"))),
+            Text(_("SIZE")),
+            Text(_("PUBLISHED")),
+            Text(_("CONFINEMENT")),
             ]))
         colspecs = {
             1: ColSpec(can_shrink=True),
@@ -173,7 +173,7 @@ class SnapInfoView(WidgetWrap):
         info_table.bind(self.lb_channels)
         self.info_padding = Padding.pull_1(info_table)
 
-        publisher = [('info_minor', "by: "), snap.publisher]
+        publisher = [('info_minor', _("by: ")), snap.publisher]
         if snap.verified:
             publisher.append(('verified', ' \N{check mark}'))
 

--- a/subiquity/ui/views/ssh.py
+++ b/subiquity/ui/views/ssh.py
@@ -71,18 +71,18 @@ _ssh_import_data = {
         },
     'gh': {
         'caption': _("Github Username:"),
-        'help': "Enter your Github username.",
+        'help': _("Enter your Github username."),
         'valid_char': r'[a-zA-Z0-9\-]',
-        'error_invalid_char': ('A Github username may only contain '
-                               'alphanumeric characters or hyphens.'),
+        'error_invalid_char': _('A Github username may only contain '
+                                'alphanumeric characters or hyphens.'),
         },
     'lp': {
         'caption': _("Launchpad Username:"),
         'help': "Enter your Launchpad username.",
         'valid_char': r'[a-z0-9\+\.\-]',
-        'error_invalid_char': ('A Launchpad username may only contain '
-                               'lower-case alphanumeric characters, hyphens, '
-                               'plus, or periods.'),
+        'error_invalid_char': _('A Launchpad username may only contain '
+                                'lower-case alphanumeric characters, hyphens, '
+                                'plus, or periods.'),
         },
     }
 

--- a/subiquitycore/ui/form.py
+++ b/subiquitycore/ui/form.py
@@ -173,7 +173,7 @@ class BoundFormField(object):
             first_row = [(2, _Validator(self, widget))]
             second_row = [(2, self.under_text)]
         else:
-            self.caption_text = Text(self.field.caption)
+            self.caption_text = Text(_(self.field.caption))
 
             if self.field.caption_first:
                 self.caption_text.align = 'right'
@@ -265,7 +265,10 @@ class BoundFormField(object):
         if self._help is not None:
             return self._help
         elif self.field.help is not None:
-            return self.field.help
+            if isinstance(self.field.help, str):
+                return _(self.field.help)
+            else:
+                return self.field.help
         else:
             return ""
 

--- a/subiquitycore/ui/selector.py
+++ b/subiquitycore/ui/selector.py
@@ -141,7 +141,7 @@ class Option:
         else:
             raise SelectorError("invalid option %r", val)
         if isinstance(self.label, str):
-            self.label = Text(self.label)
+            self.label = Text(_(self.label))
 
 
 class _Launcher(PopUpLauncher):

--- a/subiquitycore/ui/views/network.py
+++ b/subiquitycore/ui/views/network.py
@@ -120,7 +120,7 @@ class NetworkView(BaseView):
             rows=rows,
             buttons=self.bottom,
             focus_buttons=True,
-            excerpt=self.excerpt))
+            excerpt=_(self.excerpt)))
 
     _action_INFO = _stretchy_shower(ViewInterfaceInfo)
     _action_EDIT_WLAN = _stretchy_shower(NetworkConfigureWLANStretchy)
@@ -184,7 +184,8 @@ class NetworkView(BaseView):
             if dev2.type != "bond":
                 continue
             if dev.name in dev2.config.get('interfaces', []):
-                notes.append(_("enslaved to {}").format(dev2.name))
+                notes.append(
+                    _("enslaved to {device}").format(device=dev2.name))
                 break
         if notes:
             notes = ", ".join(notes)
@@ -214,7 +215,9 @@ class NetworkView(BaseView):
                 else:
                     address_info.append((
                         label,
-                        Text(_("unknown state {}".format(dev.dhcp_state(v))))
+                        Text(
+                            _("unknown state {state}".format(
+                                state=dev.dhcp_state(v))))
                         ))
             else:
                 addrs = []
@@ -352,8 +355,8 @@ class NetworkView(BaseView):
             info = _("VLAN {id} on interface {link}").format(
                 **dev.config)
         elif dev.type == "bond":
-            info = _("bond master for {}").format(
-                ', '.join(dev.config['interfaces']))
+            info = _("bond master for {interfaces}").format(
+                interfaces=', '.join(dev.config['interfaces']))
         else:
             info = " / ".join([
                 dev.info.hwaddr, dev.info.vendor, dev.info.model])

--- a/subiquitycore/ui/views/network_configure_manual_interface.py
+++ b/subiquitycore/ui/views/network_configure_manual_interface.py
@@ -99,7 +99,8 @@ class NetworkConfigForm(Form):
                 example = "xx.xx.xx.xx/yy"
             else:
                 example = "xx:xx:..:xx/yy"
-            raise ValueError(_("should be in CIDR form ({})").format(example))
+            raise ValueError(_("should be in CIDR form ({example})").format(
+                example=example))
         return self.ip_network_cls(subnet)
 
     def clean_address(self, address):
@@ -327,7 +328,7 @@ class ViewInterfaceInfo(Stretchy):
             Text(""),
             button_pile([done_btn(_("Close"), on_press=self.close)]),
             ]
-        title = _("Info for {}").format(device.name)
+        title = _("Info for {device}").format(device=device.name)
         super().__init__(title, widgets, 0, 2)
 
     def close(self, button=None):
@@ -399,8 +400,8 @@ class BondForm(Form):
         name = self.name.value
         if name in self.all_netdev_names:
             return _(
-                'There is already a network device named "{}"'
-                ).format(name)
+                'There is already a network device named "{netdev}"'
+                ).format(netdev=name)
         if len(name) == 0:
             return _("Name cannot be empty")
         if len(name) > 16:

--- a/subiquitycore/ui/views/network_configure_wlan_interface.py
+++ b/subiquitycore/ui/views/network_configure_wlan_interface.py
@@ -34,7 +34,7 @@ class NetworkList(WidgetWrap):
                      for ssid in ssids if ssid]
         p = Pile([BoxAdapter(ListBox(ssid_list), height=10),
                   Padding.fixed_10(button)])
-        box = LineBox(p, title="Select a network")
+        box = LineBox(p, title=_("Select a network"))
         super().__init__(box)
 
     def do_network(self, sender):
@@ -66,8 +66,8 @@ class NetworkConfigureWLANStretchy(Stretchy):
     def __init__(self, parent, device):
         self.parent = parent
         self.device = device
-        title = _("Network interface {} WIFI configuration").format(
-            device.name)
+        title = _("Network interface {nic} WIFI configuration").format(
+            nic=device.name)
 
         self.form = WLANForm()
 


### PR DESCRIPTION
 * annotate a few missed string literals with _()
 * try to consistently use named placeholders when formatting strings
   for display (i.e. _("frob the {thing}") not _("frob the {}")
 * run selector values, form captions and form help through _() before
   display
 * use ngettext in one place. not sure if there need to be more...
 * reduce cuteness about how strings are constructed in a few places