### PR TITLE
allow keyboard/toggle to be null

### DIFF
--- a/subiquity/controllers/keyboard.py
+++ b/subiquity/controllers/keyboard.py
@@ -35,7 +35,7 @@ class KeyboardController(SubiquityController):
         'properties': {
             'layout': {'type': 'string'},
             'variant': {'type': 'string'},
-            'toggle': {'type': 'string'},
+            'toggle': {'type': ['string', 'null']},
             },
         'required': ['layout'],
         'additionalProperties': False,


### PR DESCRIPTION
Documentation allows toggle to be null and it's the default value.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>