### PR TITLE
Normalise messages to consistently use "GitHub"

### DIFF
--- a/po/ast.po
+++ b/po/ast.po
@@ -1603,7 +1603,7 @@ msgid "Import Username:"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:73
-msgid "Github Username:"
+msgid "GitHub Username:"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:80
@@ -1619,7 +1619,7 @@ msgid "Import SSH identity:"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:98
-msgid "from Github"
+msgid "from GitHub"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:99
@@ -1627,7 +1627,7 @@ msgid "from Launchpad"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from Github or Launchpad."
+msgid "You can import your SSH keys from GitHub or Launchpad."
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:105
@@ -1651,7 +1651,7 @@ msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:150
 msgid ""
-"A Github username may only contain alphanumeric characters or single "
+"A GitHub username may only contain alphanumeric characters or single "
 "hyphens, and cannot begin or end with a hyphen."
 msgstr ""
 

--- a/po/be.po
+++ b/po/be.po
@@ -1603,7 +1603,7 @@ msgid "Import Username:"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:73
-msgid "Github Username:"
+msgid "GitHub Username:"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:80
@@ -1619,7 +1619,7 @@ msgid "Import SSH identity:"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:98
-msgid "from Github"
+msgid "from GitHub"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:99
@@ -1627,7 +1627,7 @@ msgid "from Launchpad"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from Github or Launchpad."
+msgid "You can import your SSH keys from GitHub or Launchpad."
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:105
@@ -1651,7 +1651,7 @@ msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:150
 msgid ""
-"A Github username may only contain alphanumeric characters or single "
+"A GitHub username may only contain alphanumeric characters or single "
 "hyphens, and cannot begin or end with a hyphen."
 msgstr ""
 

--- a/po/bo.po
+++ b/po/bo.po
@@ -1603,7 +1603,7 @@ msgid "Import Username:"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:73
-msgid "Github Username:"
+msgid "GitHub Username:"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:80
@@ -1619,7 +1619,7 @@ msgid "Import SSH identity:"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:98
-msgid "from Github"
+msgid "from GitHub"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:99
@@ -1627,7 +1627,7 @@ msgid "from Launchpad"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from Github or Launchpad."
+msgid "You can import your SSH keys from GitHub or Launchpad."
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:105
@@ -1651,7 +1651,7 @@ msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:150
 msgid ""
-"A Github username may only contain alphanumeric characters or single "
+"A GitHub username may only contain alphanumeric characters or single "
 "hyphens, and cannot begin or end with a hyphen."
 msgstr ""
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -1604,7 +1604,7 @@ msgid "Import Username:"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:73
-msgid "Github Username:"
+msgid "GitHub Username:"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:80
@@ -1620,15 +1620,15 @@ msgid "Import SSH identity:"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:98
-msgid "from Github"
-msgstr "des de Github"
+msgid "from GitHub"
+msgstr "des de GitHub"
 
 #: ../subiquity/ui/views/ssh.py:99
 msgid "from Launchpad"
 msgstr "des de Launchpad"
 
 #: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from Github or Launchpad."
+msgid "You can import your SSH keys from GitHub or Launchpad."
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:105
@@ -1652,7 +1652,7 @@ msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:150
 msgid ""
-"A Github username may only contain alphanumeric characters or single "
+"A GitHub username may only contain alphanumeric characters or single "
 "hyphens, and cannot begin or end with a hyphen."
 msgstr ""
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -1790,8 +1790,8 @@ msgid "Import Username:"
 msgstr "Uživatelské jméno importu:"
 
 #: ../subiquity/ui/views/ssh.py:73
-msgid "Github Username:"
-msgstr "Github uživatelské jméno:"
+msgid "GitHub Username:"
+msgstr "GitHub uživatelské jméno:"
 
 #: ../subiquity/ui/views/ssh.py:80
 msgid "Launchpad Username:"
@@ -1806,16 +1806,16 @@ msgid "Import SSH identity:"
 msgstr "Importovat SSH identitu:"
 
 #: ../subiquity/ui/views/ssh.py:98
-msgid "from Github"
-msgstr "z účtu na Github"
+msgid "from GitHub"
+msgstr "z účtu na GitHub"
 
 #: ../subiquity/ui/views/ssh.py:99
 msgid "from Launchpad"
 msgstr "z účtu na Launchpad"
 
 #: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from Github or Launchpad."
