### PR TITLE
console-conf-wrapper: show snapd log during install

### DIFF
--- a/bin/console-conf-wrapper
+++ b/bin/console-conf-wrapper
@@ -21,6 +21,9 @@ fi
 
 if grep -q 'snapd_recovery_mode=install' /proc/cmdline ; then
     echo "Installing the system, please wait for reboot"
+    snap watch --last=install-system || true
+    snap change --last=install-system || true
+    journalctl -u snapd.service -f
     sleep infinity
 fi
 

--- a/bin/console-conf-wrapper
+++ b/bin/console-conf-wrapper
@@ -21,8 +21,7 @@ fi
 
 if grep -q 'snapd_recovery_mode=install' /proc/cmdline ; then
     echo "Installing the system, please wait for reboot"
-    snap watch --last=install-system || true
-    snap change --last=install-system || true
+    # XXX: replace with something more user friendly after the beta?
     journalctl -u snapd.service -f
     sleep infinity
 fi


### PR DESCRIPTION
This will help finding some of the current install problems by
showing the snapd log on the terminal during the install.