### PR TITLE
putting "update: no" in autoinstall for refresh section should prevent update

### DIFF
--- a/subiquity/server/controllers/refresh.py
+++ b/subiquity/server/controllers/refresh.py
@@ -71,7 +71,7 @@ class RefreshController(SubiquityController):
     @property
     def active(self):
         if 'update' in self.ai_data:
-            return True
+            return self.ai_data['update']
         else:
             return self.interactive()
 


### PR DESCRIPTION
Crazily, the code interpreted the presence of an 'update' key as meaning
a refresh should be attempted and ignored its value.