-msgstr "Můžete importovat své SSH klíče z portálů Github nebo Launchpad."
+msgid "You can import your SSH keys from GitHub or Launchpad."
+msgstr "Můžete importovat své SSH klíče z portálů GitHub nebo Launchpad."
 
 #: ../subiquity/ui/views/ssh.py:105
 msgid "Allow password authentication over SSH"
@@ -1841,10 +1841,10 @@ msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:150
 msgid ""
-"A Github username may only contain alphanumeric characters or single "
+"A GitHub username may only contain alphanumeric characters or single "
 "hyphens, and cannot begin or end with a hyphen."
 msgstr ""
-"Github uživatelské jméno může obsahovat pouze písmena a číslice a jednotlivé "
+"GitHub uživatelské jméno může obsahovat pouze písmena a číslice a jednotlivé "
 "spojovníky a nemůže začínat nebo končit na spojovník."
 
 #: ../subiquity/ui/views/ssh.py:160

--- a/po/de.po
+++ b/po/de.po
@@ -1701,8 +1701,8 @@ msgid "Import Username:"
 msgstr "Importiere Benutzername:"
 
 #: ../subiquity/ui/views/ssh.py:73
-msgid "Github Username:"
-msgstr "Github-Benutzername:"
+msgid "GitHub Username:"
+msgstr "GitHub-Benutzername:"
 
 #: ../subiquity/ui/views/ssh.py:80
 msgid "Launchpad Username:"
@@ -1717,16 +1717,16 @@ msgid "Import SSH identity:"
 msgstr "SSH-Identität importieren:"
 
 #: ../subiquity/ui/views/ssh.py:98
-msgid "from Github"
-msgstr "aus Github"
+msgid "from GitHub"
+msgstr "aus GitHub"
 
 #: ../subiquity/ui/views/ssh.py:99
 msgid "from Launchpad"
 msgstr "aus Launchpad"
 
 #: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from Github or Launchpad."
-msgstr "Sie können Ihre SSH-Schlüssel aus Github oder Launchpad importieren."
+msgid "You can import your SSH keys from GitHub or Launchpad."
+msgstr "Sie können Ihre SSH-Schlüssel aus GitHub oder Launchpad importieren."
 
 #: ../subiquity/ui/views/ssh.py:105
 msgid "Allow password authentication over SSH"
@@ -1752,10 +1752,10 @@ msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:150
 msgid ""
-"A Github username may only contain alphanumeric characters or single "
+"A GitHub username may only contain alphanumeric characters or single "
 "hyphens, and cannot begin or end with a hyphen."
 msgstr ""
-"Ein Github-Benutzername darf nur alphanumerische Zeichen oder einzelne "
+"Ein GitHub-Benutzername darf nur alphanumerische Zeichen oder einzelne "
 "Bindestriche enthalten und nicht mit einem Bindestrich beginnen oder enden."
 
 #: ../subiquity/ui/views/ssh.py:160

--- a/po/el.po
+++ b/po/el.po
@@ -1608,7 +1608,7 @@ msgid "Import Username:"
 msgstr "Όνομα χρήστη εισαγωγής:"
 
 #: ../subiquity/ui/views/ssh.py:73
-msgid "Github Username:"
+msgid "GitHub Username:"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:80
@@ -1624,15 +1624,15 @@ msgid "Import SSH identity:"
 msgstr "Εισαγωγή ταυτότητας SSH:"
 
 #: ../subiquity/ui/views/ssh.py:98
-msgid "from Github"
-msgstr "από Github"
+msgid "from GitHub"
+msgstr "από GitHub"
 
 #: ../subiquity/ui/views/ssh.py:99
 msgid "from Launchpad"
 msgstr "από Launchpad"
 
 #: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from Github or Launchpad."
+msgid "You can import your SSH keys from GitHub or Launchpad."
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:105
@@ -1656,7 +1656,7 @@ msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:150
 msgid ""
-"A Github username may only contain alphanumeric characters or single "
+"A GitHub username may only contain alphanumeric characters or single "
 "hyphens, and cannot begin or end with a hyphen."
 msgstr ""
 

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -1772,8 +1772,8 @@ msgid "Import Username:"
 msgstr "Import Username:"
 
 #: ../subiquity/ui/views/ssh.py:73
-msgid "Github Username:"
-msgstr "Github Username:"
+msgid "GitHub Username:"
+msgstr "GitHub Username:"
 
 #: ../subiquity/ui/views/ssh.py:80
 msgid "Launchpad Username:"
@@ -1788,16 +1788,16 @@ msgid "Import SSH identity:"
 msgstr "Import SSH identity:"
 
 #: ../subiquity/ui/views/ssh.py:98
