### PR TITLE
do not generate a crash report if we are not in a live session

### DIFF
--- a/subiquity/controllers/filesystem.py
+++ b/subiquity/controllers/filesystem.py
@@ -161,7 +161,8 @@ class FilesystemController(SubiquityController):
                         "block probing failed restricted=%s", restricted)
                     report = self.app.make_apport_report(
                         kind, "block probing", interrupt=False)
-                    self._crash_reports[restricted] = report
+                    if report is not None:
+                        self._crash_reports[restricted] = report
                     continue
                 break
 

--- a/subiquity/controllers/installprogress.py
+++ b/subiquity/controllers/installprogress.py
@@ -153,7 +153,8 @@ class InstallProgressController(SubiquityController):
         self.progress_view.set_status(('info_error',
                                        _("An error has occurred")))
         self.start_ui()
-        self.progress_view.show_error(crash_report)
+        if crash_report is not None:
+            self.progress_view.show_error(crash_report)
 
     def logged_command(self, cmd):
         return ['systemd-cat', '--level-prefix=false',

--- a/subiquity/core.py
+++ b/subiquity/core.py
@@ -274,7 +274,8 @@ class Subiquity(Application):
                 report = self.make_apport_report(
                     ErrorReportKind.UI, "Installer UI", interrupt=False,
                     wait=True)
-                print("report saved to {}".format(report.path))
+                if report is not None:
+                    print("report saved to {}".format(report.path))
             except Exception:
                 print("report generation failed")
                 traceback.print_exc()
@@ -457,6 +458,9 @@ class Subiquity(Application):
         self._apport_data.append((key, value))
 
     def make_apport_report(self, kind, thing, *, interrupt, wait=False, **kw):
+        if not self.opts.dry_run and not os.path.exists('/cdrom/.disk/info'):
+            return None
+
         log.debug("generating crash report")
 
         try:


### PR DESCRIPTION
Some people for whatever reason have subiquity installed on their systems
and their error reports flood the tracker.