### PR TITLE
wait for cloud-init to complete after starting api server

### DIFF
--- a/subiquity/cmd/server.py
+++ b/subiquity/cmd/server.py
@@ -16,14 +16,9 @@
 import argparse
 import logging
 import os
-import subprocess
 import sys
-import time
-
-from cloudinit import atomic_helper, safeyaml, stages
 
 from subiquitycore.log import setup_logger
-from subiquitycore.utils import run_command
 
 from .common import (
     LOGDIR,
@@ -109,38 +104,7 @@ def main():
     logger.info("Starting Subiquity server revision {}".format(version))
     logger.info("Arguments passed: {}".format(sys.argv))
 
-    cloud_init_ok = True
-    if not opts.dry_run:
-        ci_start = time.time()
-        try:
-            status_txt = run_command(
-                ["cloud-init", "status", "--wait"], timeout=600).stdout
-        except subprocess.TimeoutExpired:
-            status_txt = '<timeout>'
-            cloud_init_ok = False
-        logger.debug("waited %ss for cloud-init", time.time() - ci_start)
-        if "status: done" in status_txt:
-            logger.debug("loading cloud config")
-            init = stages.Init()
-            init.read_cfg()
-            init.fetch(existing="trust")
-            cloud = init.cloudify()
-            autoinstall_path = '/autoinstall.yaml'
-            if 'autoinstall' in cloud.cfg:
-                if not os.path.exists(autoinstall_path):
-                    atomic_helper.write_file(
-                        autoinstall_path,
-                        safeyaml.dumps(
-                            cloud.cfg['autoinstall']).encode('utf-8'),
-                        mode=0o600)
-            if os.path.exists(autoinstall_path):
-                opts.autoinstall = autoinstall_path
-        else:
-            logger.debug(
-                "cloud-init status: %r, assumed disabled",
-                status_txt)
-
-    server = SubiquityServer(opts, block_log_dir, cloud_init_ok)
+    server = SubiquityServer(opts, block_log_dir)
 
     server.note_file_for_apport(
         "InstallerServerLog", logfiles['debug'])

--- a/subiquity/common/types.py
+++ b/subiquity/common/types.py
@@ -54,6 +54,8 @@ class ErrorReportRef:
 
 class ApplicationState(enum.Enum):
     STARTING_UP = enum.auto()
+    CLOUD_INIT_WAIT = enum.auto()
+    EARLY_COMMANDS = enum.auto()
     WAITING = enum.auto()
     NEEDS_CONFIRMATION = enum.auto()
     RUNNING = enum.auto()
@@ -70,7 +72,7 @@ class ApplicationStatus:
     state: ApplicationState
     confirming_tty: str
     error: Optional[ErrorReportRef]
-    cloud_init_ok: bool
+    cloud_init_ok: Optional[bool]
     interactive: Optional[bool]
     echo_syslog_id: str
     log_syslog_id: str


### PR DESCRIPTION
Currently the api server waits for cloud-init to complete very very
early, before starting the API server. This can leave the client at a
message that just says "connecting...." for quite a few seconds. This
branch adds a couple more states to ApplicationState to use during
startup and has the client print appropriate messages for each one.