### PR TITLE
use the "None" datasource for on-first-boot configuration

### DIFF
--- a/scripts/check-yaml-fields.py
+++ b/scripts/check-yaml-fields.py
@@ -10,11 +10,18 @@ config = yaml.safe_load(open(sys.argv[1]))
 def main():
 
     for arg in sys.argv[2:]:
-        k, expected = arg.split('=', 1)
-        expected = yaml.safe_load(expected)
+        if '=' in arg:
+            k, expected = arg.split('=', 1)
+            expected = yaml.safe_load(expected)
+        else:
+            k, expected = arg, None
         v = config
         for part in k.split('.'):
             v = v[part]
-        assert v == expected, "{!r} != {!r}".format(v, expected)
+        if expected is None:
+            print(v)
+        else:
+            assert v == expected, "{!r} != {!r}".format(v, expected)
+
 
 main()

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -41,7 +41,7 @@ timeout --foreground 60 sh -c "LANG=C.UTF-8 python3 -m subiquity.cmd.tui --autoi
 validate
 python3 scripts/check-yaml-fields.py .subiquity/subiquity-curtin-install.conf \
         debconf_selections.subiquity='"eek"'
-python3 scripts/check-yaml-fields.py .subiquity/var/lib/cloud/seed/nocloud-net/user-data \
+python3 scripts/check-yaml-fields.py <(python3 scripts/check-yaml-fields.py .subiquity/etc/cloud/cloud.cfg.d/installer.cfg datasource.None.userdata_raw) \
         locale='"en_GB.UTF-8"'
 grep -q 'finish: subiquity/InstallProgress/install/postinstall/install_package1: SUCCESS: installing package1' \
      .subiquity/subiquity-debug.log

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -41,7 +41,7 @@ timeout --foreground 60 sh -c "LANG=C.UTF-8 python3 -m subiquity.cmd.tui --autoi
 validate
 python3 scripts/check-yaml-fields.py .subiquity/subiquity-curtin-install.conf \
         debconf_selections.subiquity='"eek"'
-python3 scripts/check-yaml-fields.py <(python3 scripts/check-yaml-fields.py .subiquity/etc/cloud/cloud.cfg.d/installer.cfg datasource.None.userdata_raw) \
+python3 scripts/check-yaml-fields.py <(python3 scripts/check-yaml-fields.py .subiquity/etc/cloud/cloud.cfg.d/99-installer.cfg datasource.None.userdata_raw) \
         locale='"en_GB.UTF-8"'
 grep -q 'finish: subiquity/InstallProgress/install/postinstall/install_package1: SUCCESS: installing package1' \
      .subiquity/subiquity-debug.log

--- a/subiquity/models/subiquity.py
+++ b/subiquity/models/subiquity.py
@@ -203,10 +203,18 @@ class SubiquityModel:
         # for subsequent boots.
         # (mwhudson does not entirely know what the above means!)
         userdata = '#cloud-config\n' + yaml.dump(self._cloud_init_config())
-        metadata = yaml.dump({'instance-id': str(uuid.uuid4())})
+        metadata = {'instance-id': str(uuid.uuid4())}
+        config = {
+            'datasource_list': ["None"],
+            'datasource': {
+                "None": {
+                    'userdata_raw': userdata,
+                    'metadata': metadata,
+                    },
+                },
+            }
         files = [
-            ('var/lib/cloud/seed/nocloud-net/meta-data', metadata, 0o644),
-            ('var/lib/cloud/seed/nocloud-net/user-data', userdata, 0o600),
+            ('etc/cloud/cloud.cfg.d/installer.cfg', yaml.dump(config), 0o600),
             ('etc/cloud/ds-identify.cfg', 'policy: enabled\n', 0o644),
             ]
         if self.identity.hostname is not None:

--- a/subiquity/models/subiquity.py
+++ b/subiquity/models/subiquity.py
@@ -204,7 +204,7 @@ class SubiquityModel:
         # (mwhudson does not entirely know what the above means!)
         userdata = '#cloud-config\n' + yaml.dump(self._cloud_init_config())
         metadata = {'instance-id': str(uuid.uuid4())}
-        config = {
+        config = yaml.dump({
             'datasource_list': ["None"],
             'datasource': {
                 "None": {
@@ -212,9 +212,9 @@ class SubiquityModel:
                     'metadata': metadata,
                     },
                 },
-            }
+            })
         files = [
-            ('etc/cloud/cloud.cfg.d/installer.cfg', yaml.dump(config), 0o600),
+            ('etc/cloud/cloud.cfg.d/99-installer.cfg', config, 0o600),
             ('etc/cloud/ds-identify.cfg', 'policy: enabled\n', 0o644),
             ]
         if self.identity.hostname is not None:


### PR DESCRIPTION
Using the NoCloud source meant that a filesystem label of "cidata"
(probably containing autoinstall config) could override the cloud-init
nocloud seed subiquity wrote and then users would not get created. So
instead write cloud config directly that hardcodes using the
DataSourceNone source and config for it.

https://bugs.launchpad.net/subiquity/+bug/1879103