### PR TITLE
add all documented fields to filesystem model classes

### DIFF
--- a/subiquity/models/filesystem.py
+++ b/subiquity/models/filesystem.py
@@ -893,6 +893,8 @@ class Partition(_Formattable):
     number = attr.ib(default=None)
     preserve = attr.ib(default=False)
     grub_device = attr.ib(default=False)
+    name = attr.ib(default=None)
+    multipath = attr.ib(default=None)
 
     @property
     def annotations(self):
@@ -1047,7 +1049,9 @@ class Raid(_Device):
         backlink="_constructed_device", default=attr.Factory(set))
 
     preserve = attr.ib(default=False)
+    wipe = attr.ib(default=None)
     ptable = attributes.ptable()
+    metadata = attr.ib(default=None)
 
     @property
     def size(self):
@@ -1177,6 +1181,7 @@ class LVM_LogicalVolume(_Formattable):
     name = attr.ib()
     volgroup = attributes.ref(backlink="_partitions")  # LVM_VolGroup
     size = attributes.size()
+    wipe = attr.ib(default=None)
 
     preserve = attr.ib(default=False)
 
@@ -1260,6 +1265,7 @@ class Filesystem:
     label = attr.ib(default=None)
     uuid = attr.ib(default=None)
     preserve = attr.ib(default=False)
+    extra_options = attr.ib(default=None)
 
     _mount = attributes.backlink()
 
@@ -1281,6 +1287,9 @@ class Filesystem:
 class Mount:
     device = attributes.ref(backlink="_mount")  # Filesystem
     path = attr.ib()
+    fstype = attr.ib(default=None)
+    options = attr.ib(default=None)
+    spec = attr.ib(default=None)
 
     def can_delete(self):
         # Can't delete mount of /boot/efi or swap, anything else is fine.


### PR DESCRIPTION
This lets autoinstall configs set them, even though nothing in subiquity
can set them yet.