-msgid "from Github"
-msgstr "from Github"
+msgid "from GitHub"
+msgstr "from GitHub"
 
 #: ../subiquity/ui/views/ssh.py:99
 msgid "from Launchpad"
 msgstr "from Launchpad"
 
 #: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from Github or Launchpad."
-msgstr "You can import your SSH keys from Github or Launchpad."
+msgid "You can import your SSH keys from GitHub or Launchpad."
+msgstr "You can import your SSH keys from GitHub or Launchpad."
 
 #: ../subiquity/ui/views/ssh.py:105
 msgid "Allow password authentication over SSH"
@@ -1823,10 +1823,10 @@ msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:150
 msgid ""
-"A Github username may only contain alphanumeric characters or single "
+"A GitHub username may only contain alphanumeric characters or single "
 "hyphens, and cannot begin or end with a hyphen."
 msgstr ""
-"A Github username may only contain alphanumeric characters or single "
+"A GitHub username may only contain alphanumeric characters or single "
 "hyphens, and cannot begin or end with a hyphen."
 
 #: ../subiquity/ui/views/ssh.py:160

--- a/po/en_US.po
+++ b/po/en_US.po
@@ -1601,7 +1601,7 @@ msgid "Import Username:"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:73
-msgid "Github Username:"
+msgid "GitHub Username:"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:80
@@ -1617,7 +1617,7 @@ msgid "Import SSH identity:"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:98
-msgid "from Github"
+msgid "from GitHub"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:99
@@ -1625,7 +1625,7 @@ msgid "from Launchpad"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from Github or Launchpad."
+msgid "You can import your SSH keys from GitHub or Launchpad."
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:105
@@ -1649,7 +1649,7 @@ msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:150
 msgid ""
-"A Github username may only contain alphanumeric characters or single "
+"A GitHub username may only contain alphanumeric characters or single "
 "hyphens, and cannot begin or end with a hyphen."
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -1613,7 +1613,7 @@ msgid "Import Username:"
 msgstr "Importar nombre de usuario:"
 
 #: ../subiquity/ui/views/ssh.py:73
-msgid "Github Username:"
+msgid "GitHub Username:"
 msgstr "Nombre de usuario de GitHub:"
 
 #: ../subiquity/ui/views/ssh.py:80
@@ -1629,7 +1629,7 @@ msgid "Import SSH identity:"
 msgstr "Importar identidad SSH:"
 
 #: ../subiquity/ui/views/ssh.py:98
-msgid "from Github"
+msgid "from GitHub"
 msgstr "de GitHub"
 
 #: ../subiquity/ui/views/ssh.py:99
@@ -1637,7 +1637,7 @@ msgid "from Launchpad"
 msgstr "de Launchpad"
 
 #: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from Github or Launchpad."
+msgid "You can import your SSH keys from GitHub or Launchpad."
 msgstr "Puede importar sus claves SSH desde GitHub o Launchpad."
 
 #: ../subiquity/ui/views/ssh.py:105
@@ -1661,7 +1661,7 @@ msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:150
 msgid ""
-"A Github username may only contain alphanumeric characters or single "
+"A GitHub username may only contain alphanumeric characters or single "
 "hyphens, and cannot begin or end with a hyphen."
 msgstr ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -1604,8 +1604,8 @@ msgid "Import Username:"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:73
-msgid "Github Username:"
-msgstr "Github-käyttäjätunnus:"
+msgid "GitHub Username:"
+msgstr "GitHub-käyttäjätunnus:"
 
 #: ../subiquity/ui/views/ssh.py:80
 msgid "Launchpad Username:"
@@ -1620,15 +1620,15 @@ msgid "Import SSH identity:"
 msgstr "Tuo SSH-identiteetti:"
 
 #: ../subiquity/ui/views/ssh.py:98
-msgid "from Github"
-msgstr "Githubista"
+msgid "from GitHub"
+msgstr "GitHubista"
 
 #: ../subiquity/ui/views/ssh.py:99
 msgid "from Launchpad"
 msgstr "Launchpadilta"
 
 #: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from Github or Launchpad."
+msgid "You can import your SSH keys from GitHub or Launchpad."
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:105
@@ -1652,7 +1652,7 @@ msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:150
 msgid ""
-"A Github username may only contain alphanumeric characters or single "
+"A GitHub username may only contain alphanumeric characters or single "
 "hyphens, and cannot begin or end with a hyphen."
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -1622,8 +1622,8 @@ msgid "Import Username:"
 msgstr "Importer le nom d'utilisateur :"
 
 #: ../subiquity/ui/views/ssh.py:73
