### PR TITLE
Fix the native name of "kab" language, the native name corrected to " Taqbaylit"

### DIFF
--- a/languagelist
+++ b/languagelist
@@ -1,6 +1,6 @@
 console:en_US:English
 console:en_GB:English (UK)
-ssh:kab:Tamaziɣt Taqbaylit
+ssh:kab:Taqbaylit
 console:ca:Català
 ssh:zh_CN:中文(简体)
 console:hr:Hrvatski

--- a/scripts/make-language-lists
+++ b/scripts/make-language-lists
@@ -23,7 +23,7 @@ if not translations:
 langs = [
     ('console', 'en_US', 'English'),
     ('console', 'en_GB', 'English (UK)'),
-    ('ssh',     'kab',   'Tamaziɣt Taqbaylit'),
+    ('ssh',     'kab',   'Taqbaylit'),
 ]
 
 for level, code, name in langs:


### PR DESCRIPTION
"Taqbaylit" is the native name of the language,  "Tamaziɣt" is the name of languages group which kab is part of.