### PR TITLE
append, do not overwrite logs

### DIFF
--- a/subiquitycore/log.py
+++ b/subiquitycore/log.py
@@ -28,7 +28,7 @@ def setup_logger(dir, base='subiquity'):
     for level in 'info', 'debug':
         nopid_file = os.path.join(dir, "{}-{}.log".format(base, level))
         logfile = "{}.{}".format(nopid_file, os.getpid())
-        handler = logging.FileHandler(logfile, mode='w')
+        handler = logging.FileHandler(logfile)
         # os.symlink cannot replace an existing file or symlink so create
         # it and then rename it over.
         tmplink = logfile + ".link"


### PR DESCRIPTION
The log file names have pids in now, but when subiquity re-execs itself
to fake a snap refresh the pid doesn't change. Having the pre "refresh"
logs get overwritten does not help anything and is sometimes very
annoying.