### PR TITLE
Ignore CAN and unknown interfaces (LP: #1890397)

### DIFF
--- a/subiquitycore/models/network.py
+++ b/subiquitycore/models/network.py
@@ -23,7 +23,9 @@ from subiquitycore.gettext38 import pgettext
 from subiquitycore import netplan
 
 
-NETDEV_IGNORED_IFACE_TYPES = ['lo', 'bridge', 'tun', 'tap', 'dummy', 'sit']
+NETDEV_IGNORED_IFACE_TYPES = [
+    'lo', 'bridge', 'tun', 'tap', 'dummy', 'sit', 'can', '???'
+]
 NETDEV_ALLOWED_VIRTUAL_IFACE_TYPES = ['vlan', 'bond']
 
 


### PR DESCRIPTION
Add CAN and unknown interfaces to `NETDEV_IGNORED_IFACE_TYPES`, otherwise `rander_config()` will throw a KeyError exception when a unsupported interface shows up.