### PR TITLE
fix initial language selection

### DIFF
--- a/subiquity/client/controllers/welcome.py
+++ b/subiquity/client/controllers/welcome.py
@@ -28,6 +28,7 @@ class WelcomeController(SubiquityTuiController):
 
     async def make_ui(self):
         language = await self.endpoint.GET()
+        i18n.switch_language(language)
         serial = self.app.opts.run_on_serial
         if serial:
             ips = await self.app.client.network.global_addresses.GET()

--- a/subiquity/server/controllers/locale.py
+++ b/subiquity/server/controllers/locale.py
@@ -38,10 +38,7 @@ class LocaleController(SubiquityController):
         os.environ["LANG"] = data
 
     def start(self):
-        lang = os.environ.get("LANG")
-        if lang is not None and lang.endswith(".UTF-8"):
-            lang = lang.rsplit('.', 1)[0]
-        self.model.selected_language = lang
+        self.model.selected_language = os.environ.get("LANG")
 
     def serialize(self):
         return self.model.selected_language


### PR DESCRIPTION
there were two issues: the client never set up translation based on the
initial setting and the server contined to strip ".UTF-8" off the $LANG
value so the client didn't find a matching value to highlight the
initial language correctly.