### PR TITLE
handle server errors nicely

### DIFF
--- a/subiquity/common/apidef.py
+++ b/subiquity/common/apidef.py
@@ -28,6 +28,10 @@ class API:
             def GET() -> ApplicationState:
                 """Get the installer state."""
 
+        class restart:
+            def POST() -> None:
+                """Restart the server process."""
+
     class dry_run:
         """This endpoint only works in dry-run mode."""
 

--- a/subiquity/common/apidef.py
+++ b/subiquity/common/apidef.py
@@ -16,6 +16,7 @@
 from subiquity.common.api.defs import api
 from subiquity.common.types import (
     ApplicationState,
+    ErrorReportRef,
     )
 
 
@@ -31,6 +32,10 @@ class API:
         class restart:
             def POST() -> None:
                 """Restart the server process."""
+    class errors:
+        class wait:
+            def GET(error_ref: ErrorReportRef) -> ErrorReportRef:
+                """Block until the error report is fully populated."""
 
     class dry_run:
         """This endpoint only works in dry-run mode."""

--- a/subiquity/common/types.py
+++ b/subiquity/common/types.py
@@ -43,6 +43,7 @@ class ErrorReportKind(enum.Enum):
     INSTALL_FAIL = _("Install failure")
     UI = _("Installer crash")
     NETWORK_FAIL = _("Network error")
+    SERVER_REQUEST_FAIL = _("Server request failure")
     UNKNOWN = _("Unknown error")
 
 

--- a/subiquity/core.py
+++ b/subiquity/core.py
@@ -463,6 +463,8 @@ class Subiquity(TuiApplication):
                     ErrorReportKind.UNKNOWN, "example", interrupt=interrupt)
         elif key == 'ctrl u':
             1/0
+        elif key == 'ctrl b':
+            self.aio_loop.create_task(self.client.dry_run.crash.GET())
         else:
             super().unhandled_input(key)
 

--- a/subiquity/server/dryrun.py
+++ b/subiquity/server/dryrun.py
@@ -13,24 +13,12 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from subiquity.common.api.defs import api
-from subiquity.common.types import (
-    ApplicationState,
-    )
 
+class DryRunController:
 
-@api
-class API:
-    """The API offered by the subiquity installer process."""
+    def __init__(self, app):
+        self.app = app
+        self.context = app.context.child("DryRun")
 
-    class meta:
-        class status:
-            def GET() -> ApplicationState:
-                """Get the installer state."""
-
-    class dry_run:
-        """This endpoint only works in dry-run mode."""
-
-        class crash:
-            def GET() -> None:
-                """Requests to this method will fail with a HTTP 500."""
+    async def crash_GET(self) -> None:
+        1/0

--- a/subiquity/server/errors.py
+++ b/subiquity/server/errors.py
@@ -1,0 +1,29 @@
+# Copyright 2020 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from subiquity.common.types import ErrorReportState, ErrorReportRef
+
+
+class ErrorController:
+
+    def __init__(self, app):
+        self.context = app.context.child("Error")
+        self.error_reporter = app.error_reporter
+
+    async def wait_GET(self, error_ref: ErrorReportRef) -> ErrorReportRef:
+        report = self.error_reporter.get(error_ref)
+        if report.state == ErrorReportState.INCOMPLETE:
+            await report._info_task
+        return report.ref()

--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -14,6 +14,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
+import os
+import sys
 
 from aiohttp import web
 
@@ -40,6 +42,9 @@ class MetaController:
 
     async def status_GET(self) -> ApplicationState:
         return self.app.status
+
+    async def restart_POST(self) -> None:
+        self.app.restart()
 
 
 class SubiquityServer(Application):
@@ -82,3 +87,11 @@ class SubiquityServer(Application):
     async def start(self):
         await super().start()
         await self.start_api_server()
+
+    def restart(self):
+        cmdline = ['snap', 'run', 'subiquity']
+        if self.opts.dry_run:
+            cmdline = [
+                sys.executable, '-m', 'subiquity.cmd.server',
+                ] + sys.argv[1:]
+        os.execvp(cmdline[0], cmdline)

--- a/subiquity/server/server.py
+++ b/subiquity/server/server.py
@@ -71,6 +71,9 @@ class SubiquityServer(Application):
     async def start_api_server(self):
         app = web.Application()
         bind(app.router, API.meta, MetaController(self))
+        if self.opts.dry_run:
+            from .dryrun import DryRunController
+            bind(app.router, API.dry_run, DryRunController(self))
         runner = web.AppRunner(app)
         await runner.setup()
         site = web.UnixSite(runner, self.opts.socket)

--- a/subiquity/ui/views/error.py
+++ b/subiquity/ui/views/error.py
@@ -76,6 +76,9 @@ Sorry, there was a problem completing the installation.
     ErrorReportKind.NETWORK_FAIL: _("""
 Sorry, there was a problem applying the network configuration.
 """),
+    ErrorReportKind.SERVER_REQUEST_FAIL: _("""
+Sorry, the installer has encountered an internal error.
+"""),
     ErrorReportKind.UI: _("""
 Sorry, the installer has restarted because of an error.
 """),
@@ -116,6 +119,9 @@ reconfiguring the system's block devices manually.
 You can continue with the installation but it will be assumed the network
 is not functional.
 """), ['continue']),
+    ErrorReportKind.SERVER_REQUEST_FAIL: (_("""
+You can continue or restart the installer.
+"""), ['continue', 'restart']),
     ErrorReportKind.INSTALL_FAIL: (_("""
 Do you want to try starting the installation again?
 """), ['restart', 'close']),

--- a/subiquity/ui/views/error.py
+++ b/subiquity/ui/views/error.py
@@ -278,7 +278,7 @@ class ErrorReportStretchy(Stretchy):
         self.app.debug_shell()
 
     def restart(self, sender):
-        self.app.restart()
+        self.app.restart(restart_server=True)
 
     def view_report(self, sender):
         self.app.run_command_in_foreground(["less", self.report.path])


### PR DESCRIPTION
This requires some machinery around handling errors generated in the server in the client and some plumbing to restart the server too when 'restart' is clicked in an error report.