### PR TITLE
bin/console-conf-wrapper: start snapd console-conf routine after user interacts

### DIFF
--- a/bin/console-conf-wrapper
+++ b/bin/console-conf-wrapper
@@ -82,5 +82,7 @@ read REPLY
 # start the console-conf routine in snapd to delay any new refreshes, and wait
 # for current refreshes to complete, this will print off messages if there are
 # on-going refreshes
-snap routine console-conf-start
+if snap routine console-conf-start --help >/dev/null 2>/dev/null; then
+    snap routine console-conf-start
+fi
 exec console-conf "$@"

--- a/bin/console-conf-wrapper
+++ b/bin/console-conf-wrapper
@@ -79,4 +79,8 @@ fi
 
 cat /usr/share/subiquity/console-conf-wait
 read REPLY
+# start the console-conf routine in snapd to delay any new refreshes, and wait
+# for current refreshes to complete, this will print off messages if there are
+# on-going refreshes
+snap routine console-conf-start
 exec console-conf "$@"


### PR DESCRIPTION
After the user has pressed enter to being using console-conf, we should invoke
the snapd routine for console-conf, which currently does the following:
* Unconditionally delays refreshes for 20 minutes from when first invoked.
* Blocks waiting for all pending refreshes to complete, including if those
  involve a reboot.

This is the first step towards a more integrated user story where console-conf
is a part of the first-boot process, and at least will minimize user confusion
where console-conf proceeds asking about network configuration and then just
hangs when snapd starts a refresh as soon as network is available.

The snap routine console-conf-start command was merged to snapd with 
https://github.com/snapcore/snapd/pull/9418 and will be first available in snapd
2.48.