### PR TITLE
Add missing build dependencies, improve ISO generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ install_deps:
 		python3-yaml python3-coverage python3-dev pkg-config libnl-genl-3-dev \
 		libnl-route-3-dev python3-attr python3-distutils-extra python3-requests \
 		python3-requests-unixsocket python3-jsonschema python3-curtin python3-apport \
-		python3-bson
+		python3-bson xorriso isolinux
 
 i18n:
 	$(PYTHON) setup.py build_i18n

--- a/scripts/inject-subiquity-snap.sh
+++ b/scripts/inject-subiquity-snap.sh
@@ -177,8 +177,14 @@ elif [ -n "${source_filesystem}" ]; then
     cp "${source_filesystem}" new_iso/casper/filesystem.squashfs
 fi
 
-rm new_iso/casper/installer.squashfs
+rm new_iso/casper/installer.squashfs new_iso/casper/installer.squashfs.gpg
 mksquashfs new_installer new_iso/casper/installer.squashfs
+
+(
+    cd new_iso
+    sed -i'' '/\.\/casper\/installer.squashfs/d' md5sum.txt
+    md5sum ./casper/installer.squashfs >> md5sum.txt
+)
 
 if [ -e new_iso/boot/grub/efi.img ]; then
     xorriso -as mkisofs -r -checksum_algorithm_iso md5,sha1 \

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -131,6 +131,10 @@ parts:
     build-packages:
       - localechooser-data
     override-build: |
+      grep '^path-exclude=.*LC_MESSAGES.*' /etc/dpkg/dpkg.cfg.d/excludes && {
+        sed -i 's/^path-exclude.*LC_MESSAGES.*/#\0/g' /etc/dpkg/dpkg.cfg.d/excludes
+        apt-get -y install --reinstall iso-codes
+      } || true
       $SNAPCRAFT_PROJECT_DIR/scripts/make-language-lists $SNAPCRAFT_PROJECT_DIR/po > $SNAPCRAFT_PART_INSTALL/languagelist
     stage:
       - languagelist

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -140,7 +140,7 @@ parts:
       - languagelist
   probert:
     plugin: python
-    build-packages: [python-setuptools, libnl-3-dev, libnl-genl-3-dev, libnl-route-3-dev]
+    build-packages: [python-setuptools, build-essential, libnl-3-dev, libnl-genl-3-dev, libnl-route-3-dev]
     source: https://github.com/CanonicalLtd/probert.git
     source-type: git
     source-commit: b6329b0dfe2c2deef1b3f862a451e28d5c1f7cf3


### PR DESCRIPTION
This pull request is the result of me trying to build Subiquity in a clean environment, with the goal of having an ISO with the injected freshly-built snap.

Environment:

* ESXi 6.7U3 host hypervisor
* Clean Ubuntu Server 20.04 as the host VM
* Multipass (Ubuntu Server 18.04, core18) for building the actual snap

Here's how I was doing it:

```console
$ sudo apt install make
$ make install_deps
$ sudo snap install snapcraft --classic
$ snapcraft snap --output subiquity_test.snap
$ sudo ./scripts/inject-subiquity-snap.sh ../focal-live-server-amd64.iso subiquity_test.snap focal-custom.iso
```

Doing the steps above, I've encountered multiple errors, that I tried to fix within this pull request:

1. `languagelists` step failing due to missing translation files in a minimised core image. Fixed in 304719eb4dfae16f13610bd1c776fa3db73071e6 by removing the translations from dpkg exclude list.
2. Error compiling `probert._rtnetlink` due to missing gcc. Fixed in e90b84b675f7e2f9c1cf83181d31099917c8b7bc by adding `build-essential` for `probert` step.
3. Errors building the ISO due to missing `xorriso` and `isolinux`. Fixed in ec1fa0fe01f35f1366345c4cdf871dc5dd6745cd by adding these packages to `install_deps` target in Makefile.
4. Non-critical error message about a "damaged" file when booting the created ISO, due to the MD5 hash not being updated for the generated `installer.squashfs`. Fixed in dca298a81558fc9557db028cd19e5d51f93b8aa8 by regenerating the MD5 hash for `installer.squashfs`.

Respective commits have more detailed descriptions.