### PR TITLE
smoosh InstallState into ApplicationState

### DIFF
--- a/subiquity/common/apidef.py
+++ b/subiquity/common/apidef.py
@@ -29,8 +29,6 @@ from subiquity.common.types import (
     ErrorReportRef,
     KeyboardSetting,
     IdentityData,
-    InstallState,
-    InstallStatus,
     RefreshStatus,
     SnapInfo,
     SnapListResponse,
@@ -79,6 +77,7 @@ class API:
         class crash:
             def GET() -> None:
                 """Requests to this method will fail with a HTTP 500."""
+
     class refresh:
         def GET(wait: bool = False) -> RefreshStatus:
             """Get information about the snap refresh status.
@@ -181,10 +180,6 @@ class API:
 
         class snap_info:
             def GET(snap_name: str) -> SnapInfo: ...
-
-    class install:
-        class status:
-            def GET(cur: Optional[InstallState] = None) -> InstallStatus: ...
 
     class reboot:
         def POST(): ...

--- a/subiquity/common/types.py
+++ b/subiquity/common/types.py
@@ -25,22 +25,6 @@ from typing import List, Optional
 import attr
 
 
-class ApplicationState(enum.Enum):
-    STARTING = enum.auto()
-    EARLY_COMMANDS = enum.auto()
-    INTERACTIVE = enum.auto()
-    NON_INTERACTIVE = enum.auto()
-
-
-@attr.s(auto_attribs=True)
-class ApplicationStatus:
-    state: ApplicationState
-    cloud_init_ok: bool
-    echo_syslog_id: str
-    log_syslog_id: str
-    event_syslog_id: str
-
-
 class ErrorReportState(enum.Enum):
     INCOMPLETE = enum.auto()
     LOADING = enum.auto()
@@ -66,6 +50,31 @@ class ErrorReportRef:
     kind: ErrorReportKind
     seen: bool
     oops_id: Optional[str]
+
+
+class ApplicationState(enum.Enum):
+    STARTING_UP = enum.auto()
+    WAITING = enum.auto()
+    NEEDS_CONFIRMATION = enum.auto()
+    RUNNING = enum.auto()
+    POST_WAIT = enum.auto()
+    POST_RUNNING = enum.auto()
+    UU_RUNNING = enum.auto()
+    UU_CANCELLING = enum.auto()
+    DONE = enum.auto()
+    ERROR = enum.auto()
+
+
+@attr.s(auto_attribs=True)
+class ApplicationStatus:
+    state: ApplicationState
+    confirming_tty: str
+    error: Optional[ErrorReportRef]
+    cloud_init_ok: bool
+    interactive: Optional[bool]
+    echo_syslog_id: str
+    log_syslog_id: str
+    event_syslog_id: str
 
 
 class RefreshCheckState(enum.Enum):
@@ -195,22 +204,3 @@ class SnapListResponse:
     status: SnapCheckState
     snaps: List[SnapInfo] = attr.Factory(list)
     selections: List[SnapSelection] = attr.Factory(list)
-
-
-class InstallState(enum.Enum):
-    NOT_STARTED = enum.auto()
-    NEEDS_CONFIRMATION = enum.auto()
-    RUNNING = enum.auto()
-    POST_WAIT = enum.auto()
-    POST_RUNNING = enum.auto()
-    UU_RUNNING = enum.auto()
-    UU_CANCELLING = enum.auto()
-    DONE = enum.auto()
-    ERROR = enum.auto()
-
-
-@attr.s(auto_attribs=True)
-class InstallStatus:
-    state: InstallState
-    confirming_tty: str = ''
-    error: Optional[ErrorReportRef] = None

--- a/subiquity/server/controllers/cmdlist.py
+++ b/subiquity/server/controllers/cmdlist.py
@@ -21,7 +21,7 @@ from systemd import journal
 from subiquitycore.context import with_context
 from subiquitycore.utils import arun_command
 
-from subiquity.common.types import InstallState
+from subiquity.common.types import ApplicationState
 from subiquity.server.controller import NonInteractiveController
 
 
@@ -102,7 +102,7 @@ class LateController(CmdListController):
     async def _run(self):
         Install = self.app.controllers.Install
         await Install.install_task
-        if Install.install_state == InstallState.DONE:
+        if self.app.state == ApplicationState.DONE:
             await self.run()
 
 
@@ -113,7 +113,7 @@ class ErrorController(CmdListController):
 
     @with_context()
     async def run(self, context):
-        if self.app.interactive():
+        if self.app.interactive:
             self.syslog_id = self.app.log_syslog_id
         else:
             self.syslog_id = self.app.echo_syslog_id

--- a/subiquity/server/controllers/locale.py
+++ b/subiquity/server/controllers/locale.py
@@ -32,7 +32,7 @@ class LocaleController(SubiquityController):
     autoinstall_default = 'en_US.UTF-8'
 
     def interactive(self):
-        return self.app.interactive()
+        return self.app.interactive
 
     def load_autoinstall_data(self, data):
         os.environ["LANG"] = data

--- a/subiquity/server/controllers/reboot.py
+++ b/subiquity/server/controllers/reboot.py
@@ -24,7 +24,7 @@ from subiquitycore.utils import arun_command, run_command
 
 from subiquity.common.apidef import API
 from subiquity.server.controller import SubiquityController
-from subiquity.server.controllers.install import InstallState
+from subiquity.server.controllers.install import ApplicationState
 
 log = logging.getLogger("subiquity.controllers.restart")
 
@@ -51,10 +51,10 @@ class RebootController(SubiquityController):
         await Install.install_task
         await self.app.controllers.Late.run_event.wait()
         await self.copy_logs_to_target()
-        if self.app.interactive():
+        if self.app.interactive:
             await self.user_reboot_event.wait()
             self.reboot()
-        elif Install.install_state == InstallState.DONE:
+        elif self.app.state == ApplicationState.DONE:
             self.reboot()
 
     @with_context()

--- a/subiquity/server/controllers/reporting.py
+++ b/subiquity/server/controllers/reporting.py
@@ -69,7 +69,7 @@ class ReportingController(NonInteractiveController):
         app.add_event_listener(self)
 
     def load_autoinstall_data(self, data):
-        if self.app.interactive():
+        if self.app.interactive:
             return
         self.config.update(copy.deepcopy(NON_INTERACTIVE_CONFIG))
         if data is not None:

--- a/subiquity/ui/views/installprogress.py
+++ b/subiquity/ui/views/installprogress.py
@@ -33,7 +33,7 @@ from subiquitycore.ui.utils import button_pile, Padding, rewrap
 from subiquitycore.ui.stretchy import Stretchy
 from subiquitycore.ui.width import widget_width
 
-from subiquity.common.types import InstallState
+from subiquity.common.types import ApplicationState
 
 
 log = logging.getLogger("subiquity.views.installprogress")
@@ -138,22 +138,22 @@ class ProgressView(BaseView):
         self._set_button_width()
 
     def update_for_state(self, state):
-        if state == InstallState.NOT_STARTED:
+        if state == ApplicationState.WAITING:
             self.title = _("Installing system")
             btns = []
-        elif state == InstallState.NEEDS_CONFIRMATION:
+        elif state == ApplicationState.NEEDS_CONFIRMATION:
             self.title = _("Installing system")
             btns = []
-        elif state == InstallState.RUNNING:
+        elif state == ApplicationState.RUNNING:
             self.title = _("Installing system")
             btns = [self.view_log_btn]
-        elif state == InstallState.POST_WAIT:
+        elif state == ApplicationState.POST_WAIT:
             self.title = _("Installing system")
             btns = [self.view_log_btn]
-        elif state == InstallState.POST_RUNNING:
+        elif state == ApplicationState.POST_RUNNING:
             self.title = _("Installing system")
             btns = [self.view_log_btn]
-        elif state == InstallState.UU_RUNNING:
+        elif state == ApplicationState.UU_RUNNING:
             self.title = _("Install complete!")
             self.reboot_btn.base_widget.set_label(
                 _("Cancel update and reboot"))
@@ -161,7 +161,7 @@ class ProgressView(BaseView):
                 self.view_log_btn,
                 self.reboot_btn,
                 ]
-        elif state == InstallState.UU_CANCELLING:
+        elif state == ApplicationState.UU_CANCELLING:
             self.title = _("Install complete!")
             self.reboot_btn.base_widget.set_label(_("Rebooting..."))
             self.reboot_btn.enabled = False
@@ -169,14 +169,14 @@ class ProgressView(BaseView):
                 self.view_log_btn,
                 self.reboot_btn,
                 ]
-        elif state == InstallState.DONE:
+        elif state == ApplicationState.DONE:
             self.title = _("Install complete!")
             self.reboot_btn.base_widget.set_label(_("Reboot Now"))
             btns = [
                 self.view_log_btn,
                 self.reboot_btn,
                 ]
-        elif state == InstallState.ERROR:
+        elif state == ApplicationState.ERROR:
             self.title = _('An error occurred during installation')
             self.reboot_btn.base_widget.set_label(_("Reboot Now"))
             self.reboot_btn.enabled = True

--- a/subiquity/ui/views/tests/test_installprogress.py
+++ b/subiquity/ui/views/tests/test_installprogress.py
@@ -4,7 +4,7 @@ from unittest import mock
 from subiquitycore.testing import view_helpers
 
 from subiquity.client.controllers.progress import ProgressController
-from subiquity.common.types import InstallState
+from subiquity.common.types import ApplicationState
 from subiquity.ui.views.installprogress import ProgressView
 
 
@@ -28,7 +28,7 @@ class IdentityViewTests(unittest.TestCase):
         view = self.make_view()
         btn = view_helpers.find_button_matching(view, "^Reboot Now$")
         self.assertIs(btn, None)
-        view.update_for_state(InstallState.DONE)
+        view.update_for_state(ApplicationState.DONE)
         btn = view_helpers.find_button_matching(view, "^Reboot Now$")
         self.assertIsNot(btn, None)
         view_helpers.click(btn)


### PR DESCRIPTION
Having these be separate was slightly confusing, particular as I need to
add an "ERROR" state that isn't necessarily due to the install step
itself failing. Now we have one enum for the overall status of the
installer and a separate field that indicates whether the client should
be in interactive or non-interactive mode (or "not-yet-known" which is
handled more or less like non-interactive mode).