### PR TITLE
Add disk size match smallest

### DIFF
--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -1392,6 +1392,8 @@ class FilesystemModel(object):
                     break
             else:
                 candidates.append(candidate)
+        if match.get('size') == 'smallest':
+            candidates.sort(key=lambda d: d.size)
         if match.get('size') == 'largest':
             candidates.sort(key=lambda d: d.size, reverse=True)
         if candidates:


### PR DESCRIPTION
In addition to matching the largest disk it would be great to have a matcher for the smallest disk as well. This is helpful if you have a large disk for data and a smaller one for the OS, both being SSD/HDD.