### PR TITLE
a snap refresh failure means the refresh state is unknown

### DIFF
--- a/subiquity/controllers/refresh.py
+++ b/subiquity/controllers/refresh.py
@@ -196,7 +196,7 @@ class RefreshController(SubiquityController):
         except requests.exceptions.RequestException:
             log.exception("checking for snap update failed")
             context.description = "checking for snap update failed"
-            return CheckState.UNAVAILABLE
+            return CheckState.UNKNOWN
         log.debug("check_for_update received %s", result)
         for snap in result["result"]:
             if snap["name"] == self.snap_name:


### PR DESCRIPTION
for https://bugs.launchpad.net/subiquity/+bug/1886816