### PR TITLE
do not append .UTF-8 to language in cloud-init user data

### DIFF
--- a/subiquity/models/subiquity.py
+++ b/subiquity/models/subiquity.py
@@ -168,7 +168,7 @@ class SubiquityModel:
             'growpart': {
                 'mode': 'off',
                 },
-            'locale': self.locale.selected_language + '.UTF-8',
+            'locale': self.locale.selected_language,
             'resize_rootfs': False,
         }
         if self.identity.hostname is not None:


### PR DESCRIPTION
"locale-gen fr" succeeds, "locale-gen fr.UTF-8" does not. possibly we should be writing
"fr_FR.UTF-8" but this is a simple fix.