### PR TITLE
set PYTHONIOENCODING to utf-8 in snapcraft.yaml for subiquity{,-service}

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -8,6 +8,8 @@ confinement: classic
 apps:
   subiquity:
     command: usr/bin/subiquity
+    environment:
+      PYTHONIOENCODING: utf-8
   subiquity-loadkeys:
     command: usr/bin/subiquity-loadkeys
   subiquity-configure-apt:
@@ -22,6 +24,8 @@ apps:
     command: usr/bin/subiquity-service
     daemon: simple
     restart-condition: always
+    environment:
+      PYTHONIOENCODING: utf-8
 
 parts:
   curtin:


### PR DESCRIPTION
for https://bugs.launchpad.net/ubuntu-z-systems/+bug/1884027

Not really sure why this only shows up now.