### PR TITLE
noinstall kernel_cmdline

### DIFF
--- a/subiquity/core.py
+++ b/subiquity/core.py
@@ -162,6 +162,9 @@ class Subiquity(TuiApplication):
         self.global_overlays = []
         self.block_log_dir = block_log_dir
         self.kernel_cmdline = shlex.split(opts.kernel_cmdline)
+        if "noinstall" in self.kernel_cmdline:
+          logging.Info("Exiting due to noinstall kernel parameter")
+          sys.exit(0)
         if opts.snaps_from_examples:
             connection = FakeSnapdConnection(
                 os.path.join(


### PR DESCRIPTION
This would add an option to avoid the installer so the installation medium can be used as a live troubleshooting environment. Where is a kernel cmdline "noinstall", subiqui would exit and drop to the shell.

I know subiqiti can be suspended with CTRL-Z and that you could also change the initialization such that subiqiti isn't launched, so maybe those are better options.

This might be useful for manual home servers, but the target I have in mind are environments with PXE where there are PXE menus with pre-defined kernel command-lines. It is fairly common practice for pxe menus to have a "troubleshooting" option or an "installation" option. Ubuntu 20.04 works very well for automated remote installations with cloud-config. It also works well with manual pxe remote installations where subiqiti can be viewed over IPMI-SOL or SSH. However, for a simple "live-cd" style troubleshooting environment, he best I can do is bring up the manual installer and then suspend it.

There are certainly other ways to achieve the result, maybe this isn't the right way to do this or the right place.