### PR TITLE
console-conf: always run when triggered for the chooser

### DIFF
--- a/bin/console-conf-wrapper
+++ b/bin/console-conf-wrapper
@@ -17,6 +17,9 @@ if [ -e /run/snapd-recovery-chooser-triggered ]; then
         # when recovery chooser is invoked it takes over the terminal
         exec /usr/lib/snapd/snap-recovery-chooser
     fi
+    if [ -e /var/lib/console-conf/complete ]; then
+        exit 0
+    fi
 fi
 
 if grep -q 'snapd_recovery_mode=install' /proc/cmdline ; then

--- a/debian/console-conf.console-conf@.service
+++ b/debian/console-conf.console-conf@.service
@@ -10,7 +10,8 @@ After=core18.start-snapd.service core.start-snapd.service
 After=snapd.recovery-chooser-trigger.service
 IgnoreOnIsolate=yes
 ConditionPathExists=/dev/tty0
-ConditionPathExists=!/var/lib/console-conf/complete
+ConditionPathExists=|!/var/lib/console-conf/complete
+ConditionPathExists=|/run/snapd-recovery-chooser-triggered
 StartLimitInterval=0
 
 [Service]


### PR DESCRIPTION
Use triggering conditions for controlling when console-conf should run. We effectively want it to start if there is no `/var/lib/console-conf/complete` file *or* the snapd recovery marker file exists. 

By converting both conditions into triggers we ensure that console-conf will run the recovery chooser even when console-conf is soft-disabled.

This unblocks https://github.com/snapcore/snapd/pull/8661