-msgid "Github Username:"
-msgstr "Nom d'utilisateur Github :"
+msgid "GitHub Username:"
+msgstr "Nom d'utilisateur GitHub :"
 
 #: ../subiquity/ui/views/ssh.py:80
 msgid "Launchpad Username:"
@@ -1638,16 +1638,16 @@ msgid "Import SSH identity:"
 msgstr "Importer une identité SSH:"
 
 #: ../subiquity/ui/views/ssh.py:98
-msgid "from Github"
-msgstr "depuis Github"
+msgid "from GitHub"
+msgstr "depuis GitHub"
 
 #: ../subiquity/ui/views/ssh.py:99
 msgid "from Launchpad"
 msgstr "depuis Launchpad"
 
 #: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from Github or Launchpad."
-msgstr "Vous pouvez importer vos clés SSH depuis Github ou Launchpad."
+msgid "You can import your SSH keys from GitHub or Launchpad."
+msgstr "Vous pouvez importer vos clés SSH depuis GitHub ou Launchpad."
 
 #: ../subiquity/ui/views/ssh.py:105
 msgid "Allow password authentication over SSH"
@@ -1670,10 +1670,10 @@ msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:150
 msgid ""
-"A Github username may only contain alphanumeric characters or single "
+"A GitHub username may only contain alphanumeric characters or single "
 "hyphens, and cannot begin or end with a hyphen."
 msgstr ""
-"Un nom d'utilisateur Github ne peut contenir que des caractères "
+"Un nom d'utilisateur GitHub ne peut contenir que des caractères "
 "alphanumériques ou des traits d'union simples et ne peut pas commencer ou se "
 "terminer par un trait d'union."
 

--- a/po/he.po
+++ b/po/he.po
@@ -1750,8 +1750,8 @@ msgid "Import Username:"
 msgstr "יבוא שם משתמש:"
 
 #: ../subiquity/ui/views/ssh.py:73
-msgid "Github Username:"
-msgstr "שם משתמש ב־Github:"
+msgid "GitHub Username:"
+msgstr "שם משתמש ב־GitHub:"
 
 #: ../subiquity/ui/views/ssh.py:80
 msgid "Launchpad Username:"
@@ -1766,16 +1766,16 @@ msgid "Import SSH identity:"
 msgstr "יבוא זהות SSH:"
 
 #: ../subiquity/ui/views/ssh.py:98
-msgid "from Github"
-msgstr "מ־Github"
+msgid "from GitHub"
+msgstr "מ־GitHub"
 
 #: ../subiquity/ui/views/ssh.py:99
 msgid "from Launchpad"
 msgstr "מ־Launchpad"
 
 #: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from Github or Launchpad."
-msgstr "ניתן לייבא את מפתחות ה־SSH שלך מ־Github או מ־Launchpad."
+msgid "You can import your SSH keys from GitHub or Launchpad."
+msgstr "ניתן לייבא את מפתחות ה־SSH שלך מ־GitHub או מ־Launchpad."
 
 #: ../subiquity/ui/views/ssh.py:105
 msgid "Allow password authentication over SSH"
@@ -1800,10 +1800,10 @@ msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:150
 msgid ""
-"A Github username may only contain alphanumeric characters or single "
+"A GitHub username may only contain alphanumeric characters or single "
 "hyphens, and cannot begin or end with a hyphen."
 msgstr ""
-"שם משתמש ב־Github יכול להכיל רק תווים אלפאנומריים או סימני מינוס בודדים ולא "
+"שם משתמש ב־GitHub יכול להכיל רק תווים אלפאנומריים או סימני מינוס בודדים ולא "
 "יכול להתחיל או להסתיים במינוס."
 
 #: ../subiquity/ui/views/ssh.py:160

--- a/po/hr.po
+++ b/po/hr.po
@@ -1785,8 +1785,8 @@ msgid "Import Username:"
 msgstr "Uvezi korisničko ime:"
 
 #: ../subiquity/ui/views/ssh.py:73
-msgid "Github Username:"
-msgstr "Github korisničko ime:"
+msgid "GitHub Username:"
+msgstr "GitHub korisničko ime:"
 
 #: ../subiquity/ui/views/ssh.py:80
 msgid "Launchpad Username:"
@@ -1801,16 +1801,16 @@ msgid "Import SSH identity:"
 msgstr "Uvezi SSH identitet:"
 
 #: ../subiquity/ui/views/ssh.py:98
