### PR TITLE
The native name of "kab" language corrected to " Taqbaylit"

### DIFF
--- a/languagelist
+++ b/languagelist
@@ -1,6 +1,6 @@
 console:en_US:English
 console:en_GB:English (UK)
-ssh:kab:Tamaziɣt Taqbaylit
+ssh:kab:Taqbaylit
 console:ca:Català
 ssh:zh_CN:中文(简体)
 console:hr:Hrvatski


### PR DESCRIPTION
the native name of kabyle language "kab" corrected.