### PR TITLE
Corrected oc language name to "Occitan"

### DIFF
--- a/languagelist
+++ b/languagelist
@@ -25,4 +25,4 @@ console:sv:Svenska
 ssh:bo:བོད་ཡིག
 console:uk:Українська
 console:nb:Norsk bokmål
-ssh:oc:Galés
+ssh:oc:Occitan


### PR DESCRIPTION
The language with the code `oc` is is [Occitan](https://en.wikipedia.org/wiki/Occitan_language) (same name in English and in Occitan). Galés means ["Welsh" in Occitan](https://oc.wikipedia.org/wiki/Gal%C3%A9s)(‽), so "oc:Galés" is like having "en:Welsh".