-msgid "from Github"
-msgstr "iz Githuba"
+msgid "from GitHub"
+msgstr "iz GitHuba"
 
 #: ../subiquity/ui/views/ssh.py:99
 msgid "from Launchpad"
 msgstr "iz Launchpada"
 
 #: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from Github or Launchpad."
-msgstr "Možete uvesti vaše SSH ključeve iz Githuba ili Launchpada."
+msgid "You can import your SSH keys from GitHub or Launchpad."
+msgstr "Možete uvesti vaše SSH ključeve iz GitHuba ili Launchpada."
 
 #: ../subiquity/ui/views/ssh.py:105
 msgid "Allow password authentication over SSH"
@@ -1835,10 +1835,10 @@ msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:150
 msgid ""
-"A Github username may only contain alphanumeric characters or single "
+"A GitHub username may only contain alphanumeric characters or single "
 "hyphens, and cannot begin or end with a hyphen."
 msgstr ""
-"Github korisničko ime može sadržavati samo slovno-brojčane znakove ili "
+"GitHub korisničko ime može sadržavati samo slovno-brojčane znakove ili "
 "pojedinačne crtice i ne može započeti niti završavati crticom."
 
 #: ../subiquity/ui/views/ssh.py:160

--- a/po/hu.po
+++ b/po/hu.po
@@ -1693,7 +1693,7 @@ msgid "Import Username:"
 msgstr "Importált felhasználónév:"
 
 #: ../subiquity/ui/views/ssh.py:73
-msgid "Github Username:"
+msgid "GitHub Username:"
 msgstr "GitHub felhasználónév:"
 
 #: ../subiquity/ui/views/ssh.py:80
@@ -1709,7 +1709,7 @@ msgid "Import SSH identity:"
 msgstr "SSH azonosító importálása:"
 
 #: ../subiquity/ui/views/ssh.py:98
-msgid "from Github"
+msgid "from GitHub"
 msgstr "a GitHubról"
 
 #: ../subiquity/ui/views/ssh.py:99
@@ -1717,7 +1717,7 @@ msgid "from Launchpad"
 msgstr "a Launchpadról"
 
 #: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from Github or Launchpad."
+msgid "You can import your SSH keys from GitHub or Launchpad."
 msgstr "Importálhatja az SSH-kulcsait a GitHubról vagy a Launchpadról."
 
 #: ../subiquity/ui/views/ssh.py:105
@@ -1744,7 +1744,7 @@ msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:150
 msgid ""
-"A Github username may only contain alphanumeric characters or single "
+"A GitHub username may only contain alphanumeric characters or single "
 "hyphens, and cannot begin or end with a hyphen."
 msgstr ""
 "A GitHub-felhasználónév csak alfanumerikus karaktereket és egyszeres "

--- a/po/id.po
+++ b/po/id.po
@@ -1603,7 +1603,7 @@ msgid "Import Username:"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:73
-msgid "Github Username:"
+msgid "GitHub Username:"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:80
@@ -1619,7 +1619,7 @@ msgid "Import SSH identity:"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:98
-msgid "from Github"
+msgid "from GitHub"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:99
@@ -1627,7 +1627,7 @@ msgid "from Launchpad"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from Github or Launchpad."
+msgid "You can import your SSH keys from GitHub or Launchpad."
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:105
@@ -1651,7 +1651,7 @@ msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:150
 msgid ""
-"A Github username may only contain alphanumeric characters or single "
+"A GitHub username may only contain alphanumeric characters or single "
 "hyphens, and cannot begin or end with a hyphen."
 msgstr ""
 

--- a/po/kab.po
+++ b/po/kab.po
@@ -1603,7 +1603,7 @@ msgid "Import Username:"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:73
-msgid "Github Username:"
+msgid "GitHub Username:"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:80
@@ -1619,7 +1619,7 @@ msgid "Import SSH identity:"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:98
-msgid "from Github"
+msgid "from GitHub"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:99
@@ -1627,7 +1627,7 @@ msgid "from Launchpad"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from Github or Launchpad."
+msgid "You can import your SSH keys from GitHub or Launchpad."
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:105
@@ -1651,7 +1651,7 @@ msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:150
 msgid ""
-"A Github username may only contain alphanumeric characters or single "
+"A GitHub username may only contain alphanumeric characters or single "
 "hyphens, and cannot begin or end with a hyphen."
 msgstr ""
 

