### PR TITLE
examples/autoinstall-interactive: remove duplicate "snaps" section

### DIFF
--- a/examples/autoinstall-interactive.yaml
+++ b/examples/autoinstall-interactive.yaml
@@ -11,9 +11,6 @@ keyboard:
   layout: gb
 interactive-sections:
   - network
-snaps:
-  - name: etcd
-    channel: 3.2/stable
 identity:
   realname: ''
   username: ubuntu


### PR DESCRIPTION
Fixes a duplicate `snaps` key in `examples/autoinstall-interactive.yaml`.