### PR TITLE
Stop subiquity-service on non-installer media.

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# snapd will always start subiquity.service, but when we are not
+# booted off the server.iso there is not enough things in place to run
+# subiquity. Keep subiquity installed, but do not start the
+# service. This way, one can use --dry-run mode for example.
+if [ ! -e /cdrom/.disk/info ]; then
+    snapctl stop --disable "$SNAP_NAME.subiquity-service"
+fi


### PR DESCRIPTION
This will prevent subiquity service starting/crashing in a loop, when installed on regular systems.

Separately this allows to e.g. run subiquity in --dry-run mode on regular installed machines.

However, it still hits segmentation fault when run as `$ sudo subiquity --dry-run` But at least it's not piling up crash reports anymore.

Thanks to @anonymouse64 for the know-how!