--- a/po/lt.po
+++ b/po/lt.po
@@ -1608,8 +1608,8 @@ msgid "Import Username:"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:73
-msgid "Github Username:"
-msgstr "Github naudotojo vardas:"
+msgid "GitHub Username:"
+msgstr "GitHub naudotojo vardas:"
 
 #: ../subiquity/ui/views/ssh.py:80
 msgid "Launchpad Username:"
@@ -1624,15 +1624,15 @@ msgid "Import SSH identity:"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:98
-msgid "from Github"
-msgstr "iš Github"
+msgid "from GitHub"
+msgstr "iš GitHub"
 
 #: ../subiquity/ui/views/ssh.py:99
 msgid "from Launchpad"
 msgstr "iš Launchpad"
 
 #: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from Github or Launchpad."
+msgid "You can import your SSH keys from GitHub or Launchpad."
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:105
@@ -1656,7 +1656,7 @@ msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:150
 msgid ""
-"A Github username may only contain alphanumeric characters or single "
+"A GitHub username may only contain alphanumeric characters or single "
 "hyphens, and cannot begin or end with a hyphen."
 msgstr ""
 

--- a/po/lv.po
+++ b/po/lv.po
@@ -1603,7 +1603,7 @@ msgid "Import Username:"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:73
-msgid "Github Username:"
+msgid "GitHub Username:"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:80
@@ -1619,7 +1619,7 @@ msgid "Import SSH identity:"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:98
-msgid "from Github"
+msgid "from GitHub"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:99
@@ -1627,7 +1627,7 @@ msgid "from Launchpad"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from Github or Launchpad."
+msgid "You can import your SSH keys from GitHub or Launchpad."
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:105
@@ -1651,7 +1651,7 @@ msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:150
 msgid ""
-"A Github username may only contain alphanumeric characters or single "
+"A GitHub username may only contain alphanumeric characters or single "
 "hyphens, and cannot begin or end with a hyphen."
 msgstr ""
 

--- a/po/nb.po
+++ b/po/nb.po
@@ -1617,8 +1617,8 @@ msgid "Import Username:"
 msgstr "Importer brukernavn:"
 
 #: ../subiquity/ui/views/ssh.py:73
-msgid "Github Username:"
-msgstr "Github-brukernavn:"
+msgid "GitHub Username:"
+msgstr "GitHub-brukernavn:"
 
 #: ../subiquity/ui/views/ssh.py:80
 msgid "Launchpad Username:"
@@ -1633,16 +1633,16 @@ msgid "Import SSH identity:"
 msgstr "Importer SSH-identitet:"
 
 #: ../subiquity/ui/views/ssh.py:98
-msgid "from Github"
-msgstr "fra Github"
+msgid "from GitHub"
+msgstr "fra GitHub"
 
 #: ../subiquity/ui/views/ssh.py:99
 msgid "from Launchpad"
 msgstr "fra Launchpad"
 
 #: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from Github or Launchpad."
-msgstr "Du kan importere SSH-nøkler fra Github eller Launchpad."
+msgid "You can import your SSH keys from GitHub or Launchpad."
+msgstr "Du kan importere SSH-nøkler fra GitHub eller Launchpad."
 
 #: ../subiquity/ui/views/ssh.py:105
 msgid "Allow password authentication over SSH"
@@ -1665,10 +1665,10 @@ msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:150
 msgid ""
-"A Github username may only contain alphanumeric characters or single "
+"A GitHub username may only contain alphanumeric characters or single "
 "hyphens, and cannot begin or end with a hyphen."
 msgstr ""
-"Github-brukernavn kan bare inneholde alfanumeriske tegn og bindestreker, og "
+"GitHub-brukernavn kan bare inneholde alfanumeriske tegn og bindestreker, og "
 "de kan ikke begynne med bindestrek."
 
 #: ../subiquity/ui/views/ssh.py:160

--- a/po/nl.po
+++ b/po/nl.po
@@ -1615,7 +1615,7 @@ msgid "Import Username:"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:73
-msgid "Github Username:"
+msgid "GitHub Username:"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:80
@@ -1631,7 +1631,7 @@ msgid "Import SSH identity:"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:98
-msgid "from Github"
+msgid "from GitHub"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:99
@@ -1639,7 +1639,7 @@ msgid "from Launchpad"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from Github or Launchpad."
+msgid "You can import your SSH keys from GitHub or Launchpad."
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:105
@@ -1663,7 +1663,7 @@ msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:150
 msgid ""
-"A Github username may only contain alphanumeric characters or single "
+"A GitHub username may only contain alphanumeric characters or single "
 "hyphens, and cannot begin or end with a hyphen."
 msgstr ""
 

