### PR TITLE
fix crash on refresh: change ids are strings in the snapd api

### DIFF
--- a/subiquity/common/apidef.py
+++ b/subiquity/common/apidef.py
@@ -84,11 +84,11 @@ class API:
 
             If wait is true, block until the status is known."""
 
-        def POST() -> int:
+        def POST() -> str:
             """Start the update and return the change id."""
 
         class progress:
-            def GET(change_id: int) -> dict: ...
+            def GET(change_id: str) -> dict: ...
 
     class zdev:
         def GET() -> List[ZdevInfo]: ...

--- a/subiquity/server/controllers/refresh.py
+++ b/subiquity/server/controllers/refresh.py
@@ -212,8 +212,8 @@ class RefreshController(SubiquityController):
             await self.check_task.wait()
         return self.status
 
-    async def POST(self, context) -> int:
+    async def POST(self, context) -> str:
         return await self.start_update(context=context)
 
-    async def progress_GET(self, change_id: int) -> dict:
+    async def progress_GET(self, change_id: str) -> dict:
         return await self.get_progress(change_id)

--- a/subiquitycore/snapd.py
+++ b/subiquitycore/snapd.py
@@ -132,14 +132,14 @@ class FakeSnapdConnection:
         if path == "v2/snaps/subiquity" and body['action'] == 'refresh':
             return _FakeMemoryResponse({
                 "type": "async",
-                "change": 7,
+                "change": "7",
                 "status-code": 200,
                 "status": "OK",
                 })
         if path == "v2/snaps/subiquity" and body['action'] == 'switch':
             return _FakeMemoryResponse({
                 "type": "async",
-                "change": 8,
+                "change": "8",
                 "status-code": 200,
                 "status": "Accepted",
                 })


### PR DESCRIPTION
for https://bugs.launchpad.net/subiquity/+bug/1913417