### PR TITLE
snaplist: fix snaplist with filesystem without snaps

### DIFF
--- a/subiquity/ui/views/snaplist.py
+++ b/subiquity/ui/views/snaplist.py
@@ -426,7 +426,7 @@ class SnapListView(BaseView):
     file: lxd_59.snap
 '''
         seed_location = '/media/filesystem/var/lib/snapd/seed/seed.yaml'
-        content = ""
+        content = "{}"
         try:
             with open(seed_location, encoding='utf-8', errors='replace') as fp:
                 content = fp.read()


### PR DESCRIPTION
When no snaps are seeded in the filesystem, empty string is returned,
which yaml safe load interprets as None.

But snapd seed.yaml is defined as a dictionary with snaps key. Ensure
that when no seed.yaml is present (or readable), that at least an
empty dictionary is returned, such that later calls to `.get("snaps",
[])` succeed.

LP: #1889429