--- a/po/oc.po
+++ b/po/oc.po
@@ -1603,7 +1603,7 @@ msgid "Import Username:"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:73
-msgid "Github Username:"
+msgid "GitHub Username:"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:80
@@ -1619,7 +1619,7 @@ msgid "Import SSH identity:"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:98
-msgid "from Github"
+msgid "from GitHub"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:99
@@ -1627,7 +1627,7 @@ msgid "from Launchpad"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from Github or Launchpad."
+msgid "You can import your SSH keys from GitHub or Launchpad."
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:105
@@ -1651,7 +1651,7 @@ msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:150
 msgid ""
-"A Github username may only contain alphanumeric characters or single "
+"A GitHub username may only contain alphanumeric characters or single "
 "hyphens, and cannot begin or end with a hyphen."
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -1606,8 +1606,8 @@ msgid "Import Username:"
 msgstr "Import nazwy użytkownika:"
 
 #: ../subiquity/ui/views/ssh.py:73
-msgid "Github Username:"
-msgstr "Nazwa użytkownika Github:"
+msgid "GitHub Username:"
+msgstr "Nazwa użytkownika GitHub:"
 
 #: ../subiquity/ui/views/ssh.py:80
 msgid "Launchpad Username:"
@@ -1622,16 +1622,16 @@ msgid "Import SSH identity:"
 msgstr "Importuj tożsamość SSH:"
 
 #: ../subiquity/ui/views/ssh.py:98
-msgid "from Github"
-msgstr "z Github"
+msgid "from GitHub"
+msgstr "z GitHub"
 
 #: ../subiquity/ui/views/ssh.py:99
 msgid "from Launchpad"
 msgstr "z Launchpad"
 
 #: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from Github or Launchpad."
-msgstr "Możesz importować klucze SSH z Github lub Launchpad"
+msgid "You can import your SSH keys from GitHub or Launchpad."
+msgstr "Możesz importować klucze SSH z GitHub lub Launchpad"
 
 #: ../subiquity/ui/views/ssh.py:105
 msgid "Allow password authentication over SSH"
@@ -1654,7 +1654,7 @@ msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:150
 msgid ""
-"A Github username may only contain alphanumeric characters or single "
+"A GitHub username may only contain alphanumeric characters or single "
 "hyphens, and cannot begin or end with a hyphen."
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -1604,7 +1604,7 @@ msgid "Import Username:"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:73
-msgid "Github Username:"
+msgid "GitHub Username:"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:80
@@ -1620,7 +1620,7 @@ msgid "Import SSH identity:"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:98
-msgid "from Github"
+msgid "from GitHub"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:99
@@ -1628,7 +1628,7 @@ msgid "from Launchpad"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from Github or Launchpad."
+msgid "You can import your SSH keys from GitHub or Launchpad."
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:105
@@ -1652,7 +1652,7 @@ msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:150
 msgid ""
-"A Github username may only contain alphanumeric characters or single "
+"A GitHub username may only contain alphanumeric characters or single "
 "hyphens, and cannot begin or end with a hyphen."
 msgstr ""
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -1603,7 +1603,7 @@ msgid "Import Username:"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:73
-msgid "Github Username:"
+msgid "GitHub Username:"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:80
@@ -1619,7 +1619,7 @@ msgid "Import SSH identity:"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:98
-msgid "from Github"
+msgid "from GitHub"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:99
@@ -1627,7 +1627,7 @@ msgid "from Launchpad"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from Github or Launchpad."
+msgid "You can import your SSH keys from GitHub or Launchpad."
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:105
@@ -1651,7 +1651,7 @@ msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:150
 msgid ""
-"A Github username may only contain alphanumeric characters or single "
+"A GitHub username may only contain alphanumeric characters or single "
 "hyphens, and cannot begin or end with a hyphen."
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -1603,7 +1603,7 @@ msgid "Import Username:"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:73
-msgid "Github Username:"
+msgid "GitHub Username:"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:80
@@ -1619,7 +1619,7 @@ msgid "Import SSH identity:"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:98
-msgid "from Github"
+msgid "from GitHub"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:99
@@ -1627,7 +1627,7 @@ msgid "from Launchpad"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from Github or Launchpad."
+msgid "You can import your SSH keys from GitHub or Launchpad."
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:105
@@ -1651,7 +1651,7 @@ msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:150
 msgid ""
