### PR TITLE
client: lookup machine IPs via API call

### DIFF
--- a/subiquity/ui/views/help.py
+++ b/subiquity/ui/views/help.py
@@ -242,11 +242,9 @@ def menu_item(text, on_press=None):
 
 
 async def get_global_addresses(app):
-    task = app.aio_loop.create_task(
-           app.client.network.global_addresses.GET())
     return await app.wait_with_text_dialog(
-        task,
-        _("getting network info"),
+        app.client.network.global_addresses.GET(),
+        _("Getting network info"),
         can_cancel=True)
 
 


### PR DESCRIPTION
Attempts to look them up directly fail due to an empty app.base_model.
Add an API call invocation to grab the public IPs.