-"A Github username may only contain alphanumeric characters or single "
+"A GitHub username may only contain alphanumeric characters or single "
 "hyphens, and cannot begin or end with a hyphen."
 msgstr ""
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -1620,8 +1620,8 @@ msgid "Import Username:"
 msgstr "Користувач імпортування:"
 
 #: ../subiquity/ui/views/ssh.py:73
-msgid "Github Username:"
-msgstr "Користувач github:"
+msgid "GitHub Username:"
+msgstr "Користувач GitHub:"
 
 #: ../subiquity/ui/views/ssh.py:80
 msgid "Launchpad Username:"
@@ -1636,16 +1636,16 @@ msgid "Import SSH identity:"
 msgstr "Імпортувати профіль SSH:"
 
 #: ../subiquity/ui/views/ssh.py:98
-msgid "from Github"
-msgstr "з Github"
+msgid "from GitHub"
+msgstr "з GitHub"
 
 #: ../subiquity/ui/views/ssh.py:99
 msgid "from Launchpad"
 msgstr "з Launchpad"
 
 #: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from Github or Launchpad."
-msgstr "Ви можете імпортувати ваші ключі SSH з Github або Launchpad."
+msgid "You can import your SSH keys from GitHub or Launchpad."
+msgstr "Ви можете імпортувати ваші ключі SSH з GitHub або Launchpad."
 
 #: ../subiquity/ui/views/ssh.py:105
 msgid "Allow password authentication over SSH"
@@ -1668,10 +1668,10 @@ msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:150
 msgid ""
-"A Github username may only contain alphanumeric characters or single "
+"A GitHub username may only contain alphanumeric characters or single "
 "hyphens, and cannot begin or end with a hyphen."
 msgstr ""
-"Ім'я користувача Github може складатися лише літер, цифр та одинарних "
+"Ім'я користувача GitHub може складатися лише літер, цифр та одинарних "
 "дефісів і не може починатися або завершуватися дефісом."
 
 #: ../subiquity/ui/views/ssh.py:160

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1603,7 +1603,7 @@ msgid "Import Username:"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:73
-msgid "Github Username:"
+msgid "GitHub Username:"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:80
@@ -1619,7 +1619,7 @@ msgid "Import SSH identity:"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:98
-msgid "from Github"
+msgid "from GitHub"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:99
@@ -1627,7 +1627,7 @@ msgid "from Launchpad"
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:101
-msgid "You can import your SSH keys from Github or Launchpad."
+msgid "You can import your SSH keys from GitHub or Launchpad."
 msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:105
@@ -1651,7 +1651,7 @@ msgstr ""
 
 #: ../subiquity/ui/views/ssh.py:150
 msgid ""
-"A Github username may only contain alphanumeric characters or single "
+"A GitHub username may only contain alphanumeric characters or single "
 "hyphens, and cannot begin or end with a hyphen."
 msgstr ""
 

--- a/subiquity/ui/views/ssh.py
+++ b/subiquity/ui/views/ssh.py
@@ -70,10 +70,10 @@ _ssh_import_data = {
         'regex': '.*',
         },
     'gh': {
-        'caption': _("Github Username:"),
-        'help': _("Enter your Github username."),
+        'caption': _("GitHub Username:"),
+        'help': _("Enter your GitHub username."),
         'valid_char': r'[a-zA-Z0-9\-]',
-        'error_invalid_char': _('A Github username may only contain '
+        'error_invalid_char': _('A GitHub username may only contain '
                                 'alphanumeric characters or hyphens.'),
         },
     'lp': {
@@ -95,10 +95,10 @@ class SSHForm(Form):
         _("Import SSH identity:"),
         choices=[
             (_("No"), True, None),
-            (_("from Github"), True, "gh"),
+            (_("from GitHub"), True, "gh"),
             (_("from Launchpad"), True, "lp"),
             ],
-        help=_("You can import your SSH keys from Github or Launchpad."))
+        help=_("You can import your SSH keys from GitHub or Launchpad."))
 
     import_username = UsernameField(_ssh_import_data[None]['caption'])
 
@@ -147,7 +147,7 @@ class SSHForm(Form):
                          "the first character.""")
         elif self.ssh_import_id_value == 'gh':
             if not re.match(r'^[a-zA-Z0-9\-]+$', username):
-                return _("A Github username may only contain alphanumeric "
+                return _("A GitHub username may only contain alphanumeric "
                          "characters or single hyphens, and cannot begin or "
                          "end with a hyphen.")
 


### PR DESCRIPTION
Made changes to consistently use "GitHub" (upper case letter "H") in message strings. Previously, "Github" was used in many cases.